### PR TITLE
18/bug/mirroring ressource loader dep

### DIFF
--- a/lib/mwoffliner.lib.js
+++ b/lib/mwoffliner.lib.js
@@ -310,6 +310,10 @@ module.exports = {
 
         const genericJsModules = ['startup', 'jquery', 'mediawiki', 'site']
 
+        // this module has no css, blacklisting it avoid creating an empty file that generate an error in firefox
+        // error is "style sheet could not be loaded"
+        const blackListCssModules = ['mediawiki.page.gallery']
+
         var mediaRegex = /^(.*\/)([^\/]+)(\/)(\d+px-|)(.+?)(\.[A-Za-z0-9]{2,6}|)(\.[A-Za-z0-9]{2,6}|)$/;
         var htmlTemplateCode = `
 <!DOCTYPE html>
@@ -944,6 +948,8 @@ module.exports = {
                 .then(({ parse: { modules, modulescripts, modulestyles, headhtml }}) => {
                     jsDependenciesList = genericJsModules.concat(modules, modulescripts)
                     styleDependenciesList = [].concat(modules, modulestyles)
+
+                    styleDependenciesList = styleDependenciesList.filter(oneStyleDep => !blackListCssModules.includes(oneStyleDep))
 
                     printLog(`Js dependencies of ${articleId} : ${jsDependenciesList}`)
                     printLog(`Css dependencies of ${articleId} : ${styleDependenciesList}`)
@@ -2562,7 +2568,9 @@ module.exports = {
 
             function createMainPage( finished ) {
                 printLog( 'Creating main page...' );
-                var doc = domino.createDocument( htmlTemplateCode.replace('__ARTICLE_JS_LIST__', '').replace('__ARTICLE_CSS_LIST__', '') );
+                var doc = domino.createDocument(
+                    htmlTemplateCode.replace('__ARTICLE_JS_LIST__', '').replace('__ARTICLE_CSS_LIST__', '').replace('__ARTICLE_CONFIGVARS_LIST__ ', '')
+                );
                 doc.getElementById( 'titleHeading' ).innerHTML = 'Summary';
                 doc.getElementsByTagName( 'title' )[0].innerHTML = 'Summary';
 

--- a/lib/mwoffliner.lib.js
+++ b/lib/mwoffliner.lib.js
@@ -308,7 +308,7 @@ module.exports = {
         var javascriptDirectory = 'j';
         var jsModulesDirectory = 'js_modules'
 
-        const genericJsModules = ['startup', 'jquery', 'mediawiki']
+        const genericJsModules = ['startup', 'jquery', 'mediawiki', 'site']
 
         var mediaRegex = /^(.*\/)([^\/]+)(\/)(\d+px-|)(.+?)(\.[A-Za-z0-9]{2,6}|)(\.[A-Za-z0-9]{2,6}|)$/;
         var htmlTemplateCode = `
@@ -319,6 +319,9 @@ module.exports = {
     <title></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="s/style.css" />
+    <script>
+        function importScript(){return 1} // this is to avoid the error from site.js
+    </script>
     __ARTICLE_CSS_LIST__
   </head>
   <body class="mw-body mw-body-content mediawiki" style="background-color: white; margin: 0; border-width: 0px; padding: 0px;">
@@ -328,6 +331,7 @@ module.exports = {
       <div id="mw-content-text">
       </div>
     </div>
+    __ARTICLE_CONFIGVARS_LIST__
     __ARTICLE_JS_LIST__
   </body>
 </html>`
@@ -914,6 +918,7 @@ module.exports = {
 
         function saveArticles( finished ) {
             // thoses var will store the list of js and css dependencies for the article we are downloading. they are populated in storeDependencies and used in setFooter
+            let jsConfigVars = ''
             let jsDependenciesList = []
             let styleDependenciesList = []
 
@@ -931,12 +936,12 @@ module.exports = {
                 const filenameRadical = computeFilenameRadical()
 
                 // the encodeURI bellow is mandatory for languages with illegal letters for uri (like fa.wikipedia.org)
-                fetch(encodeURI(`${apiUrl}action=parse&format=json&page=${articleId}&prop=modules|jsconfigvars`), {
+                fetch(encodeURI(`${apiUrl}action=parse&format=json&page=${articleId}&prop=modules|jsconfigvars|headhtml`), {
                     method: 'GET',
                     headers: { 'Accept': 'application/json' }
                 })
                 .then(response => response.json())
-                .then(({ parse: { modules, modulescripts, modulestyles } }) => {
+                .then(({ parse: { modules, modulescripts, modulestyles, headhtml }}) => {
                     jsDependenciesList = genericJsModules.concat(modules, modulescripts)
                     styleDependenciesList = [].concat(modules, modulestyles)
 
@@ -949,6 +954,22 @@ module.exports = {
                     ]
 
                     allDependenciesWithType.forEach(({ type, moduleList }) => moduleList.forEach(oneModule => downloadAndSaveModule(oneModule, type)))
+
+                    // Saving, as a js module, the jsconfigvars that are set in the header of a wikiepdia page
+                    // the script bellow extract the config with a regex executed on the page header returned from the api
+                    const scriptTags = domino.createDocument(headhtml['*'] + '</body></html>').getElementsByTagName('script')
+                    const regex = /mw\.config\.set\(\{.*?\}\);/mg;
+                    for (let i=0; i < scriptTags.length; i++) {
+                        if (scriptTags[i].text.includes('mw.config.set')) jsConfigVars = regex.exec(scriptTags[i].text)
+                    }
+                    jsConfigVars = `(window.RLQ=window.RLQ||[]).push(function() {${jsConfigVars}});`
+                    jsConfigVars = jsConfigVars.replace('nosuchaction', 'view') // to replace the wgAction config that is set to 'nosuchaction' from api but should be 'view'
+                    try {
+                        fs.writeFileSync( `./${tmpDirectory}${filenameRadical}/${javascriptDirectory}/${jsModulesDirectory}/jsConfigVars.js`, jsConfigVars )
+                        printLog(`created dep jsConfigVars.js for article ${articleId}`)
+                    } catch (e) {
+                        console.log(`Error writing file ${moduleUri}`, e)
+                    }
 
                     finished(null, parsoidDoc, articleId)
                 })
@@ -1488,6 +1509,10 @@ module.exports = {
             function setFooter( parsoidDoc, articleId, finished ) {
                 const htmlTemplateDoc = domino.createDocument(
                     htmlTemplateCode
+                    .replace('__ARTICLE_CONFIGVARS_LIST__', jsConfigVars !== ''
+                        ? `<script src="${javascriptDirectory}/${jsModulesDirectory}/jsConfigVars.js"></script>`
+                        : ''
+                    )
                     .replace('__ARTICLE_JS_LIST__', jsDependenciesList.length !== 0
                         ? jsDependenciesList.map(oneJsDep => `<script src="${javascriptDirectory}/${jsModulesDirectory}/${oneJsDep}.js"></script>`).join('\n')
                         : ''

--- a/lib/mwoffliner.lib.js
+++ b/lib/mwoffliner.lib.js
@@ -2569,7 +2569,7 @@ module.exports = {
             function createMainPage( finished ) {
                 printLog( 'Creating main page...' );
                 var doc = domino.createDocument(
-                    htmlTemplateCode.replace('__ARTICLE_JS_LIST__', '').replace('__ARTICLE_CSS_LIST__', '').replace('__ARTICLE_CONFIGVARS_LIST__ ', '')
+                    htmlTemplateCode.replace('__ARTICLE_JS_LIST__', '').replace('__ARTICLE_CSS_LIST__', '').replace('__ARTICLE_CONFIGVARS_LIST__', '')
                 );
                 doc.getElementById( 'titleHeading' ).innerHTML = 'Summary';
                 doc.getElementsByTagName( 'title' )[0].innerHTML = 'Summary';


### PR DESCRIPTION
mwoffliner includes jsconfigvars from the api header html  
also added a way to blacklist a css module that raise a "style sheet could not be loaded" on firefox because it tries to download a 0 length file