### PR TITLE
added error handling for json response

### DIFF
--- a/lib/mwoffliner.lib.js
+++ b/lib/mwoffliner.lib.js
@@ -1765,6 +1765,10 @@ module.exports = {
 
                         buildArticleFromApiData()
                     })
+                    .catch(e => {
+                        console.log('Error handling json response from api. ', e)
+                        buildArticleFromApiData()
+                    })
                 } else {
                     setTimeout(skipHtmlCache || articleId == mainPageId ? downloadContent : downloadContentAndCache, downloadFileQueue.length() + optimizationQueue.length(), articleUrl, function(content, responseHeaders, articleId) {
                         let json;


### PR DESCRIPTION
This will handle errors in the json from api. The article wont be properly downloaded in the ZIM but the script should not stop