### PR TITLE
added dump format to redis module name + fixed relative path for modules

### DIFF
--- a/lib/mwoffliner.lib.js
+++ b/lib/mwoffliner.lib.js
@@ -452,7 +452,7 @@ module.exports = {
                                     function (finished) { saveFavicon(finished) },
                                     function (finished) { getMainPage(finished) },
                                     function (finished) { writeHtmlRedirects ? saveHtmlRedirects(finished) : finished() },
-                                    function (finished) { saveArticles(finished) },
+                                    function (finished) { saveArticles(dump, finished) },
                                     function (finished) { drainDownloadFileQueue(finished) },
                                     function (finished) { drainOptimizationQueue(finished) },
                                     function (finished) { buildZIM(finished) },
@@ -704,24 +704,24 @@ module.exports = {
 
         function saveStaticFiles(finished) {
             try {
-                fs.readFile('./content.parsoid.css', (err, data) =>
-                    fs.writeFile(`./${tmpDirectory}${filenameRadical}/${styleDirectory}/${styleModulesDirectory}/content.parsoid.css`, data, () => {})
+                fs.readFile(pathParser.resolve(__dirname, "../content.parsoid.css"), (err, data) =>
+                    fs.writeFile(pathParser.resolve(htmlRootPath, `${styleDirectory}/${styleModulesDirectory}/content.parsoid.css`), data, () => {})
                 )
             } catch (error) {
                 console.error('Could not create content.parsoid.css file : ', error)
             }
 
             try {
-                fs.readFile('./mobile.css', (err, data) =>
-                    fs.writeFile(`./${tmpDirectory}${filenameRadical}/${styleDirectory}/${styleModulesDirectory}/mobile.css`, data, () => {})
+                fs.readFile(pathParser.resolve(__dirname, "../mobile.css"), (err, data) =>
+                    fs.writeFile(pathParser.resolve(htmlRootPath, `${styleDirectory}/${styleModulesDirectory}/mobile.css`), data, () => {})
                 )
             } catch (error) {
                 console.error('Could not create mobile.css file : ', error)
             }
 
             try {
-                fs.readFile('./inserted_style_mobile.css', (err, data) =>
-                    fs.writeFile(`./${tmpDirectory}${filenameRadical}/${styleDirectory}/${styleModulesDirectory}/inserted_style_mobile.css`, data, () => finished())
+                fs.readFile(pathParser.resolve(__dirname, "../inserted_style_mobile.css"), (err, data) =>
+                    fs.writeFile(pathParser.resolve(htmlRootPath, `${styleDirectory}/${styleModulesDirectory}/inserted_style_mobile.css`), data, () => finished())
                 )
             } catch (error) {
                 console.error('Could not create inserted_style_mobile.css file : ', error)
@@ -1028,7 +1028,7 @@ module.exports = {
             });
         }
 
-        function saveArticles(finished) {
+        function saveArticles(dump, finished) {
             // thoses var will store the list of js and css dependencies for the article we are downloading. they are populated in storeDependencies and used in setFooter
             let jsConfigVars = ''
             let jsDependenciesList = []
@@ -1082,7 +1082,7 @@ module.exports = {
                     jsConfigVars = `(window.RLQ=window.RLQ||[]).push(function() {${jsConfigVars}});`
                     jsConfigVars = jsConfigVars.replace('nosuchaction', 'view') // to replace the wgAction config that is set to 'nosuchaction' from api but should be 'view'
                     try {
-                        fs.writeFileSync( `./${tmpDirectory}${filenameRadical}/${javascriptDirectory}/${jsModulesDirectory}/jsConfigVars.js`, jsConfigVars )
+                        fs.writeFileSync(pathParser.resolve(htmlRootPath, `${javascriptDirectory}/${jsModulesDirectory}/jsConfigVars.js`), jsConfigVars )
                         printLog(`created dep jsConfigVars.js for article ${articleId}`)
                     } catch (e) {
                         console.error(`Error writing file ${moduleUri}`, e)
@@ -1105,7 +1105,7 @@ module.exports = {
                     //   a promise resolving 1 if data has been succesfully saved or resolving 0 if data was already in redis
                     const saveModuleInRedis = (module, moduleUri, type) => new Promise((resolve, reject) => {
                         // hsetnx() store in redis only if key doesn't already exists
-                        redisClient.hsetnx(redisModuleDatabase, `${module}.${type}`, moduleUri, (err, res) => err
+                        redisClient.hsetnx(redisModuleDatabase, `${dump}_${module}.${type}`, moduleUri, (err, res) => err
                             ? reject(`Error, unable to save module ${module} in redis`)
                             : resolve(res)
                         )
@@ -1128,10 +1128,10 @@ module.exports = {
                     let moduleUri
                     let apiParameterOnly
                     if (type === 'js') {
-                        moduleUri = `./${tmpDirectory}${filenameRadical}/${javascriptDirectory}/${jsModulesDirectory}/${module}.js`
+                        moduleUri = pathParser.resolve(htmlRootPath, `${javascriptDirectory}/${jsModulesDirectory}/${module}.js`)
                         apiParameterOnly = 'scripts'
                     } else if (type === 'css') {
-                        moduleUri = `./${tmpDirectory}${filenameRadical}/${styleDirectory}/${styleModulesDirectory}/${module}.css`
+                        moduleUri = pathParser.resolve(htmlRootPath, `${styleDirectory}/${styleModulesDirectory}/${module}.css`)
                         apiParameterOnly = 'styles'
                     }
 


### PR DESCRIPTION
This PR fixes 2 things : 
- the path to modules is now generated relatively to the source file folder 
This fixes the difference when using mwoffliner as a lib and as a script (whether it's installed globally (/usr/local/...) or as a local dependency to a project)


- the redis module entry now integrates the dump specification in its name
This fixes the problem where static modules where not created in zim files when creating 2 zims with different format in one command line. The module entry in redis would match between the different format then static modules where only created in the first zim.