### PR TITLE
Reduce call stack pressure in rewriteUrls

### DIFF
--- a/lib/mwoffliner.lib.js
+++ b/lib/mwoffliner.lib.js
@@ -1409,7 +1409,9 @@ module.exports = {
 
                     if (!href) {
                         deleteNode(linkNode);
-                        finished();
+                        setImmediate(function() {
+                            finished();
+                        });
                     } else {
 
                         /* Deal with custom geo. URL replacement, for example:
@@ -1499,7 +1501,9 @@ module.exports = {
                                     }
                                     linkNode.parentNode.removeChild(linkNode);
                                 }
-                                finished();
+                                setImmediate(function() {
+                                    finished();
+                                });
                             }
 
                             /* Remove internal links pointing to no mirrored articles */
@@ -1515,7 +1519,9 @@ module.exports = {
 
                                 if (isMirrored(targetId)) {
                                     linkNode.setAttribute('href', getArticleUrl(targetId) + localAnchor);
-                                    finished();
+                                    setImmediate(function() {
+                                        finished();
+                                    });
                                 } else {
                                     try {
                                         redisClient.hexists(redisRedirectsDatabase, targetId, function (error, res) {
@@ -1532,7 +1538,9 @@ module.exports = {
                                                     linkNode.parentNode.removeChild(linkNode);
                                                 }
                                             }
-                                            finished();
+                                            setImmediate(function() {
+                                                finished();
+                                            });
                                         });
                                     } catch (error) {
                                         console.error("Exception by requesting redis " + error);
@@ -1540,14 +1548,18 @@ module.exports = {
                                     }
                                 }
                             } else {
-                                finished();
+                                setImmediate(function() {
+                                    finished();
+                                });
                             }
                         } else {
                             var targetId = extractTargetIdFromHref(href);
                             if (targetId) {
                                 if (isMirrored(targetId)) {
                                     linkNode.setAttribute('href', getArticleUrl(targetId));
-                                    finished();
+                                    setImmediate(function() {
+                                        finished();
+                                    });
                                 } else {
                                     redisClient.hexists(redisRedirectsDatabase, targetId, function (error, res) {
                                         if (error) {
@@ -1563,11 +1575,15 @@ module.exports = {
                                                 linkNode.parentNode.removeChild(linkNode);
                                             }
                                         }
-                                        finished();
+                                        setImmediate(function() {
+                                            finished();
+                                        });
                                     });
                                 }
                             } else {
-                                finished();
+                                setImmediate(function() {
+                                    finished();
+                                });
                             }
                         }
                     }


### PR DESCRIPTION
In certain processing environments the rapid iteration over anchor
elements in rewriteUrls can overflow the call stack, resulting in a
RangeError.  This patch wraps the finsihed() calls in rewriteUrls in
setImmedate callbacks in order to defer them until later in the event
loop, thereby reducing the pressure on the call stack and allowing
mwoffliner to run to completion.

Fixes #54.