### PR TITLE
white page background

### DIFF
--- a/lib/templates/mobile.html
+++ b/lib/templates/mobile.html
@@ -12,7 +12,7 @@
   </head>
   <body class="mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject page-Lyon rootpage-Lyon stable skin-minerva action-view animations">
     <div id="mw-mf-viewport" class="feature-header-v2">
-      <div id="mw-mf-page-center">
+      <div id="mw-mf-page-center" style="background-color: #ffffff;">
         <div id="content" class="mw-body">
           <a id="top"></a>
           <div id="bodyContent" class="content">


### PR DESCRIPTION
Override gray background of #mw-mf-page-center, changing it to white background.

But ultimately the solution should be to remove the background-color style of #mw-mf-page-center. In the wikimed zim I am testing, the style is defined in a file in `/-/s/css_modules/inserted_style_mobile.css`, line 1199-1201. But I cannot find out where it is.