### PR TITLE
i161 removed moduleUri from comment

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,7 @@
     "no-use-before-define": "off",
     "no-case-declarations": "off",
     "no-underscore-dangle": "off",
-    "no-console": "warn",
+    "no-console": "off",
     "no-unused-vars": "warn"
   }
 }

--- a/lib/mwoffliner.lib.js
+++ b/lib/mwoffliner.lib.js
@@ -829,7 +829,7 @@ function execute(argv) {
             fs.writeFileSync(pathParser.resolve(env.htmlRootPath, jsPath('jsConfigVars')), jsConfigVars);
             logger.log(`created dep jsConfigVars.js for article ${articleId}`);
           } catch (e) {
-            console.error(`Error writing file ${moduleUri}`, e); // TODO: moduleUri is not defined or in scope??
+            console.error(`Error writing file`, e);
           }
 
           finished(null, parsoidDoc, articleId);


### PR DESCRIPTION
Console log referenced moduleUri but wasn't in scope. Couldn't find where that function was being passed into where scope could be reached. So I removed moduleUri from the comment line.

The linter doesn't show any other variables that can't be accessed. 

This is in reference to bug 161: https://github.com/openzim/mwoffliner/issues/161