### PR TITLE
Added mw-parser-output class to desktop HTML so MW CSS matches

### DIFF
--- a/lib/templates/desktop.html
+++ b/lib/templates/desktop.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="s/style.css" />
     __ARTICLE_CSS_LIST__
   </head>
-  <body class="mw-body mw-body-content mediawiki" style="background-color: white; margin: 0; border-width: 0px; padding: 0px;">
+  <body class="mw-body mw-body-content mediawiki mw-parser-output" style="background-color: white; margin: 0; border-width: 0px; padding: 0px;">
     <div id="content" class="mw-body" style="padding: 1em; border-width: 0px; max-width: 55.8em; margin: 0 auto 0 auto">
       <a id="top"></a>
       <h1 id="titleHeading" style="background-color: white; margin: 0;"></h1>


### PR DESCRIPTION
Fixes https://github.com/openzim/mwoffliner/issues/279

Some of the MW CSS didn't match the HTML as it expects a class of `mw-parser-output`.