### PR TITLE
Make offline.css optional so that the usual errors are not reported

### DIFF
--- a/lib/Downloader.js
+++ b/lib/Downloader.js
@@ -18,6 +18,18 @@ function Downloader(logger, mw, uaString, reqTimeout) {
   this.loginCookie = '';
   this.requestTimeout = reqTimeout;
   this.webUrlPort = getPort(urlParser.parse(mw.base + mw.wikiPath + '/'));
+  // Optional URLs will not have an error message if they are
+  // are not found.
+  this.optionalUrls = new Set();
+}
+
+// Registers a URL as optional.  We don't necessarily expect this URL to be
+// present, so no error will be printed if fetching returns a value other
+// than 200.
+// Note that this also means that only a single attempt to download them
+// will be made if a status code other than 200 is returned.
+Downloader.prototype.registerOptionalUrl = function(url) {
+  this.optionalUrls.add(url);
 }
 
 Downloader.prototype.getRequestOptionsFromUrl = function(url, compression) {
@@ -112,16 +124,23 @@ Downloader.prototype.downloadContent = function(url, callback, var1, var2, var3)
           response.on('error', function () {
             response.socket.emit('agentRemove');
             response.socket.destroy();
-            callFinished(0, 'Unable to download content [' + retryCount + '] ' + decodeURI(url) + ' (response error: ' + response.statusCode + ').');
+            callFinished(0, 'Error downloading content [' + retryCount + '] ' + decodeURI(url) + ' (though response code was 200).');
           });
         } else {
           response.socket.emit('agentRemove');
           response.socket.destroy();
-          callFinished(0, 'Unable to download content [' + retryCount + '] ' + decodeURI(url) + ' (statusCode=' + response.statusCode + ').');
+          let message = 'Unable to download content [' + retryCount + '] ' + decodeURI(url) + ' (response code: ' + response.statusCode + ').';
+          // No error message for optional URLs; we don't necessarily
+          // expect them, and it confuses users who have other errors.
+          // Note that this also prevents a retry.
+          if (self.optionalUrls.has(url)) {
+            message = '';
+          }
+          callFinished(0, message);
         }
       });
       request.on('error', function (error) {
-        callFinished(10000 * retryCount, 'Unable to download content [' + retryCount + '] ' + decodeURI(url) + ' (request error: ' + error + ' ).');
+        callFinished(10000 * retryCount, 'Unable to request content [' + retryCount + '] ' + decodeURI(url) + ' (request error: ' + error + ' ).');
       });
       request.on('socket', function (socket) {
         if (!socket.custom) {

--- a/lib/Downloader.js
+++ b/lib/Downloader.js
@@ -124,7 +124,7 @@ Downloader.prototype.downloadContent = function(url, callback, var1, var2, var3)
           response.on('error', function () {
             response.socket.emit('agentRemove');
             response.socket.destroy();
-            callFinished(0, 'Error downloading content [' + retryCount + '] ' + decodeURI(url) + ' (though response code was 200).');
+            callFinished(0, 'Unable to download content [' + retryCount + '] ' + decodeURI(url) + ' (response error: ' + response.statusCode + ').');
           });
         } else {
           response.socket.emit('agentRemove');
@@ -140,7 +140,7 @@ Downloader.prototype.downloadContent = function(url, callback, var1, var2, var3)
         }
       });
       request.on('error', function (error) {
-        callFinished(10000 * retryCount, 'Unable to request content [' + retryCount + '] ' + decodeURI(url) + ' (request error: ' + error + ' ).');
+        callFinished(10000 * retryCount, 'Unable to download content [' + retryCount + '] ' + decodeURI(url) + ' (request error: ' + error + ' ).');
       });
       request.on('socket', function (socket) {
         if (!socket.custom) {

--- a/lib/Downloader.js
+++ b/lib/Downloader.js
@@ -124,12 +124,12 @@ Downloader.prototype.downloadContent = function(url, callback, var1, var2, var3)
           response.on('error', function () {
             response.socket.emit('agentRemove');
             response.socket.destroy();
-            callFinished(0, 'Error downloading content [' + retryCount + '] ' + decodeURI(url) + ' (though response code was 200).');
+            callFinished(0, 'Unable to download content [' + retryCount + '] ' + decodeURI(url) + ' (response error: ' + response.statusCode + ').');
           });
         } else {
           response.socket.emit('agentRemove');
           response.socket.destroy();
-          let message = 'Unable to download content [' + retryCount + '] ' + decodeURI(url) + ' (response code: ' + response.statusCode + ').';
+          let message = 'Unable to download content [' + retryCount + '] ' + decodeURI(url) + ' (response status code: ' + response.statusCode + ').';
           // No error message for optional URLs; we don't necessarily
           // expect them, and it confuses users who have other errors.
           // Note that this also prevents a retry.
@@ -140,7 +140,7 @@ Downloader.prototype.downloadContent = function(url, callback, var1, var2, var3)
         }
       });
       request.on('error', function (error) {
-        callFinished(10000 * retryCount, 'Unable to request content [' + retryCount + '] ' + decodeURI(url) + ' (request error: ' + error + ' ).');
+        callFinished(10000 * retryCount, 'Unable to download content [' + retryCount + '] ' + decodeURI(url) + ' (request error: ' + error + ' ).');
       });
       request.on('socket', function (socket) {
         if (!socket.custom) {

--- a/lib/mwoffliner.lib.js
+++ b/lib/mwoffliner.lib.js
@@ -1645,7 +1645,9 @@ function execute(argv) {
       }
 
       /* Push Mediawiki:Offline.css ( at the end) */
-      downloadCSSQueue.push(`${mw.webUrl}Mediawiki:offline.css?action=raw`);
+      var offlineCssUrl = `${mw.webUrl}Mediawiki:offline.css?action=raw`;
+      downloader.registerOptionalUrl(offlineCssUrl);
+      downloadCSSQueue.push(offlineCssUrl);
 
       /* Set the drain method to be called one time everything is done */
       downloadCSSQueue.drain = function(error) {

--- a/lib/mwoffliner.lib.js
+++ b/lib/mwoffliner.lib.js
@@ -1645,7 +1645,7 @@ function execute(argv) {
       }
 
       /* Push Mediawiki:Offline.css ( at the end) */
-      var offlineCssUrl = `${mw.webUrl}Mediawiki:offline.css?action=raw`;
+      let offlineCssUrl = `${mw.webUrl}Mediawiki:offline.css?action=raw`;
       downloader.registerOptionalUrl(offlineCssUrl);
       downloadCSSQueue.push(offlineCssUrl);
 


### PR DESCRIPTION
This addresses the title of #74 though not its underlying issue.
Rather than probing for offline.css, which seemed awkward, this change allows for optional URLs.  

An unintended consequence is that such URLs will only be tried one time.  If that is a concern, an alternative is to print a message that says it was not found but is not an error and add a few lines to suppress the final error message. I'm happy to convert to that solution if you prefer.

To suppress all messages while still trying multiple times would require more extensive changes, since currently it is the presence of a message that determines whether a retry is needed.