### PR TITLE
Add missing autoescape-false tag

### DIFF
--- a/lib/templates/subsection_wrapper.html
+++ b/lib/templates/subsection_wrapper.html
@@ -1,5 +1,5 @@
 <h{{ section_toclevel }} class="section-heading in-block collapsible-heading open-block" tabindex="0" aria-haspopup="true" aria-controls="content-collapsible-block-{{ section_index }}">
-    <span class="mw-headline" id="{{ section_anchor }}">{{ section_line }}</span>
+    <span class="mw-headline" id="{{ section_anchor }}">{% autoescape false %}{{ section_line }}{% endautoescape %}</span>
 </h{{ section_toclevel }}>
 <div id="mf-section-{{ section_id }}" class="mf-section-{{ section_id }} collapsible-block open-block" id="content-collapsible-block-0" aria-pressed="true" aria-expanded="true">
     {% autoescape false %}{{ section_text }}{% endautoescape %}


### PR DESCRIPTION
Fixes #178.
I was able to recreate the problem and confirm that this fixes it.  It also makes the autoescaping consistent with the other template files.