### PR TITLE
Added fallback for older mediawikis

### DIFF
--- a/lib/mwoffliner.lib.js
+++ b/lib/mwoffliner.lib.js
@@ -1034,7 +1034,7 @@ function execute(argv) {
                                 if (json && json.visualeditor) {
                                     html = json.visualeditor.content;
                                 }
-                                else if (json && json.contentmodel === 'wikitext') {
+                                else if (json && (json.contentmodel === 'wikitext' || (json.html && json.html.body))) {
                                     html = json.html.body;
                                 }
                                 else if (json && json.error) {

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -1549,7 +1549,7 @@ async function execute(argv) {
               storeDependencies,
               parseHtml,
             );
-            
+
             logger.log(`Treating and saving article ${articleId} at ${articlePath}...`);
             prepareAndSaveArticle(html, articleId, (error) => {
               if (!error) { logger.log(`Successfully dumped article ${articleId}`); }

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -1521,7 +1521,7 @@ async function execute(argv) {
                 }
                 if (json && json.visualeditor) {
                   html = json.visualeditor.content;
-                } else if (json && json.contentmodel === 'wikitext') {
+                } else if (json && (json.contentmodel === 'wikitext' || (json.html && json.html.body))) {
                   html = json.html.body;
                 } else if (json && json.error) {
                   console.error(`Error by retrieving article: ${json.error.info}`);
@@ -1549,7 +1549,7 @@ async function execute(argv) {
               storeDependencies,
               parseHtml,
             );
-
+            
             logger.log(`Treating and saving article ${articleId} at ${articlePath}...`);
             prepareAndSaveArticle(html, articleId, (error) => {
               if (!error) { logger.log(`Successfully dumped article ${articleId}`); }


### PR DESCRIPTION
Parsoid logged various warnings about old mediawikis when scraping CycloWiki (#387).

The returned Parsoid data had a different JSON schema so I've added a fallback that checks the content of the JSON too.