### PR TITLE
Added namespace fallback

### DIFF
--- a/lib/MediaWiki.js
+++ b/lib/MediaWiki.js
@@ -116,7 +116,7 @@ var MediaWiki = /** @class */ (function () {
         return this.apiUrl + "action=query&prop=redirects&format=json&rdprop=title&rdlimit=max&titles=" + encodeURIComponent(articleId) + "&rawcontinue=";
     };
     MediaWiki.prototype.pageGeneratorQueryUrl = function (namespace, init) {
-        return this.apiUrl + "action=query&generator=allpages&gapfilterredir=nonredirects&gaplimit=max&colimit=max&prop=revisions|coordinates&gapnamespace=" + this.namespaces[namespace].number + "&format=json&rawcontinue=" + init;
+        return this.apiUrl + "action=query&generator=allpages&gapfilterredir=nonredirects&gaplimit=max&colimit=max&prop=revisions|coordinates&gapnamespace=" + (this.namespaces[namespace].number || 0) + "&format=json&rawcontinue=" + init;
     };
     MediaWiki.prototype.articleApiUrl = function (articleId) {
         return this.apiUrl + "action=parse&format=json&page=" + encodeURIComponent(articleId) + "&prop=" + encodeURI('modules|jsconfigvars|headhtml');
@@ -187,8 +187,9 @@ var MediaWiki = /** @class */ (function () {
                 url = this.apiUrl + "action=query&meta=siteinfo&siprop=namespaces|namespacealiases&format=json";
                 downloader.downloadContent(url, function (content) {
                     var body = content.toString();
+                    var json = JSON.parse(body);
                     ['namespaces', 'namespacealiases'].forEach(function (type) {
-                        var entries = JSON.parse(body).query[type];
+                        var entries = json.query[type];
                         Object.keys(entries).forEach(function (key) {
                             var entry = entries[key];
                             var name = entry['*'].replace(/ /g, self.spaceDelimiter);

--- a/lib/MediaWiki.js
+++ b/lib/MediaWiki.js
@@ -116,7 +116,7 @@ var MediaWiki = /** @class */ (function () {
         return this.apiUrl + "action=query&prop=redirects&format=json&rdprop=title&rdlimit=max&titles=" + encodeURIComponent(articleId) + "&rawcontinue=";
     };
     MediaWiki.prototype.pageGeneratorQueryUrl = function (namespace, init) {
-        return this.apiUrl + "action=query&generator=allpages&gapfilterredir=nonredirects&gaplimit=max&colimit=max&prop=revisions|coordinates&gapnamespace=" + (this.namespaces[namespace].number || 0) + "&format=json&rawcontinue=" + init;
+        return this.apiUrl + "action=query&generator=allpages&gapfilterredir=nonredirects&gaplimit=max&colimit=max&prop=revisions|coordinates&gapnamespace=" + this.namespaces[namespace].num + "&format=json&rawcontinue=" + init;
     };
     MediaWiki.prototype.articleApiUrl = function (articleId) {
         return this.apiUrl + "action=parse&format=json&page=" + encodeURIComponent(articleId) + "&prop=" + encodeURI('modules|jsconfigvars|headhtml');

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -21,7 +21,11 @@ class MediaWiki {
   public apiUrl: string;
   public webUrlPath: string;
   public namespaces: {
-    [namespace: string]: any,
+    [namespace: string]: {
+      num: number,
+      allowedSubpages: boolean,
+      isContent: boolean,
+    },
   };
   public namespacesToMirror: string[];
 
@@ -92,7 +96,7 @@ class MediaWiki {
   }
 
   public pageGeneratorQueryUrl(namespace: string, init: string) {
-    return `${this.apiUrl}action=query&generator=allpages&gapfilterredir=nonredirects&gaplimit=max&colimit=max&prop=revisions|coordinates&gapnamespace=${this.namespaces[namespace].number || 0}&format=json&rawcontinue=${init}`;
+    return `${this.apiUrl}action=query&generator=allpages&gapfilterredir=nonredirects&gaplimit=max&colimit=max&prop=revisions|coordinates&gapnamespace=${this.namespaces[namespace].num}&format=json&rawcontinue=${init}`;
   }
 
   public articleApiUrl(articleId) {

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -92,7 +92,7 @@ class MediaWiki {
   }
 
   public pageGeneratorQueryUrl(namespace: string, init: string) {
-    return `${this.apiUrl}action=query&generator=allpages&gapfilterredir=nonredirects&gaplimit=max&colimit=max&prop=revisions|coordinates&gapnamespace=${this.namespaces[namespace].number}&format=json&rawcontinue=${init}`;
+    return `${this.apiUrl}action=query&generator=allpages&gapfilterredir=nonredirects&gaplimit=max&colimit=max&prop=revisions|coordinates&gapnamespace=${this.namespaces[namespace].number || 0}&format=json&rawcontinue=${init}`;
   }
 
   public articleApiUrl(articleId) {
@@ -159,8 +159,9 @@ class MediaWiki {
     const url = `${this.apiUrl}action=query&meta=siteinfo&siprop=namespaces|namespacealiases&format=json`;
     downloader.downloadContent(url, (content) => {
       const body = content.toString();
+      const json = JSON.parse(body);
       ['namespaces', 'namespacealiases'].forEach((type) => {
-        const entries = JSON.parse(body).query[type];
+        const entries = json.query[type];
         Object.keys(entries).forEach((key) => {
           const entry = entries[key];
           const name = entry['*'].replace(/ /g, self.spaceDelimiter);


### PR DESCRIPTION
@kelson42 
I'd appreciate your feedback here.

For some reason `mw.namespacesToMirror` ends up with a single empty string in it. I'm not sure if this is because of API changes or not.

The `pageGeneratorQueryUrl` method was being called with a `''` as namespace which means the `gapnamespace` query parameter was being set to `undefined`.

I've now added a fallback to `0`, but I think this doesn't solve the root issue.

In the `getNamespaces` method, there is an if statement:
```
if (isContent) {
    self.namespacesToMirror.push(name);
}
```
`isContent` is always set to false and so no namespaces are mirrored.


Do you have any thoughts as to what this could be?