### PR TITLE
Added MCS Integration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "args": [
                 "--mwUrl=https://en.wikipedia.org",
                 "--adminEmail=admin@kiwix.com",
-                "--localParsoid",
+                "--localMcs",
                 // "--verbose",
                 "--format=nozim",
                 "--articleList=./articleList",

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ See [GitHub](https://github.com/openzim/zimwriterfs)
 > mwoffliner \
     --mwUrl=https://es.wikipedia.org \
     --adminEmail=foo@bar.net \
-    --localParsoid \
+    --localMcs \
     --verbose \
     --format=nozim \ # Won't make a final ZIM file
     --articleList=./articleList # Will download one article
@@ -92,7 +92,7 @@ const mwoffliner = require('mwoffliner');
 const parameters = {
     mwUrl: "https://es.wikipedia.org",
     adminEmail: "foo@bar.net",
-    localParsoid: true,
+    localMcs: true,
     verbose: true,
     format: "nozim",
     articleList: "./articleList"

--- a/lib/MediaWiki.js
+++ b/lib/MediaWiki.js
@@ -55,15 +55,17 @@ var MediaWiki = /** @class */ (function () {
         this.logger = logger;
         // Normalize args
         this.base = config.base.replace(/\/$/, '') + "/";
-        this.wikiPath = config.wikiPath !== undefined && config.wikiPath !== true ? config.wikiPath : 'wiki';
-        this.apiPath = config.apiPath || 'w/api.php';
+        this.wikiPath = config.wikiPath !== undefined && config.wikiPath !== true ? config.wikiPath : 'wiki/';
+        this.apiPath = config.apiPath === undefined ? 'w/api.php' : config.apiPath;
+        this.modulePath = config.modulePath === undefined ? 'w/load.php' : config.modulePath;
         this.domain = config.domain || '';
         this.username = config.username;
         this.password = config.password;
         this.spaceDelimiter = config.spaceDelimiter;
         // Computed properties
-        this.webUrl = this.base + this.wikiPath + "/";
+        this.webUrl = "" + (this.base + this.wikiPath);
         this.apiUrl = this.base + this.apiPath + "?";
+        this.modulePath = this.base + this.modulePath + "?";
         this.webUrlPath = url_1.default.parse(this.webUrl).pathname;
         // State
         this.namespaces = {};

--- a/lib/mwoffliner.lib.js
+++ b/lib/mwoffliner.lib.js
@@ -57,14 +57,14 @@ var fs_1 = __importStar(require("fs"));
 var html_minifier_1 = __importDefault(require("html-minifier"));
 var node_fetch_1 = __importDefault(require("node-fetch"));
 var os_1 = __importDefault(require("os"));
-var parsoid_1 = __importDefault(require("parsoid"));
 var path_1 = __importDefault(require("path"));
 var swig_templates_1 = __importDefault(require("swig-templates"));
-var url_1 = __importDefault(require("url"));
+var url_1 = __importStar(require("url"));
 var utf8_binary_cutter_1 = __importDefault(require("utf8-binary-cutter"));
 var zlib_1 = __importDefault(require("zlib"));
 var semver_1 = __importDefault(require("semver"));
 var path = __importStar(require("path"));
+var service_runner_1 = __importDefault(require("service-runner"));
 var config_1 = __importDefault(require("./config"));
 var DOMUtils_1 = __importDefault(require("./DOMUtils"));
 var Downloader_1 = __importDefault(require("./Downloader"));
@@ -336,7 +336,7 @@ function execute(argv) {
                             apiParameterOnly = 'styles';
                         }
                         logger.info("Getting [" + type + "] module [" + module + "]");
-                        var moduleApiUrl = encodeURI(mw.base + "w/load.php?debug=false&lang=en&modules=" + module + "&only=" + apiParameterOnly + "&skin=vector&version=&*");
+                        var moduleApiUrl = encodeURI(mw.modulePath + "debug=false&lang=en&modules=" + module + "&only=" + apiParameterOnly + "&skin=vector&version=&*");
                         return redis.saveModuleIfNotExists(dump, module, moduleUri, type)
                             .then(function (redisResult) {
                             if (redisResult === 1) {
@@ -366,7 +366,9 @@ function execute(argv) {
                                 return Promise.resolve();
                             }
                         })
-                            .catch(function (e) { return logger.error(e); });
+                            .catch(function (e) {
+                            logger.error("Failed to get module with url [" + moduleApiUrl + "]\nYou may need to specify a custom --mwModulePath", e);
+                        });
                     }
                 }
                 function treatMedias(parsoidDoc, articleId, finished) {
@@ -944,7 +946,7 @@ function execute(argv) {
                 }
                 function saveArticle(articleId, finished) {
                     var html = '';
-                    var articleApiUrl = mw.base + "api/rest_v1/page/mobile-sections/" + encodeURIComponent(articleId);
+                    var articleApiUrl = "" + mcsUrl + encodeURIComponent(articleId);
                     logger.log("Getting (mobile) article from " + articleApiUrl);
                     node_fetch_1.default(articleApiUrl, {
                         method: 'GET',
@@ -1656,13 +1658,13 @@ function execute(argv) {
                 return createMainPage();
             }
         }
-        var _speed, adminEmail, localParsoid, customZimFavicon, verbose, minifyHtml, skipCacheCleaning, keepEmptyParagraphs, mwUrl, mwWikiPath, mwApiPath, mwDomain, mwUsername, mwPassword, requestTimeout, publisher, customMainPage, customZimTitle, customZimDescription, customZimTags, cacheDirectory, outputDirectory, tmpDirectory, withZimFullTextIndex, format, filenamePrefix, keepHtml, resume, deflateTmpHtml, writeHtmlRedirects, articleList, _addNamespaces, _useCache, parsoidUrl, useCache, cpuCount, speed, logger, nodeVersionSatisfiesPackage, mw, downloader, creator, zimOpts, zim, env, INFINITY_WIDTH, articleIds, webUrlHost, parsoidContentType, addNamespaces, redis, dirs, cssLinks, jsScripts, redirectTemplate, footerTemplate, leadSectionTemplate, sectionTemplate, subSectionTemplate, genericJsModules, genericCssModules, mediaRegex, htmlTemplateCode, optimizationQueue, downloadFileQueue, redirectQueue, tmpArticleListPath, articleListContentStream_1, articleListWriteStream_1;
+        var _speed, adminEmail, localMcs, customZimFavicon, verbose, minifyHtml, skipCacheCleaning, keepEmptyParagraphs, mwUrl, mwWikiPath, mwApiPath, mwModulePath, mwDomain, mwUsername, mwPassword, requestTimeout, publisher, customMainPage, customZimTitle, customZimDescription, customZimTags, cacheDirectory, outputDirectory, tmpDirectory, withZimFullTextIndex, format, filenamePrefix, keepHtml, resume, deflateTmpHtml, writeHtmlRedirects, articleList, _addNamespaces, _useCache, mcsUrl, useCache, cpuCount, speed, logger, runner, nodeVersionSatisfiesPackage, mw, downloader, creator, zimOpts, zim, env, INFINITY_WIDTH, articleIds, webUrlHost, addNamespaces, domain, redis, dirs, cssLinks, jsScripts, redirectTemplate, footerTemplate, leadSectionTemplate, sectionTemplate, subSectionTemplate, genericJsModules, genericCssModules, mediaRegex, htmlTemplateCode, optimizationQueue, downloadFileQueue, redirectQueue, tmpArticleListPath, articleListContentStream_1, articleListWriteStream_1;
         var _this = this;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
-                    _speed = argv.speed, adminEmail = argv.adminEmail, localParsoid = argv.localParsoid, customZimFavicon = argv.customZimFavicon, verbose = argv.verbose, minifyHtml = argv.minifyHtml, skipCacheCleaning = argv.skipCacheCleaning, keepEmptyParagraphs = argv.keepEmptyParagraphs, mwUrl = argv.mwUrl, mwWikiPath = argv.mwWikiPath, mwApiPath = argv.mwApiPath, mwDomain = argv.mwDomain, mwUsername = argv.mwUsername, mwPassword = argv.mwPassword, requestTimeout = argv.requestTimeout, publisher = argv.publisher, customMainPage = argv.customMainPage, customZimTitle = argv.customZimTitle, customZimDescription = argv.customZimDescription, customZimTags = argv.customZimTags, cacheDirectory = argv.cacheDirectory, outputDirectory = argv.outputDirectory, tmpDirectory = argv.tmpDirectory, withZimFullTextIndex = argv.withZimFullTextIndex, format = argv.format, filenamePrefix = argv.filenamePrefix, keepHtml = argv.keepHtml, resume = argv.resume, deflateTmpHtml = argv.deflateTmpHtml, writeHtmlRedirects = argv.writeHtmlRedirects, articleList = argv.articleList, _addNamespaces = argv.addNamespaces, _useCache = argv.useCache;
-                    parsoidUrl = argv.parsoidUrl;
+                    _speed = argv.speed, adminEmail = argv.adminEmail, localMcs = argv.localMcs, customZimFavicon = argv.customZimFavicon, verbose = argv.verbose, minifyHtml = argv.minifyHtml, skipCacheCleaning = argv.skipCacheCleaning, keepEmptyParagraphs = argv.keepEmptyParagraphs, mwUrl = argv.mwUrl, mwWikiPath = argv.mwWikiPath, mwApiPath = argv.mwApiPath, mwModulePath = argv.mwModulePath, mwDomain = argv.mwDomain, mwUsername = argv.mwUsername, mwPassword = argv.mwPassword, requestTimeout = argv.requestTimeout, publisher = argv.publisher, customMainPage = argv.customMainPage, customZimTitle = argv.customZimTitle, customZimDescription = argv.customZimDescription, customZimTags = argv.customZimTags, cacheDirectory = argv.cacheDirectory, outputDirectory = argv.outputDirectory, tmpDirectory = argv.tmpDirectory, withZimFullTextIndex = argv.withZimFullTextIndex, format = argv.format, filenamePrefix = argv.filenamePrefix, keepHtml = argv.keepHtml, resume = argv.resume, deflateTmpHtml = argv.deflateTmpHtml, writeHtmlRedirects = argv.writeHtmlRedirects, articleList = argv.articleList, _addNamespaces = argv.addNamespaces, _useCache = argv.useCache;
+                    mcsUrl = argv.mcsUrl;
                     useCache = typeof _useCache === 'undefined' ? true : _useCache;
                     /* HTTP user-agent string */
                     // const adminEmail = argv.adminEmail;
@@ -1682,12 +1684,14 @@ function execute(argv) {
                     /* Necessary to avoid problems with https */
                     process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
                     logger = new Logger_1.default(verbose);
+                    runner = new service_runner_1.default();
                     nodeVersionSatisfiesPackage = semver_1.default.satisfies(process.version, package_json_1.default.engines.node);
                     if (!nodeVersionSatisfiesPackage) {
                         logger.warn("***********\n\n\tCurrent node version is [" + process.version + "]. We recommend [" + package_json_1.default.engines.node + "]\n\n***********");
                     }
                     mw = new MediaWiki_1.default(logger, {
                         apiPath: mwApiPath,
+                        modulePath: mwModulePath,
                         base: mwUrl,
                         domain: mwDomain,
                         password: mwPassword,
@@ -1742,34 +1746,54 @@ function execute(argv) {
                     INFINITY_WIDTH = 9999999;
                     articleIds = {};
                     webUrlHost = url_1.default.parse(mw.webUrl).host;
-                    parsoidContentType = 'html';
                     addNamespaces = _addNamespaces ? String(_addNamespaces).split(',').map(function (a) { return Number(a); }) : [];
-                    if (!!parsoidUrl) return [3 /*break*/, 3];
-                    if (!localParsoid) return [3 /*break*/, 2];
-                    logger.log('Starting Parsoid');
-                    // Icky but necessary
-                    fs_1.default.writeFileSync('./localsettings.js', "\n                exports.setup = function(parsoidConfig) {\n                    parsoidConfig.setMwApi({\n                        uri: '" + (mw.base + mw.apiPath) + "',\n                    });\n                };\n                ", 'utf8');
-                    return [4 /*yield*/, parsoid_1.default
-                            .apiServiceWorker({
-                            appBasePath: './node_modules/parsoid',
-                            logger: console,
-                            config: {
-                                localsettings: '../../localsettings.js',
-                                parent: undefined,
+                    if (!localMcs) return [3 /*break*/, 2];
+                    // Start Parsoid
+                    logger.log('Starting Parsoid & MCS');
+                    return [4 /*yield*/, runner.start({
+                            num_workers: 0,
+                            services: [{
+                                    name: 'parsoid',
+                                    module: 'node_modules/parsoid/lib/index.js',
+                                    entrypoint: 'apiServiceWorker',
+                                    conf: {
+                                        mwApis: [{
+                                                uri: "" + (mw.base + mw.apiPath),
+                                            }],
+                                    },
+                                }, {
+                                    name: 'mcs',
+                                    module: 'node_modules/service-mobileapp-node/app.js',
+                                    conf: {
+                                        port: 6927,
+                                        mwapi_req: {
+                                            method: 'post',
+                                            uri: "https://{{domain}}/" + mw.apiPath,
+                                            headers: {
+                                                'user-agent': '{{user-agent}}',
+                                            },
+                                            body: '{{ default(request.query, {}) }}',
+                                        },
+                                        restbase_req: {
+                                            method: '{{request.method}}',
+                                            uri: 'http://localhost:8000/{{domain}}/v3/{+path}',
+                                            query: '{{ default(request.query, {}) }}',
+                                            headers: '{{request.headers}}',
+                                            body: '{{request.body}}',
+                                        },
+                                    },
+                                }],
+                            logging: {
+                                level: 'info',
                             },
-                        })
-                            .then(function (_) {
-                            fs_1.default.unlinkSync('./localsettings.js');
-                            logger.log('Parsoid Started Successfully');
                         })];
                 case 1:
                     _a.sent();
-                    parsoidUrl = "http://localhost:8000/" + webUrlHost + "/v3/page/pagebundle/";
-                    parsoidContentType = 'json';
+                    domain = (new url_1.URL(mw.base)).host;
+                    mcsUrl = "http://localhost:6927/" + domain + "/v1/page/mobile-sections/";
                     return [3 /*break*/, 3];
                 case 2:
-                    parsoidUrl = mw.apiUrl + "action=visualeditor&format=json&paction=parse&page=";
-                    parsoidContentType = 'json';
+                    mcsUrl = mw.base + "api/rest_v1/page/mobile-sections/";
                     _a.label = 3;
                 case 3: 
                 /* ********************************* */

--- a/lib/parameterList.js
+++ b/lib/parameterList.js
@@ -37,13 +37,14 @@ var parameterList = [
     { name: 'keepHtml', description: 'If ZIM built, keep the temporary HTML directory', required: false },
     { name: 'mwWikiPath', description: 'Mediawiki wiki base path (per default "/wiki/")', required: false },
     { name: 'mwApiPath', description: 'Mediawiki API path (per default "/w/api.php")', required: false },
+    { name: 'mwModulePath', description: 'Mediawiki module load path (per default "/w/load.php")', required: false },
     { name: 'mwDomain', description: 'Mediawiki user domain (thought for private wikis)', required: false },
     { name: 'mwUsername', description: 'Mediawiki username (thought for private wikis)', required: false },
     { name: 'mwPassword', description: 'Mediawiki user password (thought for private wikis)', required: false },
     { name: 'minifyHtml', description: 'Try to reduce the size of the HTML', required: false },
     { name: 'outputDirectory', description: 'Directory to write the downloaded content', required: false },
-    { name: 'parsoidUrl', description: 'Mediawiki Parsoid URL', required: false },
     { name: 'publisher', description: "ZIM publisher meta data, per default 'Kiwix'", required: false },
+    { name: 'mcsUrl', description: 'Mediawiki MCS URL', required: false },
     {
         name: 'redis',
         description: 'Redis configuration (https://github.com/NodeRedis/node_redis#rediscreateclient)',
@@ -66,7 +67,7 @@ var parameterList = [
     { name: 'verbose', description: 'Print debug information to the stdout', required: false },
     { name: 'withZimFullTextIndex', description: 'Include a fulltext search index to the ZIM', required: false },
     { name: 'writeHtmlRedirects', description: 'Write redirect as HTML files', required: false },
-    { name: 'localParsoid', description: 'Create a local parsoid instance default value is false', required: false },
+    { name: 'localMcs', description: 'Create a local MCS and Parsoid instance default value is false', required: false },
     { name: 'addNamespaces', description: 'Force addional namespace (comma separated numbers)', required: false },
 ];
 exports.default = parameterList;

--- a/package-lock.json
+++ b/package-lock.json
@@ -425,6 +425,11 @@
 			"resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
 		},
+		"array-uniq": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+		},
 		"array-unique": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
@@ -635,6 +640,15 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
+		"bl": {
+			"version": "1.2.2",
+			"resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+			"requires": {
+				"readable-stream": "^2.3.5",
+				"safe-buffer": "^5.1.1"
+			}
+		},
 		"bluebird": {
 			"version": "3.5.3",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
@@ -676,6 +690,11 @@
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
+		},
+		"boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
 		},
 		"boxen": {
 			"version": "1.3.0",
@@ -750,6 +769,22 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+		},
+		"bunyan": {
+			"version": "1.8.12",
+			"resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
+			"integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+			"requires": {
+				"dtrace-provider": "~0.8",
+				"moment": "^2.10.6",
+				"mv": "~2",
+				"safe-json-stringify": "~1"
+			}
+		},
+		"bunyan-syslog-udp": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/bunyan-syslog-udp/-/bunyan-syslog-udp-0.1.0.tgz",
+			"integrity": "sha1-+/ruA6gc0qlavBj5LJnyu4fiQpw="
 		},
 		"bytes": {
 			"version": "3.0.0",
@@ -834,6 +869,14 @@
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
+		"cassandra-uuid": {
+			"version": "0.0.2",
+			"resolved": "http://registry.npmjs.org/cassandra-uuid/-/cassandra-uuid-0.0.2.tgz",
+			"integrity": "sha1-QtGxVtWugfIUeVtAXW8BcAsx6Ww=",
+			"requires": {
+				"long": "^2.2.5"
+			}
+		},
 		"center-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
@@ -865,6 +908,29 @@
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
 			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
 		},
+		"cheerio": {
+			"version": "0.22.0",
+			"resolved": "http://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+			"integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+			"requires": {
+				"css-select": "~1.2.0",
+				"dom-serializer": "~0.1.0",
+				"entities": "~1.1.1",
+				"htmlparser2": "^3.9.1",
+				"lodash.assignin": "^4.0.9",
+				"lodash.bind": "^4.1.4",
+				"lodash.defaults": "^4.0.1",
+				"lodash.filter": "^4.4.0",
+				"lodash.flatten": "^4.2.0",
+				"lodash.foreach": "^4.3.0",
+				"lodash.map": "^4.4.0",
+				"lodash.merge": "^4.4.0",
+				"lodash.pick": "^4.2.1",
+				"lodash.reduce": "^4.4.0",
+				"lodash.reject": "^4.4.0",
+				"lodash.some": "^4.4.0"
+			}
+		},
 		"ci-info": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
@@ -875,6 +941,11 @@
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
 			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
 			"dev": true
+		},
+		"clarinet": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/clarinet/-/clarinet-0.11.0.tgz",
+			"integrity": "sha1-bMkSuTE43IZ/wnPNNOqQ6D4FRxk="
 		},
 		"class-utils": {
 			"version": "0.3.6",
@@ -1145,6 +1216,43 @@
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
 			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 		},
+		"compressible": {
+			"version": "2.0.15",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.15.tgz",
+			"integrity": "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==",
+			"requires": {
+				"mime-db": ">= 1.36.0 < 2"
+			}
+		},
+		"compression": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
+			"integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
+			"requires": {
+				"accepts": "~1.3.5",
+				"bytes": "3.0.0",
+				"compressible": "~2.0.14",
+				"debug": "2.6.9",
+				"on-headers": "~1.0.1",
+				"safe-buffer": "5.1.2",
+				"vary": "~1.1.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1263,6 +1371,22 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
 			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+		},
+		"css-select": {
+			"version": "1.2.0",
+			"resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+			"requires": {
+				"boolbase": "~1.0.0",
+				"css-what": "2.1",
+				"domutils": "1.5.1",
+				"nth-check": "~1.0.1"
+			}
+		},
+		"css-what": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.2.tgz",
+			"integrity": "sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ=="
 		},
 		"cycle": {
 			"version": "1.0.3",
@@ -1396,6 +1520,25 @@
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 		},
+		"dnscache": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dnscache/-/dnscache-1.0.1.tgz",
+			"integrity": "sha1-Qssrm/tej736OVqsdOEn/AUHTTE=",
+			"requires": {
+				"asap": "~2.0.3",
+				"lodash.clone": "~4.3.2"
+			},
+			"dependencies": {
+				"lodash.clone": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.3.2.tgz",
+					"integrity": "sha1-5WsXa2gjp93jj38r9Y3n1ZcSAOk=",
+					"requires": {
+						"lodash._baseclone": "~4.5.0"
+					}
+				}
+			}
+		},
 		"dockerfile-ast": {
 			"version": "0.0.12",
 			"resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.12.tgz",
@@ -1413,10 +1556,53 @@
 				"esutils": "^2.0.2"
 			}
 		},
+		"dom-serializer": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+			"requires": {
+				"domelementtype": "~1.1.1",
+				"entities": "~1.1.1"
+			},
+			"dependencies": {
+				"domelementtype": {
+					"version": "1.1.3",
+					"resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
+				}
+			}
+		},
+		"dom-storage": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
+			"integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q=="
+		},
+		"domelementtype": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+		},
+		"domhandler": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+			"requires": {
+				"domelementtype": "1"
+			}
+		},
 		"domino": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/domino/-/domino-2.1.1.tgz",
 			"integrity": "sha512-fqoTi6oQ881wYRENIEmz78hKVoc3X9HqVpklo419yxzebys6dtU5c83iVh3UYvvexPFdAuwlDYCsUM9//CrMMg=="
+		},
+		"domutils": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+			"requires": {
+				"dom-serializer": "0",
+				"domelementtype": "1"
+			}
 		},
 		"dot-prop": {
 			"version": "4.2.0",
@@ -1482,6 +1668,16 @@
 			"requires": {
 				"iconv-lite": "~0.4.13"
 			}
+		},
+		"ent": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+			"integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
+		},
+		"entities": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
 		},
 		"error-ex": {
 			"version": "1.3.2",
@@ -2255,6 +2451,19 @@
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
 		},
+		"gelf-stream": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/gelf-stream/-/gelf-stream-1.1.1.tgz",
+			"integrity": "sha1-nOqbY4asMBx0GDjKPLkeZtv79mk=",
+			"requires": {
+				"gelfling": "^0.3.0"
+			}
+		},
+		"gelfling": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/gelfling/-/gelfling-0.3.1.tgz",
+			"integrity": "sha1-M2qY+BUQ+a4K8qSU4XRooRap3AQ="
+		},
 		"get-caller-file": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -2446,6 +2655,11 @@
 				"async": "~1.5"
 			}
 		},
+		"hat": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz",
+			"integrity": "sha1-uwFKnmSzeIrtgAWRdBPU/z1QLYo="
+		},
 		"he": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -2455,6 +2669,11 @@
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
 			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+		},
+		"hot-shots": {
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-5.9.2.tgz",
+			"integrity": "sha512-ruHZvHaxZRVUCoCleiwwCcjdr9A2/Y97C7oc9LpyMg9ae39blHvsJJQQ0QtMtxKX+i4lig/7/BqZBjUUZPUp3A=="
 		},
 		"html-minifier": {
 			"version": "3.5.21",
@@ -2474,6 +2693,31 @@
 					"version": "2.17.1",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
 					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+				}
+			}
+		},
+		"htmlparser2": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
+			"integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
+			"requires": {
+				"domelementtype": "^1.3.0",
+				"domhandler": "^2.3.0",
+				"domutils": "^1.5.1",
+				"entities": "^1.1.1",
+				"inherits": "^2.0.1",
+				"readable-stream": "^3.0.6"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.0.tgz",
+					"integrity": "sha512-vpydAvIJvPODZNagCPuHG87O9JNPtvFEtjHHRVwNVsVVRBqemvPJkc2SYbxJsiZXawJdtZNmkmnsPuE3IgsG0A==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
 				}
 			}
 		},
@@ -2511,6 +2755,11 @@
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
+		},
+		"http-shutdown": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-shutdown/-/http-shutdown-1.2.0.tgz",
+			"integrity": "sha1-3y2AZ6iFbpnRHp3OshYJWR4d9RQ="
 		},
 		"http-signature": {
 			"version": "1.2.0",
@@ -3055,6 +3304,64 @@
 			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
 			"integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ=="
 		},
+		"kad": {
+			"version": "git+https://github.com/gwicke/kad.git#936c91652d757ea6f9dd30e44698afb0daaa1d17",
+			"from": "git+https://github.com/gwicke/kad.git#master",
+			"requires": {
+				"async": "^0.9.0",
+				"clarinet": "^0.11.0",
+				"colors": "^1.0.3",
+				"hat": "0.0.3",
+				"kad-fs": "0.0.4",
+				"kad-localstorage": "0.0.7",
+				"kad-memstore": "0.0.1",
+				"lodash": "^3.6.0",
+				"merge": "^1.2.0",
+				"ms": "^0.7.0",
+				"msgpack5": "^3.3.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "0.9.2",
+					"resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
+					"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+				},
+				"lodash": {
+					"version": "3.10.1",
+					"resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+				},
+				"ms": {
+					"version": "0.7.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+					"integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
+				}
+			}
+		},
+		"kad-fs": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/kad-fs/-/kad-fs-0.0.4.tgz",
+			"integrity": "sha1-Aupapc8iIlclV5YnzP1tJmNyKJo=",
+			"requires": {
+				"readable-stream": "^2.0.4"
+			}
+		},
+		"kad-localstorage": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/kad-localstorage/-/kad-localstorage-0.0.7.tgz",
+			"integrity": "sha1-96LngNpT+yi5Q8LFqJTCeaqBDxc=",
+			"requires": {
+				"dom-storage": "^2.0.1"
+			}
+		},
+		"kad-memstore": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/kad-memstore/-/kad-memstore-0.0.1.tgz",
+			"integrity": "sha1-g8t0hJasSRxxNRBMvla4jKc5JHc=",
+			"requires": {
+				"readable-stream": "^2.0.5"
+			}
+		},
 		"kind-of": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -3102,6 +3409,16 @@
 			"integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
 			"requires": {
 				"immediate": "~3.0.5"
+			}
+		},
+		"limitation": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/limitation/-/limitation-0.2.0.tgz",
+			"integrity": "sha1-cM4QKpcqC3nUyhOjq2K45v5oKmI=",
+			"requires": {
+				"bluebird": "^3.3.1",
+				"kad": "git+https://github.com/gwicke/kad.git#936c91652d757ea6f9dd30e44698afb0daaa1d17",
+				"readable-stream": "^2.0.5"
 			}
 		},
 		"lint-staged": {
@@ -3288,10 +3605,31 @@
 				}
 			}
 		},
+		"locate-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"requires": {
+				"p-locate": "^3.0.0",
+				"path-exists": "^3.0.0"
+			},
+			"dependencies": {
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+				}
+			}
+		},
 		"lodash": {
 			"version": "4.17.11",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
 			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+		},
+		"lodash._baseclone": {
+			"version": "4.5.7",
+			"resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-4.5.7.tgz",
+			"integrity": "sha1-zkKt4IOE711i+nfDD2GkbmhvhDQ="
 		},
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
@@ -3308,6 +3646,11 @@
 			"resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
 			"integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
 		},
+		"lodash.bind": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+			"integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
+		},
 		"lodash.clone": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
@@ -3318,20 +3661,85 @@
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
 			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
 		},
+		"lodash.defaults": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+		},
+		"lodash.escaperegexp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+			"integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
+		},
+		"lodash.filter": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+			"integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
+		},
 		"lodash.flatten": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
 			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+		},
+		"lodash.foreach": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+			"integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
 		},
 		"lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
 			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
 		},
+		"lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+		},
+		"lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+		},
+		"lodash.map": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+			"integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
+		},
+		"lodash.merge": {
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+		},
+		"lodash.mergewith": {
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+			"integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
+		},
+		"lodash.pick": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+			"integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+		},
+		"lodash.reduce": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+			"integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
+		},
+		"lodash.reject": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+			"integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
+		},
 		"lodash.set": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
 			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+		},
+		"lodash.some": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+			"integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
 		},
 		"lodash.template": {
 			"version": "4.4.0",
@@ -3402,6 +3810,11 @@
 			"resolved": "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz",
 			"integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ=="
 		},
+		"long": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/long/-/long-2.4.0.tgz",
+			"integrity": "sha1-n6GAux2VAM3CnEFWdmoZleH0Uk8="
+		},
 		"longest": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -3444,6 +3857,14 @@
 				"pify": "^3.0.0"
 			}
 		},
+		"map-age-cleaner": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+			"requires": {
+				"p-defer": "^1.0.0"
+			}
+		},
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -3462,6 +3883,26 @@
 			"resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
+		"mediawiki-title": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/mediawiki-title/-/mediawiki-title-0.6.5.tgz",
+			"integrity": "sha512-fPcI4r2yH02UUgMo308CVzIuXUaRUrBzMvjXX8J4XfcHgX9Y73iB0/VLp+S3TnxnTgIGrQ3BFb7kWGR7kkyS8g=="
+		},
+		"mem": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
+			"integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
+			"requires": {
+				"map-age-cleaner": "^0.1.1",
+				"mimic-fn": "^1.0.0",
+				"p-is-promise": "^1.1.0"
+			}
+		},
+		"merge": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+			"integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
+		},
 		"merge-descriptors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -3471,6 +3912,29 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
 			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+		},
+		"microformat-node": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/microformat-node/-/microformat-node-2.0.1.tgz",
+			"integrity": "sha1-CEnc+yn0+SUaTGUj2ahzz0W46UI=",
+			"requires": {
+				"bluebird": "3.4.x",
+				"cheerio": "0.22.x",
+				"ent": "^2.2.0",
+				"microformat-shiv": "^2.0.0"
+			},
+			"dependencies": {
+				"bluebird": {
+					"version": "3.4.7",
+					"resolved": "http://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+					"integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
+				}
+			}
+		},
+		"microformat-shiv": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/microformat-shiv/-/microformat-shiv-2.0.3.tgz",
+			"integrity": "sha1-A1DattosUX+PTO8asof+a+6uxyU="
 		},
 		"micromatch": {
 			"version": "3.1.10",
@@ -3645,6 +4109,17 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
 			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+		},
+		"msgpack5": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/msgpack5/-/msgpack5-3.6.0.tgz",
+			"integrity": "sha512-6HuCZHA57WtNUzrKIvjJ8OMxigzveJ6D5i13y6TsgGu3X3zxABpuBvChpppOoGdB9SyWZcmqUs1fwUV/PpSQ7Q==",
+			"requires": {
+				"bl": "^1.2.1",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.3.3",
+				"safe-buffer": "^5.1.1"
+			}
 		},
 		"mute-stream": {
 			"version": "0.0.7",
@@ -3909,6 +4384,14 @@
 				"which": "^1.2.10"
 			}
 		},
+		"nth-check": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+			"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+			"requires": {
+				"boolbase": "~1.0.0"
+			}
+		},
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -3975,6 +4458,11 @@
 			"requires": {
 				"ee-first": "1.1.1"
 			}
+		},
+		"on-headers": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+			"integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
 		},
 		"once": {
 			"version": "1.4.0",
@@ -4051,16 +4539,47 @@
 			"resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
+		"p-defer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+		},
+		"p-is-promise": {
+			"version": "1.1.0",
+			"resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
+		},
+		"p-limit": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+			"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+			"requires": {
+				"p-try": "^2.0.0"
+			}
+		},
+		"p-locate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"requires": {
+				"p-limit": "^2.0.0"
+			}
 		},
 		"p-map": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
 			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
 			"optional": true
+		},
+		"p-try": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+			"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
 		},
 		"pac-proxy-agent": {
 			"version": "2.0.2",
@@ -4318,11 +4837,6 @@
 					"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
 					"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
 				},
-				"async": {
-					"version": "0.9.2",
-					"resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
-					"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
-				},
 				"asynckit": {
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -4380,49 +4894,6 @@
 					"version": "0.4.2",
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
 					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-				},
-				"bl": {
-					"version": "1.2.2",
-					"resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-					"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
-					"requires": {
-						"readable-stream": "^2.3.5",
-						"safe-buffer": "^5.1.1"
-					},
-					"dependencies": {
-						"isarray": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-						},
-						"readable-stream": {
-							"version": "2.3.6",
-							"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						},
-						"string_decoder": {
-							"version": "1.1.1",
-							"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						}
-					}
-				},
-				"bluebird": {
-					"version": "3.5.1",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-					"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
 				},
 				"body-parser": {
 					"version": "1.18.2",
@@ -4492,22 +4963,6 @@
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
 					"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
-				},
-				"bunyan": {
-					"version": "1.8.12",
-					"resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
-					"integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
-					"requires": {
-						"dtrace-provider": "~0.8",
-						"moment": "^2.10.6",
-						"mv": "~2",
-						"safe-json-stringify": "~1"
-					}
-				},
-				"bunyan-syslog-udp": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/bunyan-syslog-udp/-/bunyan-syslog-udp-0.1.0.tgz",
-					"integrity": "sha1-+/ruA6gc0qlavBj5LJnyu4fiQpw="
 				},
 				"busboy": {
 					"version": "0.2.14",
@@ -4615,11 +5070,6 @@
 					"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
 					"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
 				},
-				"clarinet": {
-					"version": "0.11.0",
-					"resolved": "https://registry.npmjs.org/clarinet/-/clarinet-0.11.0.tgz",
-					"integrity": "sha1-bMkSuTE43IZ/wnPNNOqQ6D4FRxk="
-				},
 				"cli": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
@@ -4658,7 +5108,6 @@
 					"integrity": "sha1-LR738hig54biFFQFYtS9F3/jLZc=",
 					"requires": {
 						"colors": "^1.1.2",
-						"lodash": "^3.10.1",
 						"string-width": "^1.0.1"
 					}
 				},
@@ -4699,11 +5148,6 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"colors": {
-					"version": "1.2.4",
-					"resolved": "https://registry.npmjs.org/colors/-/colors-1.2.4.tgz",
-					"integrity": "sha512-6Y+iBnWmXL+AWtlOp2Vr6R2w5MUlNJRwR0ShVFaAb1CqWzhPOpQg4L0jxD+xpw/Nc8QJwaq3KM79QUCriY8CWQ=="
 				},
 				"combined-stream": {
 					"version": "1.0.6",
@@ -5065,15 +5509,6 @@
 					"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 				},
-				"dnscache": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/dnscache/-/dnscache-1.0.1.tgz",
-					"integrity": "sha1-Qssrm/tej736OVqsdOEn/AUHTTE=",
-					"requires": {
-						"asap": "~2.0.3",
-						"lodash.clone": "~4.3.2"
-					}
-				},
 				"doctrine": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -5097,11 +5532,6 @@
 							"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
 						}
 					}
-				},
-				"dom-storage": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
-					"integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q=="
 				},
 				"domelementtype": {
 					"version": "1.3.0",
@@ -5724,19 +6154,6 @@
 					"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 					"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
 				},
-				"gelf-stream": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/gelf-stream/-/gelf-stream-1.1.1.tgz",
-					"integrity": "sha1-nOqbY4asMBx0GDjKPLkeZtv79mk=",
-					"requires": {
-						"gelfling": "^0.3.0"
-					}
-				},
-				"gelfling": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/gelfling/-/gelfling-0.3.1.tgz",
-					"integrity": "sha1-M2qY+BUQ+a4K8qSU4XRooRap3AQ="
-				},
 				"get-caller-file": {
 					"version": "1.0.2",
 					"resolved": "http://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -5868,11 +6285,6 @@
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
 					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
 				},
-				"hat": {
-					"version": "0.0.3",
-					"resolved": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz",
-					"integrity": "sha1-uwFKnmSzeIrtgAWRdBPU/z1QLYo="
-				},
 				"hawk": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
@@ -5898,11 +6310,6 @@
 					"version": "2.5.0",
 					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
 					"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
-				},
-				"hot-shots": {
-					"version": "4.8.0",
-					"resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-4.8.0.tgz",
-					"integrity": "sha1-BSvkhDDvx9EXunzE1B8YM7o4x58="
 				},
 				"htmlparser2": {
 					"version": "3.8.3",
@@ -6334,105 +6741,6 @@
 						"verror": "1.10.0"
 					}
 				},
-				"kad": {
-					"version": "git+https://github.com/gwicke/kad.git#936c91652d757ea6f9dd30e44698afb0daaa1d17",
-					"from": "git+https://github.com/gwicke/kad.git#master",
-					"requires": {
-						"async": "^0.9.0",
-						"clarinet": "^0.11.0",
-						"colors": "^1.0.3",
-						"hat": "0.0.3",
-						"kad-fs": "0.0.4",
-						"kad-localstorage": "0.0.7",
-						"kad-memstore": "0.0.1",
-						"lodash": "^3.6.0",
-						"merge": "^1.2.0",
-						"ms": "^0.7.0",
-						"msgpack5": "^3.3.0"
-					}
-				},
-				"kad-fs": {
-					"version": "0.0.4",
-					"resolved": "https://registry.npmjs.org/kad-fs/-/kad-fs-0.0.4.tgz",
-					"integrity": "sha1-Aupapc8iIlclV5YnzP1tJmNyKJo=",
-					"requires": {
-						"readable-stream": "^2.0.4"
-					},
-					"dependencies": {
-						"isarray": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-						},
-						"readable-stream": {
-							"version": "2.3.6",
-							"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						},
-						"string_decoder": {
-							"version": "1.1.1",
-							"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						}
-					}
-				},
-				"kad-localstorage": {
-					"version": "0.0.7",
-					"resolved": "https://registry.npmjs.org/kad-localstorage/-/kad-localstorage-0.0.7.tgz",
-					"integrity": "sha1-96LngNpT+yi5Q8LFqJTCeaqBDxc=",
-					"requires": {
-						"dom-storage": "^2.0.1"
-					}
-				},
-				"kad-memstore": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/kad-memstore/-/kad-memstore-0.0.1.tgz",
-					"integrity": "sha1-g8t0hJasSRxxNRBMvla4jKc5JHc=",
-					"requires": {
-						"readable-stream": "^2.0.5"
-					},
-					"dependencies": {
-						"isarray": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-						},
-						"readable-stream": {
-							"version": "2.3.6",
-							"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						},
-						"string_decoder": {
-							"version": "1.1.1",
-							"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						}
-					}
-				},
 				"klaw": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
@@ -6463,45 +6771,6 @@
 						"type-check": "~0.3.2"
 					}
 				},
-				"limitation": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/limitation/-/limitation-0.2.0.tgz",
-					"integrity": "sha1-cM4QKpcqC3nUyhOjq2K45v5oKmI=",
-					"requires": {
-						"bluebird": "^3.3.1",
-						"kad": "git+https://github.com/gwicke/kad.git#936c91652d757ea6f9dd30e44698afb0daaa1d17",
-						"readable-stream": "^2.0.5"
-					},
-					"dependencies": {
-						"isarray": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-						},
-						"readable-stream": {
-							"version": "2.3.6",
-							"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						},
-						"string_decoder": {
-							"version": "1.1.1",
-							"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						}
-					}
-				},
 				"load-json-file": {
 					"version": "1.1.0",
 					"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -6528,24 +6797,6 @@
 							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
 							"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 						}
-					}
-				},
-				"lodash": {
-					"version": "3.10.1",
-					"resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-				},
-				"lodash._baseclone": {
-					"version": "4.5.7",
-					"resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-4.5.7.tgz",
-					"integrity": "sha1-zkKt4IOE711i+nfDD2GkbmhvhDQ="
-				},
-				"lodash.clone": {
-					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.3.2.tgz",
-					"integrity": "sha1-5WsXa2gjp93jj38r9Y3n1ZcSAOk=",
-					"requires": {
-						"lodash._baseclone": "~4.5.0"
 					}
 				},
 				"log-driver": {
@@ -6575,11 +6826,6 @@
 					"requires": {
 						"mimic-fn": "^1.0.0"
 					}
-				},
-				"merge": {
-					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-					"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
 				},
 				"merge-descriptors": {
 					"version": "1.0.1",
@@ -6692,51 +6938,6 @@
 							"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
 							"requires": {
 								"has-flag": "^2.0.0"
-							}
-						}
-					}
-				},
-				"ms": {
-					"version": "0.7.2",
-					"resolved": "http://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-					"integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
-				},
-				"msgpack5": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/msgpack5/-/msgpack5-3.6.0.tgz",
-					"integrity": "sha512-6HuCZHA57WtNUzrKIvjJ8OMxigzveJ6D5i13y6TsgGu3X3zxABpuBvChpppOoGdB9SyWZcmqUs1fwUV/PpSQ7Q==",
-					"requires": {
-						"bl": "^1.2.1",
-						"inherits": "^2.0.3",
-						"readable-stream": "^2.3.3",
-						"safe-buffer": "^5.1.1"
-					},
-					"dependencies": {
-						"isarray": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-						},
-						"readable-stream": {
-							"version": "2.3.6",
-							"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						},
-						"string_decoder": {
-							"version": "1.1.1",
-							"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-							"requires": {
-								"safe-buffer": "~5.1.0"
 							}
 						}
 					}
@@ -7197,11 +7398,6 @@
 						"core-js": "^2.5.3"
 					}
 				},
-				"process-nextick-args": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-				},
 				"progress": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
@@ -7574,20 +7770,218 @@
 					}
 				},
 				"service-runner": {
-					"version": "2.6.1",
-					"resolved": "https://registry.npmjs.org/service-runner/-/service-runner-2.6.1.tgz",
-					"integrity": "sha1-ts255lILep8Y1WlsYdgt6VVd6/s=",
+					"version": "2.6.8",
+					"resolved": "https://registry.npmjs.org/service-runner/-/service-runner-2.6.8.tgz",
+					"integrity": "sha512-sCdnvhKNCxNjTDtaePTYlb7lXsZE8LTGUKq1jbAGNK7m0GxK/LnwX5Rr96DlYfMRaimo3bV9qogb+Yq7umfINA==",
 					"requires": {
-						"bluebird": "^3.5.0",
-						"bunyan": "^1.8.10",
+						"bluebird": "^3.5.2",
+						"bunyan": "^1.8.12",
 						"bunyan-syslog-udp": "^0.1.0",
 						"dnscache": "^1.0.1",
 						"gelf-stream": "^1.1.1",
-						"hot-shots": "^4.4.0",
-						"js-yaml": "^3.8.3",
+						"hot-shots": "^5.9.1",
+						"js-yaml": "^3.12.0",
 						"limitation": "^0.2.0",
-						"semver": "^5.3.0",
-						"yargs": "^7.1.0"
+						"semver": "^5.6.0",
+						"yargs": "^12.0.2"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+						},
+						"camelcase": {
+							"version": "5.0.0",
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+							"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+						},
+						"cliui": {
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+							"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+							"requires": {
+								"string-width": "^2.1.1",
+								"strip-ansi": "^4.0.0",
+								"wrap-ansi": "^2.0.0"
+							}
+						},
+						"cross-spawn": {
+							"version": "6.0.5",
+							"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+							"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+							"requires": {
+								"nice-try": "^1.0.4",
+								"path-key": "^2.0.1",
+								"semver": "^5.5.0",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
+							}
+						},
+						"esprima": {
+							"version": "4.0.1",
+							"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+							"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+						},
+						"execa": {
+							"version": "0.10.0",
+							"resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+							"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+							"requires": {
+								"cross-spawn": "^6.0.0",
+								"get-stream": "^3.0.0",
+								"is-stream": "^1.1.0",
+								"npm-run-path": "^2.0.0",
+								"p-finally": "^1.0.0",
+								"signal-exit": "^3.0.0",
+								"strip-eof": "^1.0.0"
+							}
+						},
+						"find-up": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+							"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+							"requires": {
+								"locate-path": "^3.0.0"
+							}
+						},
+						"invert-kv": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+							"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+						},
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+						},
+						"js-yaml": {
+							"version": "3.12.0",
+							"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+							"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+							"requires": {
+								"argparse": "^1.0.7",
+								"esprima": "^4.0.0"
+							}
+						},
+						"lcid": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+							"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+							"requires": {
+								"invert-kv": "^2.0.0"
+							}
+						},
+						"locate-path": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+							"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+							"requires": {
+								"p-locate": "^3.0.0",
+								"path-exists": "^3.0.0"
+							}
+						},
+						"mem": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
+							"integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
+							"requires": {
+								"map-age-cleaner": "^0.1.1",
+								"mimic-fn": "^1.0.0",
+								"p-is-promise": "^1.1.0"
+							}
+						},
+						"os-locale": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
+							"integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+							"requires": {
+								"execa": "^0.10.0",
+								"lcid": "^2.0.0",
+								"mem": "^4.0.0"
+							}
+						},
+						"p-limit": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+							"integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+							"requires": {
+								"p-try": "^2.0.0"
+							}
+						},
+						"p-locate": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+							"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+							"requires": {
+								"p-limit": "^2.0.0"
+							}
+						},
+						"p-try": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+							"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+						},
+						"path-exists": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+							"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+						},
+						"semver": {
+							"version": "5.6.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+							"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+						},
+						"string-width": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+							"requires": {
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^4.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						},
+						"which-module": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+							"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+						},
+						"yargs": {
+							"version": "12.0.5",
+							"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+							"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+							"requires": {
+								"cliui": "^4.0.0",
+								"decamelize": "^1.2.0",
+								"find-up": "^3.0.0",
+								"get-caller-file": "^1.0.1",
+								"os-locale": "^3.0.0",
+								"require-directory": "^2.1.1",
+								"require-main-filename": "^1.0.1",
+								"set-blocking": "^2.0.0",
+								"string-width": "^2.0.0",
+								"which-module": "^2.0.0",
+								"y18n": "^3.2.1 || ^4.0.0",
+								"yargs-parser": "^11.1.1"
+							}
+						},
+						"yargs-parser": {
+							"version": "11.1.1",
+							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+							"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+							"requires": {
+								"camelcase": "^5.0.0",
+								"decamelize": "^1.2.0"
+							}
+						}
 					}
 				},
 				"set-blocking": {
@@ -8033,11 +8427,6 @@
 					"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 					"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
 				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-				},
 				"utils-merge": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -8329,6 +8718,23 @@
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
 			"optional": true
 		},
+		"postcss": {
+			"version": "7.0.7",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+			"integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+			"requires": {
+				"chalk": "^2.4.1",
+				"source-map": "^0.6.1",
+				"supports-color": "^5.5.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -8338,6 +8744,16 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
 			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+		},
+		"preq": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/preq/-/preq-0.5.7.tgz",
+			"integrity": "sha512-js/t+Hi9qSDOYoGB/+0cWLrmgW4FiouhkFnyhCRdNuV2pUnWZbL+CRuD6m19ekkY9MVgdAuG9wUoHHOcdHuMlg==",
+			"requires": {
+				"bluebird": "^3.5.2",
+				"request": "^2.88.0",
+				"requestretry": "^3.0.2"
+			}
 		},
 		"pretty-format": {
 			"version": "23.6.0",
@@ -8663,6 +9079,16 @@
 				"lodash": "^4.13.1"
 			}
 		},
+		"requestretry": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/requestretry/-/requestretry-3.1.0.tgz",
+			"integrity": "sha512-DkvCPK6qvwxIuVA5TRCvi626WHC2rWjF/n7SCQvVHAr2JX9i1/cmIpSEZlmHAo+c1bj9rjaKoZ9IsKwCpTkoXA==",
+			"requires": {
+				"extend": "^3.0.2",
+				"lodash": "^4.17.10",
+				"when": "^3.7.7"
+			}
+		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8814,6 +9240,23 @@
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
+		"sanitize-html": {
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.20.0.tgz",
+			"integrity": "sha512-BpxXkBoAG+uKCHjoXFmox6kCSYpnulABoGcZ/R3QyY9ndXbIM5S94eOr1IqnzTG8TnbmXaxWoDDzKC5eJv7fEQ==",
+			"requires": {
+				"chalk": "^2.4.1",
+				"htmlparser2": "^3.10.0",
+				"lodash.clonedeep": "^4.5.0",
+				"lodash.escaperegexp": "^4.1.2",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.mergewith": "^4.6.1",
+				"postcss": "^7.0.5",
+				"srcset": "^1.0.0",
+				"xtend": "^4.0.1"
+			}
+		},
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -8892,6 +9335,212 @@
 				"escape-html": "~1.0.3",
 				"parseurl": "~1.3.2",
 				"send": "0.16.2"
+			}
+		},
+		"service-mobileapp-node": {
+			"version": "git+https://github.com/wikimedia/mediawiki-services-mobileapps.git#d2444396a4bc2fe220304952ad08f6188914bb39",
+			"from": "git+https://github.com/wikimedia/mediawiki-services-mobileapps.git#d244439",
+			"requires": {
+				"bluebird": "^3.5.1",
+				"body-parser": "^1.18.3",
+				"bunyan": "^1.8.12",
+				"cassandra-uuid": "^0.0.2",
+				"compression": "^1.7.2",
+				"core-js": "^2.5.1",
+				"domino": "^2.1.1",
+				"escape-string-regexp": "^1.0.5",
+				"express": "^4.16.3",
+				"http-shutdown": "^1.2.0",
+				"js-yaml": "^3.12.0",
+				"mediawiki-title": "^0.6.5",
+				"microformat-node": "^2.0.1",
+				"preq": "^0.5.6",
+				"sanitize-html": "^1.19.3",
+				"service-runner": "^2.6.4",
+				"striptags": "^3.1.1",
+				"swagger-router": "^0.7.1",
+				"swagger-ui": "git+https://github.com/wikimedia/swagger-ui.git#b9b40dc8e00caeb24c19fe636b93250a7e335541",
+				"underscore": "^1.8.3",
+				"wikimedia-page-library": "^6.2.0"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.1.tgz",
+					"integrity": "sha512-L72mmmEayPJBejKIWe2pYtGis5r0tQ5NaJekdhyXgeMQTpJoBsH0NL4ElY2LfSoV15xeQWKQ+XTTOZdyero5Xg=="
+				},
+				"underscore": {
+					"version": "1.9.1",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+					"integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+				}
+			}
+		},
+		"service-runner": {
+			"version": "2.6.8",
+			"resolved": "https://registry.npmjs.org/service-runner/-/service-runner-2.6.8.tgz",
+			"integrity": "sha512-sCdnvhKNCxNjTDtaePTYlb7lXsZE8LTGUKq1jbAGNK7m0GxK/LnwX5Rr96DlYfMRaimo3bV9qogb+Yq7umfINA==",
+			"requires": {
+				"bluebird": "^3.5.2",
+				"bunyan": "^1.8.12",
+				"bunyan-syslog-udp": "^0.1.0",
+				"dnscache": "^1.0.1",
+				"gelf-stream": "^1.1.1",
+				"hot-shots": "^5.9.1",
+				"js-yaml": "^3.12.0",
+				"limitation": "^0.2.0",
+				"semver": "^5.6.0",
+				"yargs": "^12.0.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"camelcase": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+					"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+				},
+				"cliui": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+					"requires": {
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
+					}
+				},
+				"execa": {
+					"version": "0.10.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+					"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+					"requires": {
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"invert-kv": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"lcid": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+					"requires": {
+						"invert-kv": "^2.0.0"
+					}
+				},
+				"os-locale": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
+					"integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+					"requires": {
+						"execa": "^0.10.0",
+						"lcid": "^2.0.0",
+						"mem": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						}
+					}
+				},
+				"yargs": {
+					"version": "12.0.5",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+					"requires": {
+						"cliui": "^4.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^3.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1 || ^4.0.0",
+						"yargs-parser": "^11.1.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "11.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
 			}
 		},
 		"set-blocking": {
@@ -9524,6 +10173,15 @@
 			"resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
+		"srcset": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/srcset/-/srcset-1.0.0.tgz",
+			"integrity": "sha1-pWad4StC87HV6D7QPHEEb8SPQe8=",
+			"requires": {
+				"array-uniq": "^1.0.2",
+				"number-is-nan": "^1.0.0"
+			}
+		},
 		"sshpk": {
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
@@ -9660,6 +10318,11 @@
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
+		"striptags": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
+			"integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
+		},
 		"supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -9683,6 +10346,37 @@
 					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
 				}
 			}
+		},
+		"swagger-router": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/swagger-router/-/swagger-router-0.7.2.tgz",
+			"integrity": "sha512-gM1m3K4guCPzDFqFST0jhMtXa3Iq4UPUKQBA7Jq044NFP4i+g0+5NA27ryPW3qRvcpkJK4Ie71jKHbvv5DVMmA==",
+			"requires": {
+				"bluebird": "^3.5.2",
+				"cassandra-uuid": "^0.1.0",
+				"js-yaml": "^3.12.0",
+				"tassembly": "^0.2.3",
+				"template-expression-compiler": "^0.1.10"
+			},
+			"dependencies": {
+				"cassandra-uuid": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/cassandra-uuid/-/cassandra-uuid-0.1.0.tgz",
+					"integrity": "sha512-XM/UdAVoXJWDcqxVqNe2agYat51C25g5m8nkJ2/ai3QvHwWsRx/+OlziD1c1/jYLlP7kcC1DMO2IF5ldt8EV+A==",
+					"requires": {
+						"long": "^4.0.0"
+					}
+				},
+				"long": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+					"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+				}
+			}
+		},
+		"swagger-ui": {
+			"version": "git+https://github.com/wikimedia/swagger-ui.git#b9b40dc8e00caeb24c19fe636b93250a7e335541",
+			"from": "git+https://github.com/wikimedia/swagger-ui.git#master"
 		},
 		"swig-templates": {
 			"version": "2.0.3",
@@ -9802,6 +10496,11 @@
 				}
 			}
 		},
+		"tassembly": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/tassembly/-/tassembly-0.2.3.tgz",
+			"integrity": "sha1-WKq7bznvTPKgSz3mEmFzLnDBTvc="
+		},
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
@@ -9815,6 +10514,11 @@
 				"temp-dir": "^1.0.0",
 				"uuid": "^3.0.1"
 			}
+		},
+		"template-expression-compiler": {
+			"version": "0.1.10",
+			"resolved": "https://registry.npmjs.org/template-expression-compiler/-/template-expression-compiler-0.1.10.tgz",
+			"integrity": "sha1-ul3/IG8fmzEpaZDdxLwzlBKCqqM="
 		},
 		"term-size": {
 			"version": "1.2.0",
@@ -10300,6 +11004,11 @@
 				"foreachasync": "^3.0.0"
 			}
 		},
+		"when": {
+			"version": "3.7.8",
+			"resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
+			"integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I="
+		},
 		"which": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -10320,6 +11029,11 @@
 			"requires": {
 				"string-width": "^2.1.1"
 			}
+		},
+		"wikimedia-page-library": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wikimedia-page-library/-/wikimedia-page-library-6.2.0.tgz",
+			"integrity": "sha512-MVYB57AZSY1czLpw9asn4P6HdW3DxrysR1peQufmw8ZKNl9c1Z4u2FTrzVKZajshyjCVPetcjrnEK9v8zjEcqA=="
 		},
 		"win-release": {
 			"version": "1.1.1",
@@ -10444,6 +11158,11 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
 			"integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
+		},
+		"xtend": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
 		},
 		"y18n": {
 			"version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
 		"parsoid": "^0.10.0",
 		"puppeteer": "^1.11.0",
 		"redis": "^2.6.2",
+		"service-mobileapp-node": "git+https://github.com/wikimedia/mediawiki-services-mobileapps.git#d244439",
+		"service-runner": "^2.6.8",
 		"snyk": "^1.96.0",
 		"swig-templates": "^2.0.2",
 		"tslint": "^5.11.0",

--- a/simple-test.sh
+++ b/simple-test.sh
@@ -2,6 +2,6 @@
 cp ./articleList ../articleList
 
 
-./bin/mwoffliner.script.js --mwUrl=https://en.wikipedia.org --adminEmail=admin@kiwix.com --localParsoid --redis=redis://127.0.0.1:6379 --format=nozim --articleList=../articleList
+./bin/mwoffliner.script.js --mwUrl=https://en.wikipedia.org --adminEmail=admin@kiwix.com --localMcs --redis=redis://127.0.0.1:6379 --format=nozim --articleList=../articleList
 
 ./node_modules/.bin/percy exec -- ./node_modules/.bin/mocha --exit

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -13,6 +13,7 @@ class MediaWiki {
   public base: string;
   public wikiPath: string;
   public apiPath: string;
+  public modulePath: string;
   public domain: string;
   public username: string;
   public password: string;
@@ -29,19 +30,21 @@ class MediaWiki {
   };
   public namespacesToMirror: string[];
 
-  constructor(logger: Logger, config: { base: any; wikiPath: any; apiPath: any; domain: any; username: any; password: any; spaceDelimiter: string; }) {
+  constructor(logger: Logger, config: { base: any; wikiPath: any; apiPath: any; domain: any; username: any; password: any; spaceDelimiter: string; modulePath: string; }) {
     this.logger = logger;
     // Normalize args
     this.base = `${config.base.replace(/\/$/, '')}/`;
-    this.wikiPath = config.wikiPath !== undefined && config.wikiPath !== true ? config.wikiPath : 'wiki';
-    this.apiPath = config.apiPath || 'w/api.php';
+    this.wikiPath = config.wikiPath !== undefined && config.wikiPath !== true ? config.wikiPath : 'wiki/';
+    this.apiPath = config.apiPath === undefined ? 'w/api.php' : config.apiPath;
+    this.modulePath = config.modulePath === undefined ? 'w/load.php' : config.modulePath;
     this.domain = config.domain || '';
     this.username = config.username;
     this.password = config.password;
     this.spaceDelimiter = config.spaceDelimiter;
     // Computed properties
-    this.webUrl = `${this.base + this.wikiPath}/`;
+    this.webUrl = `${this.base + this.wikiPath}`;
     this.apiUrl = `${this.base + this.apiPath}?`;
+    this.modulePath = `${this.base + this.modulePath}?`;
     this.webUrlPath = urlParser.parse(this.webUrl).pathname;
     // State
     this.namespaces = {};

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -35,13 +35,14 @@ const parameterList = [
   { name: 'keepHtml', description: 'If ZIM built, keep the temporary HTML directory', required: false },
   { name: 'mwWikiPath', description: 'Mediawiki wiki base path (per default "/wiki/")', required: false },
   { name: 'mwApiPath', description: 'Mediawiki API path (per default "/w/api.php")', required: false },
+  { name: 'mwModulePath', description: 'Mediawiki module load path (per default "/w/load.php")', required: false },
   { name: 'mwDomain', description: 'Mediawiki user domain (thought for private wikis)', required: false },
   { name: 'mwUsername', description: 'Mediawiki username (thought for private wikis)', required: false },
   { name: 'mwPassword', description: 'Mediawiki user password (thought for private wikis)', required: false },
   { name: 'minifyHtml', description: 'Try to reduce the size of the HTML', required: false },
   { name: 'outputDirectory', description: 'Directory to write the downloaded content', required: false },
-  { name: 'parsoidUrl', description: 'Mediawiki Parsoid URL', required: false },
   { name: 'publisher', description: `ZIM publisher meta data, per default 'Kiwix'`, required: false },
+  { name: 'mcsUrl', description: 'Mediawiki MCS URL', required: false },
   {
     name: 'redis',
     description: 'Redis configuration (https://github.com/NodeRedis/node_redis#rediscreateclient)',
@@ -64,7 +65,7 @@ const parameterList = [
   { name: 'verbose', description: 'Print debug information to the stdout', required: false },
   { name: 'withZimFullTextIndex', description: 'Include a fulltext search index to the ZIM', required: false },
   { name: 'writeHtmlRedirects', description: 'Write redirect as HTML files', required: false },
-  { name: 'localParsoid', description: 'Create a local parsoid instance default value is false', required: false },
+  { name: 'localMcs', description: 'Create a local MCS and Parsoid instance default value is false', required: false },
   { name: 'addNamespaces', description: 'Force addional namespace (comma separated numbers)', required: false },
 ];
 


### PR DESCRIPTION
Integrating MCS and start using service-runner.

Read about it here:
- https://github.com/wikimedia/mediawiki-services-mobileapps
- https://www.mediawiki.org/wiki/Wikimedia_Apps/Team/RESTBase_services_for_apps

I've removed the options `--localParsoid` and `--parsoidUrl` in favour of `--localMcs` and `--mcsUrl`.

When `--localMcs` is present, we start a local version of Parsoid (on which MCS is dependant) and MCS.

Closes #388 when used with `--mwModulePath=/load.php`
Closes #347