### PR TITLE
Added progressive backoff to redirect query urls

### DIFF
--- a/lib/MediaWiki.js
+++ b/lib/MediaWiki.js
@@ -117,20 +117,23 @@ var MediaWiki = /** @class */ (function () {
     MediaWiki.prototype.articleQueryUrl = function (title) {
         return this.apiUrl + "action=query&redirects&format=json&prop=revisions|coordinates&titles=" + encodeURIComponent(title);
     };
-    MediaWiki.prototype.backlinkRedirectsQueryUrls = function (articleIds, maxUrlLength) {
+    MediaWiki.prototype.backlinkRedirectsQueryUrls = function (articleIds, maxArticlesPerUrl, maxUrlLength) {
         var baseUrl = this.apiUrl + "action=query&prop=redirects&format=json&rdprop=title&rdlimit=max&rawcontinue=&titles=";
-        var redirectUrls = articleIds.reduce(function (urls, articleId) {
+        var redirectUrls = articleIds.reduce(function (_a, articleId) {
+            var urls = _a.urls, activeUrlArticleCount = _a.activeUrlArticleCount;
             var encodedArticleId = encodeURIComponent(articleId);
             var url = urls[urls.length - 1];
-            if (!urls.length || url.length + encodedArticleId.length > maxUrlLength) {
+            if (!urls.length || url.length + encodedArticleId.length > maxUrlLength || activeUrlArticleCount >= maxArticlesPerUrl) {
                 urls.push(baseUrl + encodedArticleId);
+                activeUrlArticleCount = 1;
             }
             else {
                 urls[urls.length - 1] += '|' + encodedArticleId;
+                activeUrlArticleCount += 1;
             }
-            return urls;
-        }, []);
-        return redirectUrls;
+            return { urls: urls, activeUrlArticleCount: activeUrlArticleCount };
+        }, { urls: [], activeUrlArticleCount: 0 });
+        return redirectUrls.urls;
     };
     MediaWiki.prototype.pageGeneratorQueryUrl = function (namespace, init) {
         return this.apiUrl + "action=query&generator=allpages&gapfilterredir=nonredirects&gaplimit=max&colimit=max&prop=revisions|coordinates&gapnamespace=" + this.namespaces[namespace].num + "&format=json&rawcontinue=" + init;

--- a/lib/mwoffliner.lib.js
+++ b/lib/mwoffliner.lib.js
@@ -2106,7 +2106,7 @@ function execute(argv) {
                                 case 3:
                                     err_5 = _e.sent();
                                     logger.warn("Failed to get redirects for ids: [" + articleIds.join('|') + "], retrying");
-                                    articlesPerQuery = (articlesPerQuery - articlesPerQuery / 5);
+                                    articlesPerQuery = Math.max(1, Math.round(articlesPerQuery - articlesPerQuery / 5));
                                     for (_d = 0, articleIds_1 = articleIds; _d < articleIds_1.length; _d++) {
                                         id = articleIds_1[_d];
                                         redirectQueue.push(id);

--- a/lib/mwoffliner.lib.js
+++ b/lib/mwoffliner.lib.js
@@ -2153,8 +2153,9 @@ function execute(argv) {
                     return [3 /*break*/, 14];
                 case 13:
                     err_2 = _a.sent();
-                    logger.error("Failed to download article list from [" + zim.articleList + "]", err_2);
-                    throw err_2;
+                    logger.error("Failed to download article list from [" + zim.articleList + "]");
+                    process.exit();
+                    return [3 /*break*/, 14];
                 case 14:
                     try {
                         articleListLines = zim.articleList ? fs_1.default.readFileSync(zim.articleList).toString().split('\n') : [];

--- a/lib/mwoffliner.lib.js
+++ b/lib/mwoffliner.lib.js
@@ -1778,7 +1778,7 @@ function execute(argv) {
                 return createMainPage();
             }
         }
-        var _speed, adminEmail, localMcs, customZimFavicon, verbose, minifyHtml, skipCacheCleaning, keepEmptyParagraphs, mwUrl, mwWikiPath, mwApiPath, mwModulePath, mwDomain, mwUsername, mwPassword, requestTimeout, publisher, customMainPage, customZimTitle, customZimDescription, customZimTags, cacheDirectory, outputDirectory, tmpDirectory, withZimFullTextIndex, format, filenamePrefix, keepHtml, resume, deflateTmpHtml, writeHtmlRedirects, _addNamespaces, _articleList, useCache, mcsUrl, articleList, cpuCount, speed, logger, runner, nodeVersionSatisfiesPackage, mw, downloader, creator, zimOpts, zim, env, INFINITY_WIDTH, articleDetailXId, webUrlHost, addNamespaces, dumpId, dumpTmpDir, err_1, domain, redis, dirs, cssLinks, jsScripts, redirectTemplate, footerTemplate, leadSectionTemplate, sectionTemplate, subSectionTemplate, genericJsModules, genericCssModules, mediaRegex, htmlTemplateCode, articleListHomeTemplate, optimizationQueue, downloadFileQueue, redirectQueue, fileName, tmpArticleListPath, articleListContentStream_1, articleListWriteStream_1, err_2, articleListLines, strings;
+        var _speed, adminEmail, localMcs, customZimFavicon, verbose, minifyHtml, skipCacheCleaning, keepEmptyParagraphs, mwUrl, mwWikiPath, mwApiPath, mwModulePath, mwDomain, mwUsername, mwPassword, requestTimeout, publisher, customMainPage, customZimTitle, customZimDescription, customZimTags, cacheDirectory, outputDirectory, tmpDirectory, withZimFullTextIndex, format, filenamePrefix, keepHtml, resume, deflateTmpHtml, writeHtmlRedirects, _addNamespaces, _articleList, useCache, mcsUrl, articleList, cpuCount, speed, logger, runner, nodeVersionSatisfiesPackage, mw, downloader, creator, zimOpts, zim, env, INFINITY_WIDTH, articleDetailXId, webUrlHost, addNamespaces, dumpId, dumpTmpDir, err_1, domain, redis, dirs, cssLinks, jsScripts, redirectTemplate, footerTemplate, leadSectionTemplate, sectionTemplate, subSectionTemplate, genericJsModules, genericCssModules, mediaRegex, htmlTemplateCode, articleListHomeTemplate, optimizationQueue, downloadFileQueue, articlesPerQuery, redirectQueue, fileName, tmpArticleListPath, articleListContentStream_1, articleListWriteStream_1, err_2, articleListLines, strings;
         var _this = this;
         return __generator(this, function (_a) {
             switch (_a.label) {
@@ -2048,13 +2048,14 @@ function execute(argv) {
                     downloadFileQueue = async_1.default.queue(function (url, finished) {
                         downloadFileAndCache(url, finished);
                     }, speed * 5);
+                    articlesPerQuery = 500;
                     redirectQueue = async_1.default.cargo(function (articleIds, finished) { return __awaiter(_this, void 0, void 0, function () {
                         var urls, redirects, redirectsCount, _a, pages, normalized, fromXTo, pageIds, _i, pageIds_1, pageId, _b, _redirects, title, originalArticleId, _c, _redirects_1, redirect, title_2, err_5, _d, articleIds_1, id;
                         return __generator(this, function (_e) {
                             switch (_e.label) {
                                 case 0:
                                     if (!(articleIds && articleIds.length)) return [3 /*break*/, 5];
-                                    urls = mw.backlinkRedirectsQueryUrls(articleIds, 7000);
+                                    urls = mw.backlinkRedirectsQueryUrls(articleIds, articlesPerQuery, 7000);
                                     logger.info("Got [" + urls.length + "] redirect urls for [" + articleIds.length + "] articles");
                                     _e.label = 1;
                                 case 1:
@@ -2105,6 +2106,7 @@ function execute(argv) {
                                 case 3:
                                     err_5 = _e.sent();
                                     logger.warn("Failed to get redirects for ids: [" + articleIds.join('|') + "], retrying");
+                                    articlesPerQuery = (articlesPerQuery - articlesPerQuery / 5);
                                     for (_d = 0, articleIds_1 = articleIds; _d < articleIds_1.length; _d++) {
                                         id = articleIds_1[_d];
                                         redirectQueue.push(id);

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -89,19 +89,21 @@ class MediaWiki {
     return `${this.apiUrl}action=query&redirects&format=json&prop=revisions|coordinates&titles=${encodeURIComponent(title)}`;
   }
 
-  public backlinkRedirectsQueryUrls(articleIds: string[], maxUrlLength: number): string[] {
+  public backlinkRedirectsQueryUrls(articleIds: string[], maxArticlesPerUrl: number, maxUrlLength: number): string[] {
     const baseUrl = `${this.apiUrl}action=query&prop=redirects&format=json&rdprop=title&rdlimit=max&rawcontinue=&titles=`;
-    const redirectUrls = articleIds.reduce((urls, articleId) => {
+    const redirectUrls = articleIds.reduce(({ urls, activeUrlArticleCount }, articleId) => {
       const encodedArticleId = encodeURIComponent(articleId);
       const url = urls[urls.length - 1];
-      if (!urls.length || url.length + encodedArticleId.length > maxUrlLength) {
+      if (!urls.length || url.length + encodedArticleId.length > maxUrlLength || activeUrlArticleCount >= maxArticlesPerUrl) {
         urls.push(baseUrl + encodedArticleId);
+        activeUrlArticleCount = 1;
       } else {
         urls[urls.length - 1] += '|' + encodedArticleId;
+        activeUrlArticleCount += 1;
       }
-      return urls;
-    }, []);
-    return redirectUrls;
+      return { urls, activeUrlArticleCount };
+    }, { urls: [], activeUrlArticleCount: 0 });
+    return redirectUrls.urls;
   }
 
   public pageGeneratorQueryUrl(namespace: string, init: string) {

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -431,9 +431,10 @@ async function execute(argv) {
   }, speed * 5);
 
   /* Get ids */
+  let articlesPerQuery = 500;
   const redirectQueue = async.cargo(async (articleIds, finished) => {
     if (articleIds && articleIds.length) {
-      const urls = mw.backlinkRedirectsQueryUrls(articleIds, 7000);
+      const urls = mw.backlinkRedirectsQueryUrls(articleIds, articlesPerQuery, 7000);
       logger.info(`Got [${urls.length}] redirect urls for [${articleIds.length}] articles`);
       try {
         const redirects = {};
@@ -484,6 +485,7 @@ async function execute(argv) {
         redis.saveRedirects(redirectsCount, redirects, finished);
       } catch (err) {
         logger.warn(`Failed to get redirects for ids: [${articleIds.join('|')}], retrying`);
+        articlesPerQuery = (articlesPerQuery - articlesPerQuery / 5);
         for (const id of articleIds) {
           redirectQueue.push(id);
         }

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -485,7 +485,7 @@ async function execute(argv) {
         redis.saveRedirects(redirectsCount, redirects, finished);
       } catch (err) {
         logger.warn(`Failed to get redirects for ids: [${articleIds.join('|')}], retrying`);
-        articlesPerQuery = (articlesPerQuery - articlesPerQuery / 5);
+        articlesPerQuery = Math.max(1, Math.round(articlesPerQuery - articlesPerQuery / 5));
         for (const id of articleIds) {
           redirectQueue.push(id);
         }

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -517,8 +517,8 @@ async function execute(argv) {
       });
       zim.articleList = tmpArticleListPath;
     } catch (err) {
-      logger.error(`Failed to download article list from [${zim.articleList}]`, err);
-      throw err;
+      logger.error(`Failed to download article list from [${zim.articleList}]`);
+      process.exit();
     }
   }
 


### PR DESCRIPTION
Some Wikipedia sites seem to have different limitations on the number of redirect article ids we can request per query, even though the API documentation doesn't say it.

This is a worst case really which will slowly back off the size of requests if a query fails. The minimum value to go down to is one.