### PR TITLE
Implemented a fallback to simple desktop page when mobile site is inaccessible

### DIFF
--- a/lib/mwoffliner.lib.js
+++ b/lib/mwoffliner.lib.js
@@ -424,8 +424,8 @@ function execute(argv) {
                             moduleUri = path_1.default.resolve(env.htmlRootPath, cssPath(module));
                             apiParameterOnly = 'styles';
                         }
-                        logger.info("Getting [" + type + "] module [" + module + "]");
-                        var moduleApiUrl = encodeURI(mw.modulePath + "debug=false&lang=en&modules=" + module + "&only=" + apiParameterOnly + "&skin=vector&version=&*");
+                        var moduleApiUrl = encodeURI(mw.modulePath + "?debug=false&lang=en&modules=" + module + "&only=" + apiParameterOnly + "&skin=vector&version=&*");
+                        logger.info("Getting [" + type + "] module [" + moduleApiUrl + "]");
                         return redis.saveModuleIfNotExists(dump, module, moduleUri, type)
                             .then(function (redisResult) {
                             if (redisResult === 1) {
@@ -1034,9 +1034,11 @@ function execute(argv) {
                         fs_1.default.writeFile(env.getArticlePath(articleId), html, finished);
                     }
                 }
-                function saveArticle(articleId, finished) {
-                    var html = '';
-                    var articleApiUrl = "" + mcsUrl + encodeURIComponent(articleId);
+                function saveArticle(articleId, finished, usingParsoidFallback) {
+                    if (usingParsoidFallback === void 0) { usingParsoidFallback = false; }
+                    var articleApiUrl = usingParsoidFallback
+                        ? "" + parsoidFallbackUrl + encodeURIComponent(articleId)
+                        : "" + mcsUrl + encodeURIComponent(articleId);
                     logger.log("Getting (mobile) article from " + articleApiUrl);
                     node_fetch_1.default(articleApiUrl, {
                         method: 'GET',
@@ -1044,59 +1046,69 @@ function execute(argv) {
                     })
                         .then(function (response) { return response.json(); })
                         .then(function (json) {
-                        // set the first section (open by default)
-                        html += leadSectionTemplate({
-                            lead_display_title: json.lead.displaytitle,
-                            lead_section_text: json.lead.sections[0].text,
-                            strings: strings,
-                        });
-                        // set all other section (closed by default)
-                        if (!env.nodet) {
-                            json.remaining.sections.forEach(function (oneSection, i) {
-                                if (i === 0 && oneSection.toclevel !== 1) { // We need at least one Top Level Section
-                                    html += sectionTemplate({
-                                        section_index: i,
-                                        section_id: i,
-                                        section_anchor: 'TopLevelSection',
-                                        section_line: 'Disambiguation',
-                                        section_text: '',
-                                        strings: strings,
-                                    });
-                                }
-                                // if below is to test if we need to nest a subsections into a section
-                                if (oneSection.toclevel === 1) {
-                                    html = html.replace("__SUB_LEVEL_SECTION_" + (oneSection.id - 1) + "__", ''); // remove unused anchor for subsection
-                                    html += sectionTemplate({
-                                        section_index: i + 1,
-                                        section_id: oneSection.id,
-                                        section_anchor: oneSection.anchor,
-                                        section_line: oneSection.line,
-                                        section_text: oneSection.text,
-                                        strings: strings,
-                                    });
-                                }
-                                else {
-                                    var replacement = subSectionTemplate({
-                                        section_index: i + 1,
-                                        section_toclevel: oneSection.toclevel + 1,
-                                        section_id: oneSection.id,
-                                        section_anchor: oneSection.anchor,
-                                        section_line: oneSection.line,
-                                        section_text: oneSection.text,
-                                        strings: strings,
-                                    });
-                                    html = html.replace("__SUB_LEVEL_SECTION_" + (oneSection.id - 1) + "__", replacement);
-                                }
-                            });
+                        var html = '';
+                        if (usingParsoidFallback) {
+                            if (json && json.visualeditor) {
+                                html = json.visualeditor.content;
+                            }
+                            else if (json && (json.contentmodel === 'wikitext' || (json.html && json.html.body))) {
+                                html = json.html.body;
+                            }
+                            else if (json && json.error) {
+                                console.error("Error by retrieving article: " + json.error.info);
+                            }
                         }
-                        html = html.replace("__SUB_LEVEL_SECTION_" + json.remaining.sections.length + "__", ''); // remove the last subcestion anchor (all other anchor are removed in the forEach)
-                        buildArticleFromApiData();
+                        else {
+                            // set the first section (open by default)
+                            html += leadSectionTemplate({
+                                lead_display_title: json.lead.displaytitle,
+                                lead_section_text: json.lead.sections[0].text,
+                                strings: strings,
+                            });
+                            // set all other section (closed by default)
+                            if (!env.nodet) {
+                                json.remaining.sections.forEach(function (oneSection, i) {
+                                    if (i === 0 && oneSection.toclevel !== 1) { // We need at least one Top Level Section
+                                        html += sectionTemplate({
+                                            section_index: i,
+                                            section_id: i,
+                                            section_anchor: 'TopLevelSection',
+                                            section_line: 'Disambiguation',
+                                            section_text: '',
+                                            strings: strings,
+                                        });
+                                    }
+                                    // if below is to test if we need to nest a subsections into a section
+                                    if (oneSection.toclevel === 1) {
+                                        html = html.replace("__SUB_LEVEL_SECTION_" + (oneSection.id - 1) + "__", ''); // remove unused anchor for subsection
+                                        html += sectionTemplate({
+                                            section_index: i + 1,
+                                            section_id: oneSection.id,
+                                            section_anchor: oneSection.anchor,
+                                            section_line: oneSection.line,
+                                            section_text: oneSection.text,
+                                            strings: strings,
+                                        });
+                                    }
+                                    else {
+                                        var replacement = subSectionTemplate({
+                                            section_index: i + 1,
+                                            section_toclevel: oneSection.toclevel + 1,
+                                            section_id: oneSection.id,
+                                            section_anchor: oneSection.anchor,
+                                            section_line: oneSection.line,
+                                            section_text: oneSection.text,
+                                            strings: strings,
+                                        });
+                                        html = html.replace("__SUB_LEVEL_SECTION_" + (oneSection.id - 1) + "__", replacement);
+                                    }
+                                });
+                            }
+                            html = html.replace("__SUB_LEVEL_SECTION_" + json.remaining.sections.length + "__", ''); // remove the last subcestion anchor (all other anchor are removed in the forEach)
+                        }
+                        return html;
                     })
-                        .catch(function (e) {
-                        logger.error("Error handling json response from api. " + e);
-                        buildArticleFromApiData();
-                    });
-                    function buildArticleFromApiData() {
+                        .then(function (html) {
                         if (html) {
                             var articlePath = env.getArticlePath(articleId);
                             var prepareAndSaveArticle = async_1.default.compose(writeArticle, setFooter, applyOtherTreatments, rewriteUrls, treatMedias, storeDependencies, parseHtml);
@@ -1113,10 +1125,20 @@ function execute(argv) {
                             });
                         }
                         else {
+                            throw new Error("No HTML was found");
+                        }
+                    })
+                        .catch(function (e) {
+                        logger.error("Error handling json response from api. " + e);
+                        if (!usingParsoidFallback) {
+                            saveArticle(articleId, finished, true);
+                            logger.log("Failed to get mobile article [" + articleId + "], retrying with ParsoidFallback");
+                        }
+                        else {
                             delete articleDetailXId[articleId];
                             finished();
                         }
-                    }
+                    });
                 }
                 logger.log('Saving articles...');
                 async_1.default.eachLimit(Object.keys(articleDetailXId), speed, saveArticle, function (error) {
@@ -1778,7 +1800,7 @@ function execute(argv) {
                 return createMainPage();
             }
         }
-        var _speed, adminEmail, localMcs, customZimFavicon, verbose, minifyHtml, skipCacheCleaning, keepEmptyParagraphs, mwUrl, mwWikiPath, mwApiPath, mwModulePath, mwDomain, mwUsername, mwPassword, requestTimeout, publisher, customMainPage, customZimTitle, customZimDescription, customZimTags, cacheDirectory, outputDirectory, tmpDirectory, withZimFullTextIndex, format, filenamePrefix, keepHtml, resume, deflateTmpHtml, writeHtmlRedirects, _addNamespaces, _articleList, useCache, mcsUrl, articleList, cpuCount, speed, logger, runner, nodeVersionSatisfiesPackage, mw, downloader, creator, zimOpts, zim, env, INFINITY_WIDTH, articleDetailXId, webUrlHost, addNamespaces, dumpId, dumpTmpDir, err_1, domain, redis, dirs, cssLinks, jsScripts, redirectTemplate, footerTemplate, leadSectionTemplate, sectionTemplate, subSectionTemplate, genericJsModules, genericCssModules, mediaRegex, htmlTemplateCode, articleListHomeTemplate, optimizationQueue, downloadFileQueue, articlesPerQuery, redirectQueue, fileName, tmpArticleListPath, articleListContentStream_1, articleListWriteStream_1, err_2, articleListLines, strings;
+        var _speed, adminEmail, localMcs, customZimFavicon, verbose, minifyHtml, skipCacheCleaning, keepEmptyParagraphs, mwUrl, mwWikiPath, mwApiPath, mwModulePath, mwDomain, mwUsername, mwPassword, requestTimeout, publisher, customMainPage, customZimTitle, customZimDescription, customZimTags, cacheDirectory, outputDirectory, tmpDirectory, withZimFullTextIndex, format, filenamePrefix, keepHtml, resume, deflateTmpHtml, writeHtmlRedirects, _addNamespaces, _articleList, useCache, mcsUrl, articleList, cpuCount, speed, logger, runner, nodeVersionSatisfiesPackage, mw, downloader, creator, zimOpts, zim, env, INFINITY_WIDTH, articleDetailXId, webUrlHost, addNamespaces, dumpId, dumpTmpDir, err_1, parsoidFallbackUrl, domain, redis, dirs, cssLinks, jsScripts, redirectTemplate, footerTemplate, leadSectionTemplate, sectionTemplate, subSectionTemplate, genericJsModules, genericCssModules, mediaRegex, htmlTemplateCode, articleListHomeTemplate, optimizationQueue, downloadFileQueue, articlesPerQuery, redirectQueue, fileName, tmpArticleListPath, articleListContentStream_1, articleListWriteStream_1, err_2, articleListLines, strings;
         var _this = this;
         return __generator(this, function (_a) {
             switch (_a.label) {
@@ -1929,9 +1951,11 @@ function execute(argv) {
                     _a.sent();
                     domain = (new url_1.URL(mw.base)).host;
                     mcsUrl = "http://localhost:6927/" + domain + "/v1/page/mobile-sections/";
+                    parsoidFallbackUrl = "http://localhost:8000/" + webUrlHost + "/v3/page/pagebundle/";
                     return [3 /*break*/, 7];
                 case 6:
                     mcsUrl = mw.base + "api/rest_v1/page/mobile-sections/";
+                    parsoidFallbackUrl = mw.apiUrl + "action=visualeditor&format=json&paction=parse&page=";
                     _a.label = 7;
                 case 7: 
                 /* ********************************* */
@@ -2100,7 +2124,7 @@ function execute(argv) {
                                             }
                                         }
                                     }
-                                    logger.log(redirectsCount + " redirect(s) found for ids: " + articleIds.join('|'));
+                                    logger.log(redirectsCount + " redirect(s) found");
                                     redis.saveRedirects(redirectsCount, redirects, finished);
                                     return [3 /*break*/, 4];
                                 case 3:

--- a/lib/mwoffliner.lib.js
+++ b/lib/mwoffliner.lib.js
@@ -1036,6 +1036,9 @@ function execute(argv) {
                 }
                 function saveArticle(articleId, finished, usingParsoidFallback) {
                     if (usingParsoidFallback === void 0) { usingParsoidFallback = false; }
+                    if (articleId === zim.mainPageId) {
+                        usingParsoidFallback = true;
+                    }
                     var articleApiUrl = usingParsoidFallback
                         ? "" + parsoidFallbackUrl + encodeURIComponent(articleId)
                         : "" + mcsUrl + encodeURIComponent(articleId);

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -221,6 +221,8 @@ async function execute(argv) {
     rimraf.sync(dumpTmpDir);
   });
 
+  let parsoidFallbackUrl: string;
+
   if (localMcs) {
     // Start Parsoid
     logger.log('Starting Parsoid & MCS');
@@ -264,8 +266,10 @@ async function execute(argv) {
     });
     const domain = (new URL(mw.base)).host;
     mcsUrl = `http://localhost:6927/${domain}/v1/page/mobile-sections/`;
+    parsoidFallbackUrl = `http://localhost:8000/${webUrlHost}/v3/page/pagebundle/`;
   } else {
     mcsUrl = `${mw.base}api/rest_v1/page/mobile-sections/`;
+    parsoidFallbackUrl = `${mw.apiUrl}action=visualeditor&format=json&paction=parse&page=`;
   }
 
   /* ********************************* */
@@ -481,7 +485,7 @@ async function execute(argv) {
           }
         }
 
-        logger.log(`${redirectsCount} redirect(s) found for ids: ${articleIds.join('|')}`);
+        logger.log(`${redirectsCount} redirect(s) found`);
         redis.saveRedirects(redirectsCount, redirects, finished);
       } catch (err) {
         logger.warn(`Failed to get redirects for ids: [${articleIds.join('|')}], retrying`);
@@ -894,10 +898,10 @@ async function execute(argv) {
             apiParameterOnly = 'styles';
           }
 
-          logger.info(`Getting [${type}] module [${module}]`);
           const moduleApiUrl = encodeURI(
-            `${mw.modulePath}debug=false&lang=en&modules=${module}&only=${apiParameterOnly}&skin=vector&version=&*`,
+            `${mw.modulePath}?debug=false&lang=en&modules=${module}&only=${apiParameterOnly}&skin=vector&version=&*`,
           );
+          logger.info(`Getting [${type}] module [${moduleApiUrl}]`);
           return redis.saveModuleIfNotExists(dump, module, moduleUri, type)
             .then((redisResult) => {
               if (redisResult === 1) {
@@ -1568,9 +1572,10 @@ async function execute(argv) {
         }
       }
 
-      function saveArticle(articleId, finished) {
-        let html = '';
-        const articleApiUrl = `${mcsUrl}${encodeURIComponent(articleId)}`;
+      function saveArticle(articleId, finished, usingParsoidFallback = false) {
+        const articleApiUrl = usingParsoidFallback
+          ? `${parsoidFallbackUrl}${encodeURIComponent(articleId)}`
+          : `${mcsUrl}${encodeURIComponent(articleId)}`;
         logger.log(`Getting (mobile) article from ${articleApiUrl}`);
         fetch(articleApiUrl, {
           method: 'GET',
@@ -1578,89 +1583,104 @@ async function execute(argv) {
         })
           .then((response) => response.json())
           .then((json) => {
-            // set the first section (open by default)
-            html += leadSectionTemplate({
-              lead_display_title: json.lead.displaytitle,
-              lead_section_text: json.lead.sections[0].text,
-              strings,
-            });
-
-            // set all other section (closed by default)
-            if (!env.nodet) {
-              json.remaining.sections.forEach((oneSection, i) => {
-                if (i === 0 && oneSection.toclevel !== 1) { // We need at least one Top Level Section
-                  html += sectionTemplate({
-                    section_index: i,
-                    section_id: i,
-                    section_anchor: 'TopLevelSection',
-                    section_line: 'Disambiguation',
-                    section_text: '',
-                    strings,
-                  });
-                }
-
-                // if below is to test if we need to nest a subsections into a section
-                if (oneSection.toclevel === 1) {
-                  html = html.replace(`__SUB_LEVEL_SECTION_${oneSection.id - 1}__`, ''); // remove unused anchor for subsection
-                  html += sectionTemplate({
-                    section_index: i + 1,
-                    section_id: oneSection.id,
-                    section_anchor: oneSection.anchor,
-                    section_line: oneSection.line,
-                    section_text: oneSection.text,
-                    strings,
-                  });
-                } else {
-                  const replacement = subSectionTemplate({
-                    section_index: i + 1,
-                    section_toclevel: oneSection.toclevel + 1,
-                    section_id: oneSection.id,
-                    section_anchor: oneSection.anchor,
-                    section_line: oneSection.line,
-                    section_text: oneSection.text,
-                    strings,
-                  });
-                  html = html.replace(`__SUB_LEVEL_SECTION_${oneSection.id - 1}__`, replacement);
-                }
+            let html = '';
+            if (usingParsoidFallback) {
+              if (json && json.visualeditor) {
+                html = json.visualeditor.content;
+              } else if (json && (json.contentmodel === 'wikitext' || (json.html && json.html.body))) {
+                html = json.html.body;
+              } else if (json && json.error) {
+                console.error(`Error by retrieving article: ${json.error.info}`);
+              }
+            } else {
+              // set the first section (open by default)
+              html += leadSectionTemplate({
+                lead_display_title: json.lead.displaytitle,
+                lead_section_text: json.lead.sections[0].text,
+                strings,
               });
+
+              // set all other section (closed by default)
+              if (!env.nodet) {
+                json.remaining.sections.forEach((oneSection, i) => {
+                  if (i === 0 && oneSection.toclevel !== 1) { // We need at least one Top Level Section
+                    html += sectionTemplate({
+                      section_index: i,
+                      section_id: i,
+                      section_anchor: 'TopLevelSection',
+                      section_line: 'Disambiguation',
+                      section_text: '',
+                      strings,
+                    });
+                  }
+
+                  // if below is to test if we need to nest a subsections into a section
+                  if (oneSection.toclevel === 1) {
+                    html = html.replace(`__SUB_LEVEL_SECTION_${oneSection.id - 1}__`, ''); // remove unused anchor for subsection
+                    html += sectionTemplate({
+                      section_index: i + 1,
+                      section_id: oneSection.id,
+                      section_anchor: oneSection.anchor,
+                      section_line: oneSection.line,
+                      section_text: oneSection.text,
+                      strings,
+                    });
+                  } else {
+                    const replacement = subSectionTemplate({
+                      section_index: i + 1,
+                      section_toclevel: oneSection.toclevel + 1,
+                      section_id: oneSection.id,
+                      section_anchor: oneSection.anchor,
+                      section_line: oneSection.line,
+                      section_text: oneSection.text,
+                      strings,
+                    });
+                    html = html.replace(`__SUB_LEVEL_SECTION_${oneSection.id - 1}__`, replacement);
+                  }
+                });
+              }
+              html = html.replace(`__SUB_LEVEL_SECTION_${json.remaining.sections.length}__`, ''); // remove the last subcestion anchor (all other anchor are removed in the forEach)
             }
 
-            html = html.replace(`__SUB_LEVEL_SECTION_${json.remaining.sections.length}__`, ''); // remove the last subcestion anchor (all other anchor are removed in the forEach)
-            buildArticleFromApiData();
+            return html;
+          })
+          .then((html) => {
+            if (html) {
+              const articlePath = env.getArticlePath(articleId);
+              const prepareAndSaveArticle = async.compose(
+                writeArticle,
+                setFooter,
+                applyOtherTreatments,
+                rewriteUrls,
+                treatMedias,
+                storeDependencies,
+                parseHtml,
+              );
+
+              logger.info(`Treating and saving article ${articleId} at ${articlePath}...`);
+              prepareAndSaveArticle(html, articleId, (error) => {
+                if (!error) {
+                  logger.info(`Successfully dumped article ${articleId}`);
+                  finished();
+                } else {
+                  logger.warn(`Error preparing and saving file, skipping [${articleId}]`, error);
+                  finished(error);
+                }
+              });
+            } else {
+              throw new Error(`No HTML was found`);
+            }
           })
           .catch((e) => {
             logger.error(`Error handling json response from api. ${e}`);
-            buildArticleFromApiData();
+            if (!usingParsoidFallback) {
+              saveArticle(articleId, finished, true);
+              logger.log(`Failed to get mobile article [${articleId}], retrying with ParsoidFallback`);
+            } else {
+              delete articleDetailXId[articleId];
+              finished();
+            }
           });
-
-        function buildArticleFromApiData() {
-          if (html) {
-            const articlePath = env.getArticlePath(articleId);
-            const prepareAndSaveArticle = async.compose(
-              writeArticle,
-              setFooter,
-              applyOtherTreatments,
-              rewriteUrls,
-              treatMedias,
-              storeDependencies,
-              parseHtml,
-            );
-
-            logger.info(`Treating and saving article ${articleId} at ${articlePath}...`);
-            prepareAndSaveArticle(html, articleId, (error) => {
-              if (!error) {
-                logger.info(`Successfully dumped article ${articleId}`);
-                finished();
-              } else {
-                logger.warn(`Error preparing and saving file, skipping [${articleId}]`, error);
-                finished(error);
-              }
-            });
-          } else {
-            delete articleDetailXId[articleId];
-            finished();
-          }
-        }
       }
 
       logger.log('Saving articles...');

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -1573,6 +1573,10 @@ async function execute(argv) {
       }
 
       function saveArticle(articleId, finished, usingParsoidFallback = false) {
+        if (articleId === zim.mainPageId) {
+          usingParsoidFallback = true;
+        }
+
         const articleApiUrl = usingParsoidFallback
           ? `${parsoidFallbackUrl}${encodeURIComponent(articleId)}`
           : `${mcsUrl}${encodeURIComponent(articleId)}`;


### PR DESCRIPTION
Closes #388 

It seems some Wikis we can scrape everything in mobile mode (via MCS), but others don't have compatible mobile main-pages. This tries the mobile query first, and if it's missing will use the desktop site instead.