### PR TITLE
Respect absolute paths for output and cache dirs

### DIFF
--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -92,9 +92,16 @@ async function execute(argv: any) {
   const publisher = _publisher || config.defaults.publisher;
   let customZimFavicon = _customZimFavicon;
 
-  const outputDirectory = path.join(process.cwd(), _outputDirectory ? `${homeDirExpander(_outputDirectory)}/` : 'out/');
+  const expandedOutputDirectory = homeDirExpander(_outputDirectory || 'out/');
+  const outputDirectory = path.isAbsolute(expandedOutputDirectory) ?
+                            expandedOutputDirectory :
+                            path.join(process.cwd(), expandedOutputDirectory);
   await mkdirPromise(outputDirectory);
-  const cacheDirectory = path.join(process.cwd(), _cacheDirectory ? `${homeDirExpander(_cacheDirectory)}/` : `cac/dumps-${Date.now()}/`);
+
+  const expandedCacheDirectory = homeDirExpander(_cacheDirectory || `cac/dumps-${Date.now()}/`);
+  const cacheDirectory = path.isAbsolute(expandedCacheDirectory) ?
+                           expandedCacheDirectory :
+                           path.join(process.cwd(), expandedCacheDirectory);
   await mkdirPromise(cacheDirectory);
   const tmpDirectory = os.tmpdir();
 


### PR DESCRIPTION
We use 'path.join' to expand the path for the output and cache
directories even when an absolute path was given. This results
in the absolute path being joined with the current directory. As
a consequence, a chain of folders as mentioned in the absolute
path are created relative to the current directory. This
makes no sense as absolute paths should be treated as it is.

Correct this by correctly identifying absolute paths and expanding
only relative paths with respect to the current directory.