### PR TITLE
:zap: remove un-necessary call to MediaWiki:offline.css (#614)

### DIFF
--- a/src/Dump.ts
+++ b/src/Dump.ts
@@ -157,10 +157,6 @@ export class Dump {
             }
         }
 
-        /* Push Mediawiki:Offline.css (at the end) */
-        const offlineCssUrl = `${this.mwMetaData.webUrl}Mediawiki:offline.css?action=raw`;
-        sheetUrls.push(offlineCssUrl);
-
         return sheetUrls.filter((a) => a);
     }
 


### PR DESCRIPTION
Closes #614