### PR TITLE
:sparkles: support WPRU desktop mainpage CSS

### DIFF
--- a/res/templates/page.html
+++ b/res/templates/page.html
@@ -18,7 +18,7 @@
     <div id="mw-mf-page-center">
       <div id="content" class="mw-body">
         <a id="top"></a>
-        <div id="bodyContent" class="content">
+        <div id="bodyContent" class="content mw-parser-output">
           <h1 id="titleHeading" style="background-color: white; margin: 0;"></h1>
           <div id="mw-content-text">
           </div>


### PR DESCRIPTION
The problem (#841) is caused by the use of inline CSS on the WPRU main page that specifies the class `mw-parser-output`.

This pull request fixes the issue, but I think in the wrong way. The better solution is for WPRU to not specify the `mw-parser-output` class in it's page, as this makes the content fragile.

This CSS change was made recently, hence when testing on 1.7.1, we get the same result

Closes #841