### PR TITLE
:bug: remove hard-coded pixel font-sizes for headings (#825)

### DIFF
--- a/res/style.css
+++ b/res/style.css
@@ -29,23 +29,14 @@
     font-family: 'Linux Libertine', 'Georgia', 'Times', serif;
 }
 
-.mw-body h1 {
-    font-size: 42px;
-}
-
-.mw-body h2 {
-    font-size: 24px;
-}
 
 .mw-body h3 {
     border-bottom: 0px solid #eaecf0;
-    font-size: 19px;
     font-weight: bold;
 }
 
 .mw-body h4 {
     border-bottom: 0px solid #eaecf0;
-    font-size: 16px;
 }
 
 h1[tabindex="0"].collapsible-heading>.indicator {

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -489,7 +489,7 @@ async function rewriteUrls(parsoidDoc: DominoElement, articleId: string, downloa
     return { doc: parsoidDoc, mediaDependencies };
 }
 
-function applyOtherTreatments(parsoidDoc: DominoElement, dump: Dump) {
+export function applyOtherTreatments(parsoidDoc: DominoElement, dump: Dump) {
     const filtersConfig = config.filters;
 
     /* Don't need <link> and <input> tags */
@@ -596,28 +596,10 @@ function applyOtherTreatments(parsoidDoc: DominoElement, dump: Dump) {
 
     /* Remove empty paragraphs */
     if (!dump.opts.keepEmptyParagraphs) {
-        for (let level = 5; level > 0; level--) {
-            const paragraphNodes: DominoElement[] = Array.from(parsoidDoc.getElementsByTagName(`h${level}`));
-            for (const paragraphNode of paragraphNodes) {
-                const nextElementNode = DU.nextElementSibling(paragraphNode);
-                const isSummary = paragraphNode.parentElement.nodeName === 'SUMMARY';
-                if (!isSummary) {
-                    /* No nodes */
-                    if (!nextElementNode) {
-                        DU.deleteNode(paragraphNode);
-                    } else {
-                        /* Delete if nextElementNode is a paragraph with <= level */
-                        const nextElementNodeTag = nextElementNode.tagName.toLowerCase();
-                        if (
-                            nextElementNodeTag.length > 1
-                            && nextElementNodeTag[0] === 'h'
-                            && !isNaN(nextElementNodeTag[1])
-                            && nextElementNodeTag[1] <= level
-                        ) {
-                            DU.deleteNode(paragraphNode);
-                        }
-                    }
-                }
+        const paragraphNodes: DominoElement[] = Array.from(parsoidDoc.querySelectorAll('p'));
+        for (const pNode of paragraphNodes) {
+            if (!pNode.textContent) {
+                DU.deleteNode(pNode);
             }
         }
     }

--- a/test/e2e/en10.e2e.test.ts
+++ b/test/e2e/en10.e2e.test.ts
@@ -10,7 +10,7 @@ require('dotenv').config();
 const now = new Date();
 const testId = `mwo-test-${+now}`;
 
-const articleListUrl = `https://download.kiwix.org/wp1/enwiki_${now.getUTCFullYear()}-${leftPad(now.getMonth(), 2)}/tops/10`;
+const articleListUrl = `https://download.kiwix.org/wp1/enwiki/tops/10`;
 
 const parameters = {
     mwUrl: `https://en.wikipedia.org`,


### PR DESCRIPTION
This PR removed the hard-coded values, and allows the browser default to be used.

@kelson42 Do you know a specific reason we should not override the heading font-sizes?

Closes #825 