### PR TITLE
Better explain --format command line argument

### DIFF
--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -11,8 +11,7 @@ export const parameterDescriptions = {
   customZimTags: 'Allow to configure custom ZIM file tags (semi-colon separated).',
   customMainPage: 'Allow to configure a custom page as welcome page.',
   filenamePrefix: 'For the part of the ZIM filename which is before the date part.',
-  format: 'Each --format=... will cause a new file to be created, acceptable options are: "nopic,novid,nopdf,nozim,nodet"\n\
-  e.g. "--format=nopic --format=novid,nopdf" will create two ZIM files',
+  format: 'Specify a flavour for the scraping. If missing, scrape all article contents. Each --format argument will cause a new local file to be created but options can be combined. Supported options are:\n * novid: no video & audio content\n * nopic: no pictures (implies "novid")\n * nopdf: no PDF files\n * nodet: only the first/head paragraph (implies "novid")\n * nozim: create a local HTML directory (instead of ZIM file)\nExample: "... --format=nopic --format=novid,nopdf"',
   keepEmptyParagraphs: 'Keep all paragraphs, even empty ones.',
   keepHtml: 'If ZIM built, keep the temporary HTML directory',
   mwWikiPath: 'Mediawiki wiki base path (per default "/wiki/")',


### PR DESCRIPTION
Fix #740 

Here is how it looks like:
```
  --format                   Specify a flavour for the scraping. If missing,
                             scrape all article contents. Each --format argument
                             will cause a new local file to be created but
                             options can be combined. Supported options are:
                             * novid: no video & audio content
                             * nopic: no pictures (implies "novid")
                             * nopdf: no PDF files
                             * nodet: only the first/head paragraph (implies
                             "novid")
                             * nozim: create a local HTML directory (instead of
                             ZIM file)
                             Example: "... --format=nopic --format=novid,nopdf"
 ```