### PR TITLE
:bug: :art: remove un-necessary CSS collapse code (#953)

### DIFF
--- a/res/style.css
+++ b/res/style.css
@@ -39,35 +39,10 @@
     border-bottom: 0px solid #eaecf0;
 }
 
-h1[tabindex="0"].collapsible-heading {
-    cursor: none;
-    /* Article title is not collapsible */
-}
-
-h1[tabindex="0"].collapsible-heading>.indicator {
-    display: none;
-    /* hide the "v" icone for the main title */
-}
-
-@media all and (min-width: 720px) {
-    .client-js .collapsible-heading .indicator {
-        display: none !important;
-        /* this is to hide to "v" icone next to titles in desktop */
-    }
-}
-
 @media (max-width: 720px) {
     .content .thumb .thumbinner>.thumbcaption {
         flex: 1 1 auto !important;
     }
-}
-
-.collapsible-block {
-    display: none;
-}
-
-.open-block {
-    display: block;
 }
 
 .mwo-catlinks {

--- a/res/templates/lead_section_wrapper.html
+++ b/res/templates/lead_section_wrapper.html
@@ -1,9 +1,6 @@
-<h1 class="section-heading in-block collapsible-heading open-block" tabindex="0" aria-haspopup="true"
-  aria-controls="content-collapsible-block-0" data-section-id='0'>
-  <div class="mw-ui-icon mw-ui-icon-arrow mw-ui-icon-element  indicator" title=""></div>
+<h1 class="section-heading" tabindex="0" aria-haspopup="true" data-section-id='0'>
   <span class="mw-headline" id="title_0">{% autoescape false %}{{ lead_display_title }}{% endautoescape %}</span>
 </h1>
-<div id="mf-section-0" class="mf-section-0 collapsible-block open-block" id="content-collapsible-block-0"
-  aria-pressed="true" aria-expanded="true">
+<div id="mf-section-0" class="mf-section-0" aria-pressed="true" aria-expanded="true">
   {% autoescape false %}{{ lead_section_text }}{% endautoescape %}
 </div>

--- a/res/templates/page.html
+++ b/res/templates/page.html
@@ -26,14 +26,6 @@
       </div>
     </div>
   </div>
-
-  <noscript>
-    <style>
-      .collapsible-block {
-        display: block !important;
-      }
-    </style>
-  </noscript>
   __ARTICLE_CONFIGVARS_LIST__
   __ARTICLE_JS_LIST__
 </body>


### PR DESCRIPTION
I'm not sure why this code was originally in `style.css`:
```css
h1[tabindex="0"].collapsible-heading {
    cursor: none;
    /* Article title is not collapsible */
}
```
But it caused #953 

I've removed a few unused CSS rules along with fixing the specific issue