### PR TITLE
Add canonical link header

### DIFF
--- a/res/templates/page.html
+++ b/res/templates/page.html
@@ -8,6 +8,7 @@
   <script>
     function importScript() { return 1 } // this is to avoid the error from site.js
   </script>
+  __ARTICLE_CANONICAL_LINK__
   __ARTICLE_CSS_LIST__
   __CSS_LINKS__
   __JS_SCRIPTS__

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -21,7 +21,7 @@ import { config } from './config';
 import Downloader from './Downloader';
 import MediaWiki from './MediaWiki';
 import Redis from './Redis';
-import { writeFilePromise, mkdirPromise, isValidEmail, genHeaderCSSLink, genHeaderScript, saveStaticFiles, readFilePromise, makeArticleImageTile, makeArticleListItem, getDumps, getMediaBase, MIN_IMAGE_THRESHOLD_ARTICLELIST_PAGE, downloadAndSaveModule, getSizeFromUrl, getRelativeFilePath } from './util';
+import { writeFilePromise, mkdirPromise, isValidEmail, genHeaderCSSLink, genHeaderScript, genCanonicalLink, saveStaticFiles, readFilePromise, makeArticleImageTile, makeArticleListItem, getDumps, getMediaBase, MIN_IMAGE_THRESHOLD_ARTICLELIST_PAGE, downloadAndSaveModule, getSizeFromUrl, getRelativeFilePath } from './util';
 import { mapLimit } from 'promiso';
 import { ZimCreatorFs } from './ZimCreatorFs';
 import logger from './Logger';
@@ -534,6 +534,7 @@ async function execute(argv: any) {
             genHeaderScript(config, 'images_loaded.min', dump.mwMetaData.mainPage) + '\n' +
             genHeaderScript(config, 'masonry.min', dump.mwMetaData.mainPage) + '\n' +
             genHeaderScript(config, 'article_list_home', dump.mwMetaData.mainPage) + '\n' +
+            genCanonicalLink(config, dump.mwMetaData.webUrl, dump.mwMetaData.mainPage) + '\n' +
             '\n</head>'),
       );
 

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -215,6 +215,9 @@ export function genHeaderScript(config: Config, js: string, articleId: string, c
   const upStr = '../'.repeat(slashesInUrl + 1);
   return `<script src="${upStr}${resourceNamespace}/${jsPath(config, js)}" class="${classList}"></script>`;
 }
+export function genCanonicalLink(config: Config, webUrl: string, articleId: string) {
+  return `<link rel="canonical" href="${ webUrl }${ encodeURIComponent(articleId) }" />`;
+}
 
 export function getDumps(format: boolean | boolean[]) {
   let dumps: any[];

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -9,7 +9,7 @@ import DU from '../DOMUtils';
 import * as domino from 'domino';
 import { Dump } from '../Dump';
 import { mapLimit } from 'promiso';
-import { getFullUrl, genHeaderScript, genHeaderCSSLink, jsPath, contains, getMediaBase } from '.';
+import { getFullUrl, genHeaderScript, genCanonicalLink, genHeaderCSSLink, jsPath, contains, getMediaBase } from '.';
 import { config } from '../config';
 import { htmlTemplateCode, footerTemplate } from '../Templates';
 import { filesToDownloadXPath, articleDetailXId, filesToRetryXPath } from '../stores';
@@ -649,6 +649,7 @@ async function templateArticle(parsoidDoc: DominoElement, moduleDependencies: an
 
     const htmlTemplateDoc = domino.createDocument(
         htmlTemplateCode(articleId)
+            .replace('__ARTICLE_CANONICAL_LINK__', genCanonicalLink(config, mw.webUrl, articleId))
             .replace('__ARTICLE_CONFIGVARS_LIST__', jsConfigVars !== '' ? genHeaderScript(config, 'jsConfigVars', articleId) : '')
             .replace(
                 '__ARTICLE_JS_LIST__',


### PR DESCRIPTION
Fix #564

### Change

This PR adds canonical URL in form of HTML `<link>` tag in the header of each page.


#### Example

`webUrl` = `https://en.wikipedia.org/wiki/`
`articleId` = `Mew (Pokémon)` (note `é`)

produces:


```html
<link rel="canonical" href="https://en.wikipedia.org/wiki/Mew_(Pok%C3%A9mon)" />
```

### Motivation 

As noted in #564, HTML snapshot should point at canonical URL.
It improves semantics and help search engines to deduplicate relevant
results when multiple snapshots are published on the web.

Closes #564 cc @kelson42, https://github.com/ipfs/distributed-wikipedia-mirror/issues/48
