### PR TITLE
:sparkles: implement customProcessors for filtering and post/pre processing articles (#941)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,6 +30,7 @@
                 // "--articleList=https://ftp.nluug.nl/pub/kiwix/wp1/enwiki_2019-01/tops/100",
                 // "--articleList=https://download.kiwix.org/wp1/enwiki_2019-04/projects/Football",
                 "--redis=redis://127.0.0.1:6379",
+                // "--customProcessor=./extensions/wiktionary_fr.js"
                 // "--getCategories=true"
                 // "--customZimFavicon=test.png"
             ]

--- a/extensions/wiktionary_fr.js
+++ b/extensions/wiktionary_fr.js
@@ -1,0 +1,14 @@
+module.exports = class WiktionaryFR { // implements CustomProcessor
+    async shouldKeepArticle(articleId, doc) {
+        const frenchTitle = doc.querySelector(`#fr.sectionlangue`);
+        return !!frenchTitle;
+    }
+    async preProcessArticle(articleId, doc) {
+        const nonFrenchTitles = Array.from(doc.querySelectorAll(`.sectionlangue:not(#fr)`));
+        for (const title of nonFrenchTitles) {
+            title.closest('details').remove();
+        }
+
+        return doc;
+    }
+}

--- a/src/Dump.ts
+++ b/src/Dump.ts
@@ -29,6 +29,7 @@ interface DumpOpts {
 }
 
 export class Dump {
+    public customProcessor?: CustomProcessor;
     public nopic: boolean;
     public novid: boolean;
     public nopdf: boolean;
@@ -56,9 +57,10 @@ export class Dump {
 
     private formatFlavour: string;
 
-    constructor(format: string, opts: DumpOpts, mwMetaData: MWMetaData) {
+    constructor(format: string, opts: DumpOpts, mwMetaData: MWMetaData, customProcessor?: CustomProcessor) {
         this.mwMetaData = mwMetaData;
         this.opts = opts;
+        this.customProcessor = customProcessor;
 
         const [formatStr, formatFlavour] = format.split(':');
         this.nopic = formatStr.includes('nopic');

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -81,6 +81,7 @@ async function execute(argv: any) {
     customZimFavicon: _customZimFavicon,
     useCache,
     noLocalParserFallback,
+    customFlavour: customProcessorPath,
   } = argv;
 
   (process as any).verbose = !!verbose;
@@ -104,6 +105,14 @@ async function execute(argv: any) {
   const nodeVersionSatisfiesPackage = semver.satisfies(process.version, packageJSON.engines.node);
   if (!nodeVersionSatisfiesPackage) {
     logger.warn(`***********\n\n\tCurrent node version is [${process.version}]. We recommend [${packageJSON.engines.node}]\n\n***********`);
+  }
+
+  let customProcessor = null;
+  if (customProcessorPath) {
+    const CustomProcessor = require(
+      path.join(process.cwd(), customProcessorPath),
+    );
+    customProcessor = new CustomProcessor();
   }
 
   /* Wikipedia/... URL; Normalize by adding trailing / as necessary */
@@ -299,7 +308,10 @@ async function execute(argv: any) {
       minifyHtml,
       keepEmptyParagraphs,
       tags: customZimTags,
-    }, { ...mwMetaData, mainPage });
+    },
+      { ...mwMetaData, mainPage },
+      customProcessor,
+    );
     dumps.push(dump);
     logger.log(`Doing dump`);
     let shouldSkip = false;

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -34,4 +34,5 @@ export const parameterDescriptions = {
   getCategories: '[WIP] Download category pages',
   noLocalParserFallback: 'Don\'t fall back to a local MCS or Parsoid, only use remote APIs',
   osTmpDir: 'Override default operating system temporary directory path environnement variable',
+  customFlavour: 'A custom processor that can filter and process articles (see extensions/*.js)',
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -18,6 +18,12 @@ type DominoElement = any;
 type Callback = (err?: any, data?: any, extra?: any) => void;
 type KVS<T> = { [key: string]: T };
 
+interface CustomProcessor {
+    shouldKeepArticle?: (articleId: string, doc: Document) => Promise<boolean>;
+    preProcessArticle?: (articleId: string, doc: Document) => Promise<Document>;
+    postProcessArticle?: (articleId: string, doc: Document) => Promise<Document>;
+}
+
 interface MWMetaData {
     langIso2: string;
     langIso3: string;

--- a/test/unit/saveArticles.test.ts
+++ b/test/unit/saveArticles.test.ts
@@ -182,3 +182,58 @@ test('treatMedias format="novid"', async (t) => {
     t.equals(videoEl, undefined, 'Video element removed in novid');
     t.ok(!!imgEl, 'Img element not removed in novid');
 });
+
+test('--customFlavour', async (t) => {
+    const { downloader, mw, dump } = await setupScrapeClasses({ format: 'nopic' }); // en wikipedia
+    class CustomFlavour implements CustomProcessor {
+        public async shouldKeepArticle(articleId: string, doc: Document) {
+            return articleId !== 'London';
+        }
+        public async preProcessArticle(articleId: string, doc: Document) {
+            if (articleId === 'Paris') {
+                const h2 = doc.createElement('h2');
+                h2.textContent = 'INSERTED_BY_PRE_PROCESSOR';
+                h2.id = 'PRE_PROCESSOR';
+                doc.body.appendChild(h2);
+            }
+            return doc;
+        }
+        public async postProcessArticle(articleId: string, doc: Document) {
+            if (articleId === 'Prague') {
+                const h2 = doc.createElement('h2');
+                h2.textContent = 'INSERTED_BY_POST_PROCESSOR';
+                h2.id = 'POST_PROCESSOR';
+                doc.body.appendChild(h2);
+            }
+            return doc;
+        }
+    }
+    const customFlavour = new CustomFlavour();
+    dump.customProcessor = customFlavour;
+
+    const _articlesDetail = await downloader.getArticleDetailsIds(['London', 'Paris', 'Prague']);
+    const articlesDetail = mwRetToArticleDetail(downloader, _articlesDetail);
+    await articleDetailXId.flush();
+    await articleDetailXId.setMany(articlesDetail);
+
+    const writtenArticles: any = {};
+    await saveArticles({
+        addArticle(article: ZimArticle) {
+            if (article.mimeType === 'text/html') {
+                writtenArticles[article.title] = article;
+            }
+            return Promise.resolve();
+        },
+    } as any,
+        downloader,
+        mw,
+        dump,
+    );
+
+    const ParisDocument = domino.createDocument(writtenArticles.Paris.bufferData);
+    const PragueDocument = domino.createDocument(writtenArticles.Prague.bufferData);
+
+    t.ok(!writtenArticles.London, `London was correctly filtered out by customFlavour`);
+    t.ok(ParisDocument.querySelector('#PRE_PROCESSOR'), `Paris was correctly pre-processed`);
+    t.ok(PragueDocument.querySelector('#POST_PROCESSOR'), `Prague was correctly post-processed`);
+});


### PR DESCRIPTION
Closes #941 
Relates to #989 

This is not intending to fully implement #989, just to get it started.

`CustomProcessor`s must implement the `CustomProcessor` interface:
```typescript
interface CustomProcessor {
    shouldKeepArticle?: (articleId: string, doc: Document) => Promise<boolean>;
    preProcessArticle?: (articleId: string, doc: Document) => Promise<Document>;
    postProcessArticle?: (articleId: string, doc: Document) => Promise<Document>;
}
```

The `--customProcessor` argument takes a path to a JS file, e.g.: `--customProcessor=./extensions/wiktionary_fr.js`

Please confirm I've understood the specification correctly?
If so, I'll start writing tests