### PR TITLE
single container for mwoffliner and redis

### DIFF
--- a/docker/.custom-bashrc
+++ b/docker/.custom-bashrc
@@ -1,2 +1,3 @@
 source ~/.old-bashrc
-alias mwoffliner='mwoffliner --redis="redis://redis"'
+alias mwoffliner='mwoffliner --redis=/dev/shm/redis.sock'
+alias redis-cli='redis-cli -s /dev/shm/redis.sock'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,11 @@
-FROM node:10
+FROM openzim/node-redis
 
 # Install dependences
-RUN apt update && apt install -y --no-install-recommends make g++ curl git imagemagick
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    make g++ curl git imagemagick && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install mwoffliner
 WORKDIR /tmp/mwoffliner

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openzim/node-redis
+FROM openzim/node-redis:latest
 
 # Install dependences
 RUN apt-get update && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openzim/node-redis:latest
+FROM openzim/node-redis:10-5
 
 # Install dependences
 RUN apt-get update && \

--- a/docker/node-redis.Dockerfile
+++ b/docker/node-redis.Dockerfile
@@ -1,0 +1,13 @@
+FROM redis:5.0 as redis
+
+FROM node:10-buster
+
+COPY --from=redis /usr/local/bin/redis-* /usr/local/bin/
+RUN redis-cli --version
+RUN redis-server --version
+
+COPY node_redis-entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["node_redis-entrypoint.sh"]
+
+CMD ["bash"]

--- a/docker/node_redis-entrypoint.sh
+++ b/docker/node_redis-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+echo "starting redis-server in the background…"
+nohup redis-server --save "" --appendonly no --unixsocket /dev/shm/redis.sock --unixsocketperm 744 --port 0 --bind 127.0.0.1 > /dev/shm/redis.log 2>&1&
+# allow redis to start before we continue and bind
+sleep 2
+
+exec "$@"


### PR DESCRIPTION
**WARNING**: not intended to be merged-in as is.

* mwoffliner has a runtime dependency to redis.
* most people run mwoffliner via our docker image
* redis-server is a lightweight service (when idle) with close to no output
* most people using mwoffliner have to start a detached redis container for mwoffliner use and stop it afterwards.

For this last reason, and the fact that in my (zimfarm) use case, I have to write and maintain specific code to handle that two-containers situation (so far, all other scrapers are single-containers), I figured it would be handy to offer an all-inclusive image: **a docker image containing both a running redis and mwoffliner**.

This PR offers exactly this: it adds a new dockerfile (and entrypoint) to create a new _node-redis_ base image that is basically the `node:10` image with the redis binaries and an entrypoint to start it in the background.
Additionally, it changes our `mwoffliner` base image to this one.

Using this:
* regular user would just have to run mwoffliner container directly (bash alias adding `--redis redis.sock` automatically).
* advanced user would still be able to run a dedicated redis (specifying it with `--redis`).

**advantages**:

* simpler for most users.
* simpler resources monitoring/restriction of the _scraping job_.

**drawbacks**:

* not following docker dogma (but not preventing it)
* a non-used running redis-server in the background

--

Let me know what you think. maybe we could provide this in addition to the normal docker image on a separate tag but that looks like maintenance work with low benefits ; hence this version.

Haven't updated doc in the PR on purpose. Will do should we agree on doing this.
