### PR TITLE
added node-redis container recipe

### DIFF
--- a/docker/node-redis.Dockerfile
+++ b/docker/node-redis.Dockerfile
@@ -1,0 +1,13 @@
+FROM redis:5.0 as redis
+
+FROM node:10-buster
+
+COPY --from=redis /usr/local/bin/redis-* /usr/local/bin/
+RUN redis-cli --version
+RUN redis-server --version
+
+COPY node_redis-entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["node_redis-entrypoint.sh"]
+
+CMD ["bash"]

--- a/docker/node_redis-entrypoint.sh
+++ b/docker/node_redis-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+echo "starting redis-server in the background…"
+nohup redis-server --save "" --appendonly no --unixsocket /dev/shm/redis.sock --unixsocketperm 744 --port 0 --bind 127.0.0.1 > /dev/shm/redis.log 2>&1&
+# allow redis to start before we continue and bind
+sleep 2
+
+exec "$@"


### PR DESCRIPTION
Breaking down #1012, here's the new base container Dockerfile so we can create the docker hub repo/image.

- a `node:10` (buster flavor instead of stretch) image
- with redis binaries from `redis:5.0`
- an entrypoint starting redis-server in the background
  without any writes on disk
  using only socket binding