### PR TITLE
using our node-redis base image instead of node:10

### DIFF
--- a/docker/.custom-bashrc
+++ b/docker/.custom-bashrc
@@ -1,2 +1,3 @@
 source ~/.old-bashrc
-alias mwoffliner='mwoffliner --redis="redis://redis"'
+alias mwoffliner='mwoffliner --redis=/dev/shm/redis.sock'
+alias redis-cli='redis-cli -s /dev/shm/redis.sock'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,11 @@
-FROM node:10
+FROM openzim/node-redis:10-5
 
 # Install dependences
-RUN apt update && apt install -y --no-install-recommends make g++ curl git imagemagick
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    make g++ curl git imagemagick && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install mwoffliner
 WORKDIR /tmp/mwoffliner

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,19 +1,32 @@
-'''MWoffliner Docker image''' allows to quickly benefit of MWoffliner
+**MWoffliner Docker image** allows to quickly benefit of MWoffliner
 without having to install all dependencies. You just need a working
 [Docker](https://www.docker.com).
 
 ## Standalone
 
-The MWoffliner image needs a Redis (http://www.redis.io) server to run
-properly.
+MWoffliner requires a [Redis](http://www.redis.io) server to run.
 
-You can run a Redis docker container with:
+For convenience purpose, MWoffliner image bundles a redis server launched in the background.
+
+This bundled redis server is configured to be used only through a unix socket and to work exclusively from memory (no writes to disk).
+
+Use of this bundled server is transparent as `mwoffliner` command is aliased to `mwoffliner --redis /dev/shm/redis.sock`. 
+
+``` sh
+docker run -ti openzim/mwoffliner mwoffliner --help
+```
+
+## With dedicated redis
+
+You can also use a dedicated redis container with MWoffliner.
+
+Run a Redis docker container with:
 
 ```
 $docker run --name=redis -d redis
 ```
 
-... and then run the moffliner interactively:
+... and then run the moffliner interactively (remember to specify `--redis` in command):
 
 ```
 $docker run --link=redis:redis --name=mwoffliner -ti openzim/mwoffliner


### PR DESCRIPTION
Following #1012, here's the edit to use the new [openzim/node-redis](https://cloud.docker.com/u/openzim/repository/docker/openzim/node-redis/general) docker image.

- cleaning-up packages installation line
- updating documentation