### PR TITLE
Add extensions folder to docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,12 +13,14 @@ COPY *.json ./
 COPY src src
 COPY res res
 COPY translation translation
+COPY extensions extensions
 COPY index.js .
 COPY dev dev
 RUN npm --global config set user root
 RUN npm config set unsafe-perm true
 RUN npm i
 RUN npm i -g .
+
 
 # Configure launch environment
 WORKDIR /


### PR DESCRIPTION
Without the extensions folder in the docker image, it's very annoying to use the
embedded extension (download from source, copy to a mounted volume).

With this fix, one can simply use `--customFlavour /extensions/wiktionary_fr.js`