### PR TITLE
--optimisationCacheUrl should excpect an URL

### DIFF
--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -122,7 +122,7 @@ async function execute(argv: any) {
     // Decompose the url with path and other S3 creds
     const s3UrlObj =  urlParser.parse(optimisationCacheUrl);
     const queryReader = QueryStringParser.parse(s3UrlObj.query, '?');
-    const s3Url = (s3UrlObj.host || "") + (s3UrlObj.pathname || "");
+    const s3Url = (s3UrlObj.host || '') + (s3UrlObj.pathname || '');
     this.s3Obj = new S3(s3Url, queryReader);
     await this.s3Obj.initialise().then((data: any) => {
       logger.log('Successfuly logged in S3');

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -120,9 +120,10 @@ async function execute(argv: any) {
   // Check for S3 creds
   if (optimisationCacheUrl) {
     // Decompose the url with path and other S3 creds
-    const s3Url =  urlParser.parse(optimisationCacheUrl);
-    const queryReader = QueryStringParser.parse(s3Url.query, '?');
-    this.s3Obj = new S3(s3Url.pathname, queryReader);
+    const s3UrlObj =  urlParser.parse(optimisationCacheUrl);
+    const queryReader = QueryStringParser.parse(s3UrlObj.query, '?');
+    const s3Url = (s3UrlObj.host || "") + (s3UrlObj.pathname || "");
+    this.s3Obj = new S3(s3Url, queryReader);
     await this.s3Obj.initialise().then((data: any) => {
       logger.log('Successfuly logged in S3');
     });

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -34,5 +34,5 @@ export const parameterDescriptions = {
   noLocalParserFallback: 'Don\'t fall back to a local MCS or Parsoid, only use remote APIs',
   osTmpDir: 'Override default operating system temporary directory path environnement variable',
   customFlavour: 'A custom processor that can filter and process articles (see extensions/*.js)',
-  optimisationCacheUrl: 'S3 url and credentials to the bucket',
+  optimisationCacheUrl: 'S3 url, including credentials and bucket name',
 };


### PR DESCRIPTION
The name and help info of this option clearly lean towards it expecting an URL.
This is not the case at the moment. If one supplies a *regular* S3-like URL, it will
get rejected (with a non-informative message about incorrect credentials)

With this, `--optimisationCacheUrl` nows accepts both the previous format and an URL
containing the protocol information (which won't be used.)

Also fixed wording in help.