### PR TITLE
Internal wikis link broken fixed

### DIFF
--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -235,6 +235,11 @@ class Downloader {
     });
     const domain = (urlParser.parse(this.mw.base)).host;
     this.mcsUrl = `http://localhost:6927/${domain}/v1/page/mobile-sections/`;
+
+    if(this.mw.apiPath == 'api.php'){
+      this.mcsUrl = `http://localhost:8000/${{domain}}/v3/{+path}`
+    }
+    
     if (forceLocalParsoid) {
       const webUrlHost = urlParser.parse(this.mw.webUrl).host;
       this.parsoidFallbackUrl = `http://localhost:8000/${webUrlHost}/v3/page/pagebundle/`;


### PR DESCRIPTION
I have changed the end-point of the API for the wikis having mwApi path:
http://localhost:6927/${domain}/v1/page/mobile-sections/ **(Producing the wrong hrefs)**
to
http://localhost:8000/${{domain}}/v3/{+path}

I am not sure if every wiki has the same mwApi path like:
--mwApiPath = "api.php"

And if the wikis doesn't have same mwApiPath, on what other basis should we differentiate? @kelson42 
Should resolve #1017 