### PR TITLE
Remove a few useless 'await' calls

### DIFF
--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -384,7 +384,7 @@ async function execute(argv: any) {
       data: `mwoffliner ${packageJSON.version}`,
       url: 'Scraper',
     });
-    await zimCreator.addArticle(scraperArticle);
+    zimCreator.addArticle(scraperArticle);
 
     logger.info('Copying Static Resource Files');
     await saveStaticFiles(config, zimCreator);
@@ -400,7 +400,7 @@ async function execute(argv: any) {
     logger.log(`Downloaded stylesheets`);
 
     const article = new ZimArticle({ url: `style.css`, data: finalCss, ns: '-' });
-    await zimCreator.addArticle(article);
+    zimCreator.addArticle(article);
     await saveFavicon(dump, zimCreator);
 
     if (!customMainPage && articleList && articleListLines.length > MIN_IMAGE_THRESHOLD_ARTICLELIST_PAGE) {
@@ -488,7 +488,7 @@ async function execute(argv: any) {
               title,
               redirectUrl: targetId,
             });
-            await zimCreator.addArticle(redirectArticle);
+            zimCreator.addArticle(redirectArticle);
             dump.status.redirects.written += 1;
           }
         }
@@ -613,11 +613,7 @@ async function execute(argv: any) {
       return zimCreator.addArticle(article);
     }
 
-    if (mainPage) {
-      return createMainPageRedirect();
-    } else {
-      return createMainPage();
-    }
+    return mainPage ? createMainPageRedirect() : createMainPage();
   }
 
   closeRedis(redis);

--- a/src/util/dump.ts
+++ b/src/util/dump.ts
@@ -137,7 +137,7 @@ export async function downloadAndSaveModule(zimCreator: ZimCreator, mw: MediaWik
             ? jsPath(config, module)
             : cssPath(config, module);
         const article = new ZimArticle({ url: articleId, data: text, ns: '-' });
-        await zimCreator.addArticle(article);
+        zimCreator.addArticle(article);
         logger.info(`Saved module [${module}]`);
     } catch (e) {
         logger.error(`Failed to get module with url [${moduleApiUrl}]\nYou may need to specify a custom --mwModulePath`, e);

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -163,7 +163,7 @@ export function saveStaticFiles(config: Config, zimCreator: ZimCreator) {
       try {
         const cssCont = await readFilePromise(pathParser.resolve(__dirname, `../../res/${css}.css`));
         const article = new ZimArticle({ url: cssPath(config, css), data: cssCont, ns: '-' });
-        await zimCreator.addArticle(article);
+        zimCreator.addArticle(article);
       } catch (error) {
         logger.warn(`Could not create ${css} file : ${error}`);
       }
@@ -173,7 +173,7 @@ export function saveStaticFiles(config: Config, zimCreator: ZimCreator) {
     try {
       const jsCont = await readFilePromise(pathParser.resolve(__dirname, `../../res/${js}.js`));
       const article = new ZimArticle({ url: jsPath(config, js), data: jsCont, ns: '-' });
-      await zimCreator.addArticle(article);
+      zimCreator.addArticle(article);
     } catch (error) {
       logger.warn(`Could not create ${js} file : ${error}`);
     }

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -45,7 +45,7 @@ export async function downloadFiles(fileStore: FileStore, zimCreator: ZimCreator
         responses.forEach(async function (resp: any) {
             try {
                 const article = new ZimArticle({ url: resp.path, data: resp.result.content, ns: resp.namespace || 'I' });
-                await zimCreator.addArticle(article);
+                zimCreator.addArticle(article);
                 dump.status.files.success += 1;
             } catch (err) {
                 if (!isRetry) {
@@ -203,7 +203,7 @@ export async function saveArticles(zimCreator: ZimCreator, downloader: Downloade
                             shouldIndex: true,
                         });
 
-                        await zimCreator.addArticle(zimArticle);
+                        zimCreator.addArticle(zimArticle);
 
                         dump.status.articles.success += 1;
                     }
@@ -225,7 +225,7 @@ export async function saveArticles(zimCreator: ZimCreator, downloader: Downloade
     );
 
     const jsConfigVarArticle = new ZimArticle({ url: jsPath(config, 'jsConfigVars'), data: jsConfigVars, ns: '-' });
-    await zimCreator.addArticle(jsConfigVarArticle);
+    zimCreator.addArticle(jsConfigVarArticle);
 
     return {
         jsModuleDependencies,


### PR DESCRIPTION
I don't think these calls to `await` are necessary. The function are async but we do nothing with the result anyway, there I believe with can just throw the call and forget. Important is to properly wait at the ZIM finalization step of course.