### PR TITLE
Logs for getting total articles

### DIFF
--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -308,8 +308,12 @@ async function execute(argv: any) {
     // await trimUnmirroredPages(downloader); // TODO: improve simplify graph to remove the need for a second trim
   }
 
-  // Getting total number of articles
+  // Getting total number of articles from namespace
   logger.log(`Total articles found by namespace ${getTotalArticlesNumberByNS()}`);
+
+  // Getting total number of articles from Redis
+  logger.log(`Total articles found in Redis  ${await articleDetailXId.len()}`);
+
 
   const dumps: Dump[] = [];
 

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -33,6 +33,7 @@ import { saveArticles, downloadFiles } from './util/saveArticles';
 import { getCategoriesForArticles, trimUnmirroredPages } from './util/categories';
 import { filesToDownloadXPath, populateFilesToDownload, articleDetailXId, populateArticleDetail, populateRedirects, filesToRetryXPath, populateFilesToRetry, redirectsXId } from './stores';
 import S3 from './S3';
+import { getTotalArticlesNumberByNS } from './util/mw-api';
 const packageJSON = JSON.parse(readFileSync(path.join(__dirname, '../package.json'), 'utf8'));
 
 function closeRedis(redis: Redis) {
@@ -306,6 +307,9 @@ async function execute(argv: any) {
     // }
     // await trimUnmirroredPages(downloader); // TODO: improve simplify graph to remove the need for a second trim
   }
+
+  // Getting total number of articles
+  logger.log(`Total articles found by namespace ${getTotalArticlesNumberByNS()}`);
 
   const dumps: Dump[] = [];
 

--- a/src/util/RedisKvs.ts
+++ b/src/util/RedisKvs.ts
@@ -157,7 +157,6 @@ export class RedisKvs<T> {
           reject(err);
         } else {
           resolve(val);
-          logger.log(`Total Articles stored in redis ${val}`);
         }
       });
     });

--- a/src/util/RedisKvs.ts
+++ b/src/util/RedisKvs.ts
@@ -1,6 +1,7 @@
 import {cpus} from 'os';
 import {mapLimit} from 'promiso';
 import type {RedisClient} from 'redis';
+import logger from '../Logger';
 
 interface ScanResult {
   cursor: string;
@@ -156,6 +157,7 @@ export class RedisKvs<T> {
           reject(err);
         } else {
           resolve(val);
+          logger.log(`Total Articles stored in redis ${val}`);
         }
       });
     });

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -98,13 +98,7 @@ export async function getArticlesByNS(ns: number, downloader: Downloader, contin
         totalArticles += numDetails;
 
         // Only for testing purposes
-        if (typeof continueLimit !== 'undefined') {
-            if (continueLimit > 0) {
-                continueLimit = continueLimit - 1;
-            } else {
-                break;
-            }
-        }
+        if (--(continueLimit as number) < 0) break;
     } while (_gapContinue);
 }
 

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -5,6 +5,7 @@ import { articleDetailXId, redirectsXId } from '../stores';
 import deepmerge = require('deepmerge');
 
 let batchSize = 50;
+let totalArticles = 0;
 export async function getArticlesByIds(_articleIds: string[], downloader: Downloader, log = true): Promise<void> {
     let from = 0;
     let numArticleIds = _articleIds.length;
@@ -93,7 +94,7 @@ export async function getArticlesByNS(ns: number, downloader: Downloader, _gapCo
     }
 
     logger.log(`Got [${numDetails}] articles from namespace [${ns}]`);
-
+    totalArticles += numDetails;
     const canContinue = typeof continueLimit === 'undefined' || continueLimit > 0; // used for testing
 
     if (gapContinue && canContinue) {
@@ -157,4 +158,8 @@ export function mwRetToArticleDetail(downloader: Downloader, obj: QueryMwRet): K
         };
     }
     return ret;
+}
+
+export function getTotalArticlesNumberByNS() {
+    return totalArticles;
 }

--- a/test/unit/mwApi.test.ts
+++ b/test/unit/mwApi.test.ts
@@ -45,10 +45,7 @@ test('MWApi NS', async (t) => {
     await downloader.checkCapabilities();
 
     await getArticlesByNS(0, downloader, 5); // Get 5 continues/pages of NSes
-    
-    
     const interestingAIds = ['"...And_Ladies_of_the_Club"', '"M"_Circle'];
-
     const articles = await articleDetailXId.getMany(interestingAIds);
     const Ladies = articles['"...And_Ladies_of_the_Club"'];
     const Circle = articles['"M"_Circle'];

--- a/test/unit/mwApi.test.ts
+++ b/test/unit/mwApi.test.ts
@@ -44,8 +44,9 @@ test('MWApi NS', async (t) => {
 
     await downloader.checkCapabilities();
 
-    await getArticlesByNS(0, downloader, '', 5); // Get 5 continues/pages of NSes
-
+    await getArticlesByNS(0, downloader, 5); // Get 5 continues/pages of NSes
+    
+    
     const interestingAIds = ['"...And_Ladies_of_the_Club"', '"M"_Circle'];
 
     const articles = await articleDetailXId.getMany(interestingAIds);


### PR DESCRIPTION
 In this PR, both the logs are included:
- sum of total articles found by namespace
- Length of articles stored in Redis

@kelson42 Let me know if we need both the logs, or either of them?

Should resolve #993 