### PR TITLE
Add support for parametrized translatable strings

### DIFF
--- a/res/templates/footer.html
+++ b/res/templates/footer.html
@@ -1,8 +1,3 @@
 <div style="clear:both; background-image:linear-gradient(180deg, #E8E8E8, white); border-top: dashed 2px #AAAAAA; padding: 0.5em 0.5em 0.5em 0.5em; margin-top: 1em; direction: {{ strings.__direction }};">
-    {{ strings.ISSUED_BY }}
-    <a class="external text" {% if date %} title="{{ strings.LAST_EDITED_ON }} {{ date }}" {% endif %} href="{{ originArticleUrl }}">
-        {{ creator }}</a>.
-    {{strings.LICENSED_UNDER}} <a class="external text" href="https://creativecommons.org/licenses/by-sa/4.0/">Creative
-        Commons - Attribution - Sharealike</a>.
-    {{strings.ADDITIONAL_TERMS}}
+    {{ disclaimer|safe }}
 </div>

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -156,6 +156,14 @@ export function getStringsForLang(language: string, fallbackLanguage = 'en') {
   return strings;
 }
 
+export function interpolateTranslationString(str: string, parameters: { [key: string]: string }) {
+  let newString = str;
+  for (const key of Object.keys(parameters)) {
+    newString = newString.replace(new RegExp(`\\$\\{${key}\\}`, 'g'), parameters[key]);
+  }
+  return newString;
+}
+
 export function saveStaticFiles(config: Config, zimCreator: ZimCreator) {
   const cssPromises = config.output.cssResources
     .concat(config.output.mainPageCssResources)

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -13,7 +13,7 @@ import {contains, genCanonicalLink, genHeaderCSSLink, genHeaderScript, getFullUr
 import {config} from '../config';
 import {footerTemplate, htmlTemplateCode} from '../Templates';
 import {articleDetailXId, filesToDownloadXPath, filesToRetryXPath} from '../stores';
-import {getRelativeFilePath, getSizeFromUrl} from './misc';
+import {getRelativeFilePath, getSizeFromUrl, interpolateTranslationString} from './misc';
 import {RedisKvs} from './RedisKvs';
 import {rewriteUrl} from './rewriteUrls';
 import {CONCURRENCY_LIMIT} from './const';
@@ -805,10 +805,25 @@ async function templateArticle(parsoidDoc: DominoElement, moduleDependencies: an
         if (articleDetail.revisionId) {
             /* Revision date */
             const date = new Date(articleDetail.timestamp);
+            const lastEditedOnString = date ?
+                interpolateTranslationString(dump.strings.LAST_EDITED_ON, {
+                    date: date.toISOString().substring(0, 10),
+                }) : null;
+
+            const creatorLink =
+                `<a class="external text" ` +
+                `${lastEditedOnString ? `title="${lastEditedOnString}"` : ''} ` +
+                `href="${mw.webUrl}?title=${encodeURIComponent(articleId)}&oldid=${articleDetail.revisionId}">` +
+                `${dump.mwMetaData.creator}</a>`
+
+            const licenseLink =
+                `<a class="external text" href="https://creativecommons.org/licenses/by-sa/4.0/">${dump.strings.LICENSE_NAME}</a>`;
+
             div.innerHTML = footerTemplate({
-                originArticleUrl: `${mw.webUrl}?title=${encodeURIComponent(articleId)}&oldid=${articleDetail.revisionId}`,
-                creator: dump.mwMetaData.creator,
-                date: date.toISOString().substring(0, 10),
+                disclaimer: interpolateTranslationString(dump.strings.DISCLAIMER, {
+                    creator: creatorLink,
+                    license: licenseLink,
+                }),
                 strings: dump.strings,
             });
             htmlTemplateDoc.getElementById('mw-content-text').appendChild(div);

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -814,7 +814,7 @@ async function templateArticle(parsoidDoc: DominoElement, moduleDependencies: an
                 `<a class="external text" ` +
                 `${lastEditedOnString ? `title="${lastEditedOnString}"` : ''} ` +
                 `href="${mw.webUrl}?title=${encodeURIComponent(articleId)}&oldid=${articleDetail.revisionId}">` +
-                `${dump.mwMetaData.creator}</a>`
+                `${dump.mwMetaData.creator}</a>`;
 
             const licenseLink =
                 `<a class="external text" href="https://creativecommons.org/licenses/by-sa/4.0/">${dump.strings.LICENSE_NAME}</a>`;

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -1,6 +1,6 @@
 import './bootstrap.test';
 import test from 'blue-tape';
-import { throttle, sanitizeString, encodeArticleIdForZimHtmlUrl } from 'src/util';
+import { throttle, sanitizeString, encodeArticleIdForZimHtmlUrl, interpolateTranslationString } from 'src/util';
 import { sleep } from 'test/util';
 
 test('util -> Throttle', async (t) => {
@@ -28,6 +28,15 @@ test('util -> Throttle', async (t) => {
     t.equals(sanitizeString('Mediawiki <script></script>'), 'Mediawiki  script   script ', 'Escaping HTML Tags');
     t.equals(sanitizeString('SELECT * FROM db WHERE something="Poler"'), 'SELECT   FROM db WHERE something  Poler ', 'Escaping query characters');
 
+});
+
+test('util -> interpolateTranslationString', async (t) => {
+    t.equals(interpolateTranslationString('Hello world', {}), 'Hello world');
+    t.equals(interpolateTranslationString('Hello ${name}', { name: 'John' }), 'Hello John');
+    t.equals(interpolateTranslationString('Hello ${name} ${lastname}, bye ${name}', {
+        name: 'John',
+        lastname: 'Smith',
+    }), 'Hello John Smith, bye John');
 });
 
 test('Encoding ArticleId for Zim HTML Url', async(t) => {

--- a/translation/en.json
+++ b/translation/en.json
@@ -1,7 +1,6 @@
 {
     "__direction": "ltr",
-    "ISSUED_BY": "This article is issued from",
-    "LICENSED_UNDER": "The text is licensed under",
-    "ADDITIONAL_TERMS": "Additional terms may apply for the media files.",
-    "LAST_EDITED_ON": "Last edited on"
+    "DISCLAIMER": "This article is issued from ${creator}. The text is licensed under ${license}. Additional terms may apply for the media files.",
+    "LAST_EDITED_ON": "Last edited on ${date}",
+    "LICENSE_NAME": "Creative Commons - Attribution - Sharealike"
 }

--- a/translation/fr.json
+++ b/translation/fr.json
@@ -1,7 +1,6 @@
 {
     "__direction": "ltr",
-    "ISSUED_BY": "Cet article est issu de",
-    "LICENSED_UNDER": "Le texte est sous licence",
-    "ADDITIONAL_TERMS": "Des conditions supplémentaires peuvent s'appliquer aux fichiers multimédias.",
-    "LAST_EDITED_ON": "Dernière édition sur"
+    "DISCLAIMER": "Cet article est issu de ${creator}. Le texte est sous licence ${license}. Des conditions supplémentaires peuvent s'appliquer aux fichiers multimédias.",
+    "LAST_EDITED_ON": "Dernière édition sur ${date}",
+    "LICENSE_NAME": "Creative Commons - Attribution - Partage dans les Mêmes"
 }


### PR DESCRIPTION
This allows to have translatable strings with parameters like:

```
My name is ${name}
```

This is crucial for languages which the variable part of the translatable string is not necessarily at the end of the string like assumed in the `ISSUED_BY` string.

I'm also refactored the footer to use this kind of strings, the bad news is that the creator and license links couldn't be made inside the Swig template.