### PR TITLE
Fix querystring parsing for optimisationCacheUrl

### DIFF
--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -152,7 +152,7 @@ async function execute(argv: any) {
   if (optimisationCacheUrl) {
     // Decompose the url with path and other S3 creds
     const s3UrlObj =  urlParser.parse(optimisationCacheUrl);
-    const queryReader = QueryStringParser.parse(s3UrlObj.query, '?');
+    const queryReader = QueryStringParser.parse(s3UrlObj.query);
     const s3Url = (s3UrlObj.host || '') + (s3UrlObj.pathname || '');
     this.s3Obj = new S3(s3Url, queryReader);
     await this.s3Obj.initialise().then(() => {


### PR DESCRIPTION
optimisationCacheUrl takes a URL as a parameter to configure the S3 cache.

Current URL parser uses a non-standard query-string parsing to extract fields
based on the `?` character.

Currently expected URL format:

```
https://wasabisys.com/?bucketName=my-bucket?keyId=my-key-id?secretAccessKey=my-sac
```

This is an invalid URL. Expectation is the first `?` begins the Query String and fields are
to be separated by `&` character (or `;` in the recommendation).

There is no reason to use a custom, non-standard format here so this commit turns it back to
a regular parsing. Using standard URLs allows harmonization accross scrapers for which
parsing library may not accept this custom format.

Expected URLs are now as follows:

```
https://wasabisys.com/?bucketName=my-bucket&keyId=my-key-id&secretAccessKey=my-sac
```

Notes:

- it doesn't break tests as tests used structured data and not URLs
- this is incompatible with previous URLs

Docs:

- https://en.wikipedia.org/wiki/Query_string
- https://tools.ietf.org/html/rfc3986#section-3.4
- https://tools.ietf.org/html/rfc3986#section-2.2