### PR TITLE
remove outline and less h3 weights

### DIFF
--- a/res/style.css
+++ b/res/style.css
@@ -12,6 +12,11 @@
     margin: 0.5em 0 1em 0;
 }
 
+.mw-body h1,
+.mw-body summary {
+	outline: none;
+}
+
 .mw-body h2,
 .mw-body h3,
 .mw-body h4,
@@ -32,7 +37,7 @@
 
 .mw-body h3 {
     border-bottom: 0px solid #eaecf0;
-    font-weight: bold;
+    font-weight: initial;
 }
 
 .mw-body h4 {


### PR DESCRIPTION
Hi, I would like to remove the blue box in headings and make `h3` less prominent than `h2`. See more in #1124 where I submitted more feedbacks. Lemme know if my change will cause other issue or could / should be done in another way

See before and after screenshot:
![Screenshot 2020-05-24 at 11 05 43 AM](https://user-images.githubusercontent.com/8294252/82757571-48890b80-9daf-11ea-9f45-e9d20a8bd1e9.png)
![Screenshot 2020-05-24 at 11 06 52 AM](https://user-images.githubusercontent.com/8294252/82757572-4921a200-9daf-11ea-9a73-b6ad8bd12a8c.png)
