### PR TITLE
Rename parameter

### DIFF
--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -48,7 +48,7 @@ interface DownloaderOpts {
   useDownloadCache: boolean;
   downloadCacheDirectory?: string;
   noLocalParserFallback: boolean;
-  forceLocalParsoid: boolean;
+  forceLocalParser: boolean;
   optimisationCacheUrl: string;
   s3?: S3;
   backoffOptions?: BackoffOptions;
@@ -81,7 +81,7 @@ class Downloader {
   private maxActiveRequests = 1;
   private readonly requestTimeout: number;
   private readonly noLocalParserFallback: boolean = false;
-  private readonly forceLocalParsoid: boolean = false;
+  private readonly forceLocalParser: boolean = false;
   private forceParsoidFallback: boolean = false;
   private readonly urlPartCache: KVS<string> = {};
   private readonly backoffOptions: BackoffOptions;
@@ -91,7 +91,7 @@ class Downloader {
   private mwCapabilities: MWCapabilities; // todo move to MW
 
 
-  constructor({ mw, uaString, speed, reqTimeout, useDownloadCache, downloadCacheDirectory, noLocalParserFallback, forceLocalParsoid, optimisationCacheUrl, s3, backoffOptions }: DownloaderOpts) {
+  constructor({ mw, uaString, speed, reqTimeout, useDownloadCache, downloadCacheDirectory, noLocalParserFallback, forceLocalParser: forceLocalParser, optimisationCacheUrl, s3, backoffOptions }: DownloaderOpts) {
     this.mw = mw;
     this.uaString = uaString;
     this.speed = speed;
@@ -101,7 +101,7 @@ class Downloader {
     this.useDownloadCache = useDownloadCache;
     this.downloadCacheDirectory = downloadCacheDirectory;
     this.noLocalParserFallback = noLocalParserFallback;
-    this.forceLocalParsoid = forceLocalParsoid;
+    this.forceLocalParser = forceLocalParser;
     this.optimisationCacheUrl = optimisationCacheUrl;
     this.s3 = s3;
     this.mwCapabilities = {
@@ -156,7 +156,7 @@ class Downloader {
       logger.warn(`Failed to get remote Rest API`);
     }
 
-    if (!this.forceLocalParsoid) {
+    if (!this.forceLocalParser) {
       try {
         const parsoidMainPageQuery = await this.getJSON<any>(`${this.parsoidFallbackUrl}${encodeURIComponent(this.mw.metaData.mainPage)}`);
         this.mwCapabilities.parsoidAvailable = !!parsoidMainPageQuery.visualeditor.content;

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,8 @@ const config = {
 
   defaults: {
     publisher: 'Kiwix',
-    redisConfig: '/dev/shm/redis.sock',
+    // redisConfig: '/dev/shm/redis.sock',
+    redisConfig: 'redis://localhost:6379',
     requestTimeout: 60 * 1000,
   },
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,8 +4,7 @@ const config = {
 
   defaults: {
     publisher: 'Kiwix',
-    // redisConfig: '/dev/shm/redis.sock',
-    redisConfig: 'redis://localhost:6379',
+    redisConfig: '/dev/shm/redis.sock',
     requestTimeout: 60 * 1000,
   },
 

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -111,7 +111,7 @@ async function execute(argv: any) {
     useDownloadCache,
     optimisationCacheUrl,
     noLocalParserFallback,
-    forceLocalParsoid,
+    forceLocalParser,
     customFlavour: customProcessorPath,
   } = argv;
 
@@ -186,7 +186,7 @@ async function execute(argv: any) {
     useDownloadCache,
     downloadCacheDirectory: null,
     noLocalParserFallback,
-    forceLocalParsoid,
+    forceLocalParser,
     optimisationCacheUrl,
     s3,
   });

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -33,7 +33,7 @@ export const parameterDescriptions = {
   addNamespaces: 'Force additional namespace (comma separated numbers)',
   getCategories: '[WIP] Download category pages',
   noLocalParserFallback: 'Don\'t fall back to a local MCS or Parsoid, only use remote APIs',
-  forceLocalParsoid: 'Use local Parsoid instance even if remote one available',
+  forceLocalParser: 'Use local Parsoid instance even if remote one available',
   osTmpDir: 'Override default operating system temporary directory path environment variable',
   customFlavour: 'A custom processor that can filter and process articles (see extensions/*.js)',
   optimisationCacheUrl: 'S3 url, including credentials and bucket name',

--- a/test/unit/downloader.test.ts
+++ b/test/unit/downloader.test.ts
@@ -20,7 +20,7 @@ test('Downloader class', async (t) => {
 
     const cacheDir = `cac/dumps-${Date.now()}/`;
     await mkdirPromise(cacheDir);
-    const downloader = new Downloader({ mw, uaString: '', speed: 1, reqTimeout: 1000 * 60, useDownloadCache: true, downloadCacheDirectory: cacheDir, noLocalParserFallback: false, forceLocalParsoid: false, optimisationCacheUrl: '' });
+    const downloader = new Downloader({ mw, uaString: '', speed: 1, reqTimeout: 1000 * 60, useDownloadCache: true, downloadCacheDirectory: cacheDir, noLocalParserFallback: false, forceLocalParser: false, optimisationCacheUrl: '' });
 
     await mw.getMwMetaData(downloader);
     await downloader.checkCapabilities();
@@ -158,7 +158,7 @@ _test('Downloader class with optimisation', async (t) => {
         keyId: process.env.KEY_ID_TEST,
         secretAccessKey: process.env.SECRET_ACCESS_KEY_TEST,
     });
-    const downloader = new Downloader({ mw, uaString: '', speed: 1, reqTimeout: 1000 * 60, useDownloadCache: true, downloadCacheDirectory: cacheDir, noLocalParserFallback: false, forceLocalParsoid: false, optimisationCacheUrl: 'random-string' , s3});
+    const downloader = new Downloader({ mw, uaString: '', speed: 1, reqTimeout: 1000 * 60, useDownloadCache: true, downloadCacheDirectory: cacheDir, noLocalParserFallback: false, forceLocalParser: false, optimisationCacheUrl: 'random-string' , s3});
 
     await s3.initialise();
 

--- a/test/unit/mwApi.test.ts
+++ b/test/unit/mwApi.test.ts
@@ -13,7 +13,7 @@ test('MWApi Article Ids', async (t) => {
         getCategories: true,
     } as any);
 
-    const downloader = new Downloader({ mw, uaString: '', speed: 1, reqTimeout: 1000 * 60, useDownloadCache: false, downloadCacheDirectory: '', noLocalParserFallback: false, forceLocalParsoid: false, optimisationCacheUrl: '' });
+    const downloader = new Downloader({ mw, uaString: '', speed: 1, reqTimeout: 1000 * 60, useDownloadCache: false, downloadCacheDirectory: '', noLocalParserFallback: false, forceLocalParser: false, optimisationCacheUrl: '' });
 
     await mw.getMwMetaData(downloader);
     await downloader.checkCapabilities();
@@ -41,7 +41,7 @@ test('MWApi NS', async (t) => {
         getCategories: true,
     } as any);
 
-    const downloader = new Downloader({ mw, uaString: '', speed: 1, reqTimeout: 1000 * 60, useDownloadCache: false, downloadCacheDirectory: '', noLocalParserFallback: false, forceLocalParsoid: false, optimisationCacheUrl: '' });
+    const downloader = new Downloader({ mw, uaString: '', speed: 1, reqTimeout: 1000 * 60, useDownloadCache: false, downloadCacheDirectory: '', noLocalParserFallback: false, forceLocalParser: false, optimisationCacheUrl: '' });
 
     await mw.getMwMetaData(downloader);
     await downloader.checkCapabilities();

--- a/test/util.ts
+++ b/test/util.ts
@@ -31,7 +31,7 @@ export async function setupScrapeClasses({ mwUrl = 'https://en.wikipedia.org', f
         base: mwUrl,
     } as any);
 
-    const downloader = new Downloader({ mw, uaString: '', speed: 1, reqTimeout: 1000 * 60, useDownloadCache: false, downloadCacheDirectory: `cac/dumps-${Date.now()}/`, noLocalParserFallback: false, forceLocalParsoid: false, optimisationCacheUrl: '' });
+    const downloader = new Downloader({ mw, uaString: '', speed: 1, reqTimeout: 1000 * 60, useDownloadCache: false, downloadCacheDirectory: `cac/dumps-${Date.now()}/`, noLocalParserFallback: false, forceLocalParser: false, optimisationCacheUrl: '' });
 
     await mw.getMwMetaData(downloader);
     await downloader.checkCapabilities();


### PR DESCRIPTION
Fixes #1152.

Note: this flag had no effect and has no effect so far. We need to refactor parameters seriously (starting from how they are being used currently - we can get this info using `schedules` from zimfarm API - then remove odd/unused and simplify them) - not only rename them selectively.