### PR TITLE
Use internal redis by default on container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,4 +26,9 @@ RUN npm i -g .
 WORKDIR /
 RUN mv /root/.bashrc /root/.old-bashrc
 COPY docker/.custom-bashrc /root/.bashrc
+
+ENV REDIS /dev/shm/redis.sock
+RUN printf '#!/bin/bash\n/usr/local/bin/mwoffliner --redis=$REDIS "$@"' > /usr/local/sbin/mwoffliner
+RUN chmod +x /usr/local/sbin/mwoffliner
+
 CMD mwoffliner


### PR DESCRIPTION
New change to mwoffliner's default configuration is to use redis on localhost and its
standard 6379 port.
That is good for pure mwoffliner users but as we provide a container with bundled redis
for convenience, it's unexpected to have to specify the redis socket when using it.

This fixes it by creating a `/usr/local/sbin/mwoffliner` script (which as precedence over the real one)
which calls `/usr/local/bin/mwoffliner` (the real one) with `--redis=$REDIS` and the rest
of the passed arguments.

`$REDIS` is a docker-level environ set to the redis socket but can be overridden.

Default usage is thus as was precedently:

    docker run openzim/mwoffliner mwoffliner --help

Using another redis instance:

    docker run -e REDIS="//redishost:redisport" openzim/mwoffliner mwoffliner --help

Specifying `--redis=` on the command line wouldn't work (mwoffliner then defaults to `localhost:6379`)
or would require invocating it via `/usr/local/bin/mwoffliner`