### PR TITLE
Fix etag mgmt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2209,12 +2209,11 @@
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
     },
     "axios": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
       "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
+        "follow-redirects": "1.5.10"
       },
       "dependencies": {
         "follow-redirects": {
@@ -2224,11 +2223,6 @@
           "requires": {
             "debug": "=3.1.0"
           }
-        },
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@types/yargs": "^12.0.12",
     "async": "^2.6.2",
     "aws-sdk": "^2.606.0",
-    "axios": "^0.18.1",
+    "axios": "^0.19.2",
     "backoff": "^2.5.0",
     "country-language": "^0.1.7",
     "deepmerge": "^3.3.0",

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -587,7 +587,7 @@ class Downloader {
     try {
       // TODO: remove when Axios can handle HTTP 304 properly
       // See: https://github.com/openzim/mwoffliner/issues/1184
-      delete requestOptions['headers']['accept-encoding'];
+      delete requestOptions.headers['accept-encoding'];
 
       this.s3.downloadBlob(stripHttpFromUrl(requestOptions.url)).then(async (imageResp) => {
         if (imageResp?.Metadata?.etag) {

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -197,7 +197,7 @@ class Downloader {
   }
 
   public checkAndReplaceWeakEtag(etag: string): string {
-    return WEAK_ETAG_REGEX.test(etag) ? etag.replace('W/', '').replace(/"/g, '') : etag;
+    return etag && etag.replace(WEAK_ETAG_REGEX, '');
   }
 
   public async initLocalServices(): Promise<void> {

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -196,7 +196,7 @@ class Downloader {
     return !!MIME_IMAGE_REGEX.exec(mimetype);
   }
 
-  public checkAndReplaceWeakEtag(etag: string): string {
+  public removeEtagWeakPrefix(etag: string): string {
     return etag && etag.replace(WEAK_ETAG_REGEX, '');
   }
 
@@ -591,7 +591,7 @@ class Downloader {
 
       this.s3.downloadBlob(stripHttpFromUrl(requestOptions.url)).then(async (imageResp) => {
         if (imageResp?.Metadata?.etag) {
-          requestOptions.headers['If-None-Match'] = this.checkAndReplaceWeakEtag(imageResp.Metadata.etag);
+          requestOptions.headers['If-None-Match'] = this.removeEtagWeakPrefix(imageResp.Metadata.etag);
         }
 
         const resp = await axios(requestOptions);
@@ -605,7 +605,7 @@ class Downloader {
         }
 
         // Check for the etag and upload
-        const etag = this.checkAndReplaceWeakEtag(resp.headers.etag);
+        const etag = this.removeEtagWeakPrefix(resp.headers.etag);
         if (etag) {
           this.s3.uploadBlob(stripHttpFromUrl(requestOptions.url), resp.data, etag);
         }

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -585,6 +585,10 @@ class Downloader {
 
   private async downloadImage(requestOptions: any, handler: any) {
     try {
+      // TODO: remove when Axios can handle HTTP 304 properly
+      // See: https://github.com/openzim/mwoffliner/issues/1184
+      delete requestOptions['headers']['accept-encoding'];
+
       this.s3.downloadBlob(stripHttpFromUrl(requestOptions.url)).then(async (imageResp) => {
         if (imageResp?.Metadata?.etag) {
           requestOptions.headers['If-None-Match'] = this.checkAndReplaceWeakEtag(imageResp.Metadata.etag);

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -6,4 +6,4 @@ export const CONCURRENCY_LIMIT = 10;
 export const MIME_IMAGE_REGEX = /^image+[/-\w.]+$/;
 export const FIND_HTTP_REGEX = /^(?:https?:\/\/)?/i;
 export const DB_ERROR = 'internal_api_error_DBQueryError';
-export const WEAK_ETAG_REGEX = /^W\//;
+export const WEAK_ETAG_REGEX = /^(W\/)/;

--- a/test/unit/downloader.test.ts
+++ b/test/unit/downloader.test.ts
@@ -195,14 +195,14 @@ _test('Downloader class with optimisation', async (t) => {
 
         // Download the uploaded image from S3 and check the Etags
         const imageContent =  await s3.downloadBlob(imagePath);
-        t.equal(downloader.checkAndReplaceWeakEtag(resp.headers.etag), imageContent.Metadata.etag, 'Etag Matched from online Mediawiki and S3');
+        t.equal(downloader.removeEtagWeakPrefix(resp.headers.etag), imageContent.Metadata.etag, 'Etag Matched from online Mediawiki and S3');
 
         // Upload Image with wrong Etag
         await s3.uploadBlob(imagePath, resp.data, 'random-string');
 
         // Download again to check the Etag has been refreshed properly
         const updatedImage = await s3.downloadBlob(imagePath);
-        t.equal(updatedImage.Metadata.etag,  downloader.checkAndReplaceWeakEtag(resp.headers.etag), 'Image refreshed with proper Etag');
+        t.equal(updatedImage.Metadata.etag,  downloader.removeEtagWeakPrefix(resp.headers.etag), 'Image refreshed with proper Etag');
     }, 5000)
 });
 


### PR DESCRIPTION
By investigating #1184 I discovered a bug in the ETAG mgmt. Like explained here https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag, the quotes are parts of the ETAG. If you make a GET request without the quote where you have an etag with quotes, you won't get HTTP 304. On the top of this, it seems that Wikimedia servers have a bug as well as not all ETAG have quotes, I have reported here https://phabricator.wikimedia.org/T256217.