### PR TITLE
Add Image building on Github Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,27 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+
+jobs:
+  build-and-push:
+    name: Deploy Docker Image
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and push
+        uses: openzim/docker-publish-action@v1
+        with:
+          image-path: openzim/mwoffliner
+          on-master: dev
+          tag-pattern: /^v([0-9.]+)$/
+          latest-on-tag: true
+          restrict-to: openzim/mwoffliner
+          hub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          hub-password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          ghcr-username: ${{ secrets.GHCR_USERNAME }}
+          ghcr-token: ${{ secrets.GHCR_TOKEN }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
 FROM openzim/node-redis:14-6
+LABEL org.opencontainers.image.source https://github.com/openzim/mwoffliner
 
 # Install dependences
 RUN apt-get update && \


### PR DESCRIPTION
This workflow will build mwoffliner's Docker Image on Github Actions, according to
our process:

- will build and push `:dev` on every commit to master
- will build and push to `:latest` and `:<tag>` on every tag
- will push to both Docker Hub and GHCR (Github Container Registry)

It uses the secrets already set on the `openzim` organization. It won't run on forks.

Didn't include the node-redis image creation as this is not public-facing and only
used for building mwoffliner.

Please check https://github.com/openzim/docker-publish-action for details on the action.