### PR TITLE
Added --webpCache flag

### DIFF
--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -629,7 +629,6 @@ class Downloader {
           webpFullPath = path.join(this.webpCache, webpFilename);
 
           if (fs.existsSync(webpFullPath)) {
-            console.log('   -- webp exists!');
             try {
               resp.data = fs.readFileSync(webpFullPath);
               resp.headers['content-type'] = 'image/webp';

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -77,7 +77,7 @@ interface DownloaderOpts {
   optimisationCacheUrl: string;
   s3?: S3;
   webp: boolean;
-  webpCache: string;
+  webpCache?: string;
   backoffOptions?: BackoffOptions;
 }
 
@@ -618,14 +618,14 @@ class Downloader {
           !this.cssDependenceUrls.hasOwnProperty(resp.config.url)) {
         let webpFilename = ''; // init as empty. Only filled out if webpCache is used. needs to be in this scope.
         let webpFullPath = '';
-        
+
         if (this.webpCache) {
           /* a hash is generated based on the url. This ensures queries with queryParams recieve
           their own file, solves the issue of unsafe chars and collisions after cleaning said chars.
           Speed improvements of exist()/existSync() **should** be seen, as long-similar-names increase
-          tree traversal time. Crypto is a built-in node lib and is incredibly fast. Will not be a 
+          tree traversal time. Crypto is a built-in node lib and is incredibly fast. Will not be a
           bottleneck */
-          webpFilename = crypto.createHash("sha1").update(resp.config.url).digest("hex");
+          webpFilename = crypto.createHash('sha1').update(resp.config.url).digest('hex');
           webpFullPath = path.join(this.webpCache, webpFilename);
 
           if (fs.existsSync(webpFullPath)) {

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -634,6 +634,7 @@ class Downloader {
               resp.data = fs.readFileSync(webpFullPath);
               resp.headers['content-type'] = 'image/webp';
               resp.headers.path_postfix = '.webp';
+              resp.headers.server = 'webpCache';
 
               return true;
             } catch (err) {
@@ -658,7 +659,7 @@ class Downloader {
         })
         .then((data) => {
           resp.headers['content-type'] = 'image/webp';
-          
+
           if (webpCache) {
             try {
               fs.writeFileSync(webpFullPath, data);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,7 +57,6 @@ if (argv.osTmpDir) {
 /* ***********************/
 if (argv.webpCache) {
   const webpCache = argv.webpCache as string;
-  console.log('webpcache string', webpCache)
 
   try {
     if (!fs.statSync(webpCache)) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,6 +53,24 @@ if (argv.osTmpDir) {
 }
 
 /* ***********************/
+/* ENSURE VALID WEBPCACHE*/
+/* ***********************/
+if (argv.webpCache) {
+  const webpCache = argv.webpCache as string;
+  console.log('webpcache string', webpCache)
+
+  try {
+    if (!fs.statSync(webpCache)) {
+      console.log('returned no')
+      throw new Error();
+    }
+  } catch {
+    console.error(`--webpCache value [${webpCache}] is not valid\n  tip: ensure the directory already exists. It will not be made automatically.`);
+    process.exit(2);
+  }
+}
+
+/* ***********************/
 /* TESTING ALL ARGUMENTS */
 /* ***********************/
 

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -101,6 +101,7 @@ async function execute(argv: any) {
     customZimTags,
     withoutZimFullTextIndex,
     webp,
+    webpCache,
     format,
     filenamePrefix,
     resume,
@@ -185,6 +186,7 @@ async function execute(argv: any) {
     optimisationCacheUrl,
     s3,
     webp,
+    webpCache,
   });
 
   /* perform login */

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -29,6 +29,7 @@ export const parameterDescriptions = {
   verbose: 'Print debug information to the stdout',
   withoutZimFullTextIndex: 'Don\'t include a fulltext search index to the ZIM',
   webp: 'Convert all jpeg, png and gif images to webp format',
+  webpCache: 'Save webp to directory upon conversion; load webp from directory instead of converting (if available)',
   addNamespaces: 'Force additional namespace (comma separated numbers)',
   getCategories: '[WIP] Download category pages',
   noLocalParserFallback: 'Don\'t fall back to a local MCS or Parsoid, only use remote APIs',

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -116,9 +116,6 @@ async function downloadBulk(listOfArguments: any[], downloader: Downloader): Pro
                 resp.namespace = arg.val.namespace;
                 resp.mult = arg.val.mult;
                 resp.width = arg.val.width;
-                
-                // notes: downloadContent has the convertion to webp baked in
-                // go directly to getContentCb
                 return downloader.downloadContent(arg.val.url).then((r) => {
                     resp.result = r;
                     resp.path += resp.result.responseHeaders.path_postfix || '';

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -116,6 +116,7 @@ async function downloadBulk(listOfArguments: any[], downloader: Downloader): Pro
                 resp.namespace = arg.val.namespace;
                 resp.mult = arg.val.mult;
                 resp.width = arg.val.width;
+
                 return downloader.downloadContent(arg.val.url).then((r) => {
                     resp.result = r;
                     resp.path += resp.result.responseHeaders.path_postfix || '';

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -116,7 +116,9 @@ async function downloadBulk(listOfArguments: any[], downloader: Downloader): Pro
                 resp.namespace = arg.val.namespace;
                 resp.mult = arg.val.mult;
                 resp.width = arg.val.width;
-
+                
+                // notes: downloadContent has the convertion to webp baked in
+                // go directly to getContentCb
                 return downloader.downloadContent(arg.val.url).then((r) => {
                     resp.result = r;
                     resp.path += resp.result.responseHeaders.path_postfix || '';

--- a/test/unit/downloader.test.ts
+++ b/test/unit/downloader.test.ts
@@ -21,7 +21,7 @@ test('Downloader class', async (t) => {
 
     const cacheDir = `cac/dumps-${Date.now()}/`;
     await mkdirPromise(cacheDir);
-    const downloader = new Downloader({ mw, uaString: '', speed: 1, reqTimeout: 1000 * 60, noLocalParserFallback: false, forceLocalParser: false, webp: true, optimisationCacheUrl: '' });
+    const downloader = new Downloader({ mw, uaString: '', speed: 1, reqTimeout: 1000 * 60, noLocalParserFallback: false, forceLocalParser: false, webp: true, webpCache: '', optimisationCacheUrl: '' });
 
     await mw.getMwMetaData(downloader);
     await downloader.checkCapabilities();
@@ -167,7 +167,7 @@ _test('Downloader class with optimisation', async (t) => {
         keyId: process.env.KEY_ID_TEST,
         secretAccessKey: process.env.SECRET_ACCESS_KEY_TEST,
     });
-    const downloader = new Downloader({ mw, uaString: '', speed: 1, reqTimeout: 1000 * 60, noLocalParserFallback: false, forceLocalParser: false, webp: false, optimisationCacheUrl: 'random-string' , s3});
+    const downloader = new Downloader({ mw, uaString: '', speed: 1, reqTimeout: 1000 * 60, noLocalParserFallback: false, forceLocalParser: false, webp: false, webpCache: '', optimisationCacheUrl: 'random-string' , s3});
 
     await s3.initialise();
 


### PR DESCRIPTION
WebP conversion is probably the longest aspect of the zim building process. My team and I often find ourselves creating multiple subsets of zims (10k, 100k, 300k, 500k) in one go. It is unfortunate that the same inclusive images have to be converted once again. When  using mwoffliner for experimental websites, on bad internet or on a poor CPU, caching provides the most benefit.

I added this flag as an advanced option for those who wish to utilize a webp cache. During times when **massive** zims are being built, a failure on a 2-5 day build is devastating. Any recovery of time helps a lot. Considering that images can never be updated on wikimedias, the "validity" of cache shouldn't expire. (An updated image creates a new URI resource. Unlike articles which occurs under the same URI). 

The cached webp images are saved by their URI, so an image queried with with 2 different sets of query parameters will result in two cached images.

**Comparison Results**
_left time: no cache. Right time: same zim parameters, with cache._
100 articles = 00:00:40 -> 00:00:13
1000 articles = 00:27:54 -> 00:08:31
10k articles = WIP

The benefit is comes into play when you daisy chain down. First make a 500k article zim, then a 300k, a 100k, a 10k, 1k all with significant stacked savings.