### PR TITLE
Modification to allow s3-cache connection to non-SSL

### DIFF
--- a/src/S3.ts
+++ b/src/S3.ts
@@ -21,6 +21,7 @@ class S3 {
             endpoint: s3UrlBase,
             accessKeyId: this.params.keyId,
             secretAccessKey: this.params.secretAccessKey,
+            s3ForcePathStyle: s3UrlBase.protocol === 'http:',
         });
         try {
             if (await this.bucketExists(this.bucketName) === true) {

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -151,7 +151,7 @@ async function execute(argv: any) {
     // Decompose the url with path and other S3 creds
     const s3UrlObj = urlParser.parse(optimisationCacheUrl);
     const queryReader = QueryStringParser.parse(s3UrlObj.query);
-    const s3Url = (s3UrlObj.host || '') + (s3UrlObj.pathname || '');
+    const s3Url = (s3UrlObj.protocol || 'https:') + '//' + (s3UrlObj.host || '') + (s3UrlObj.pathname || '');
     this.s3Obj = new S3(s3Url, queryReader);
     await this.s3Obj.initialise().then(() => {
       logger.log('Successfully logged in S3');

--- a/src/sanitize-argument.ts
+++ b/src/sanitize-argument.ts
@@ -40,8 +40,9 @@ export async function sanitize_all(argv: any) {
     if (optimisationCacheUrl) {
       // Decompose the url with path and other S3 creds
       const s3UrlObj = urlParser.parse(optimisationCacheUrl);
+      console.log('s3UrlObj', s3UrlObj);
       const queryReader = QueryStringParser.parse(s3UrlObj.query);
-      const s3Url = (s3UrlObj.host || '') + (s3UrlObj.pathname || '');
+      const s3Url = (s3UrlObj.protocol || 'https:') + '//' + (s3UrlObj.host || '') + (s3UrlObj.pathname || '');
       this.s3Obj = new S3(s3Url, queryReader);
       await this.s3Obj.initialise().then(() => {
         logger.log('Successfully logged in S3');

--- a/src/sanitize-argument.ts
+++ b/src/sanitize-argument.ts
@@ -40,7 +40,6 @@ export async function sanitize_all(argv: any) {
     if (optimisationCacheUrl) {
       // Decompose the url with path and other S3 creds
       const s3UrlObj = urlParser.parse(optimisationCacheUrl);
-      console.log('s3UrlObj', s3UrlObj);
       const queryReader = QueryStringParser.parse(s3UrlObj.query);
       const s3Url = (s3UrlObj.protocol || 'https:') + '//' + (s3UrlObj.host || '') + (s3UrlObj.pathname || '');
       this.s3Obj = new S3(s3Url, queryReader);


### PR DESCRIPTION
The docker version of S3(minIO) works very well with mwoffliner. The only problem is that the URL passed into the endpoint creation method is implicit. So https is set as the default. Without fixing this, connecting to non-SSL (http) is impossible.

Related to issue: https://github.com/openzim/mwoffliner/issues/1344
