### PR TITLE
correcting the failing process for downloading articles

### DIFF
--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -256,7 +256,7 @@ export async function saveArticles(zimCreator: ZimCreator, downloader: Downloade
                 } catch (err) {
                     dump.status.articles.fail += 1;
                     logger.error(`Error downloading article ${articleId}`);
-                    if (err.response.status !== 404) {
+                    if (!err.response || err.response.status !== 404) {
                         throw err;
                     }
                 }


### PR DESCRIPTION
@kelson42 this is to handle the error properly in case the error doesn't have any response part it should fail and if it has a response part it should be checked that the status code is not 404.