### PR TITLE
Fix Downloader.ts so it stops losing thumbnails. This puts attractive graphics on ZIM files' main pages.

### DIFF
--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -516,7 +516,7 @@ class Downloader {
       coordinates: ['coordinates'],
       categories: ['categories'],
     };
-    const keysToKeep: string[] = ['subCategories', 'revisions']
+    const keysToKeep: string[] = ['subCategories', 'revisions', 'thumbnail']
       .concat(
         Object.keys(cont).reduce((acc, key) => acc.concat(propsMap[key] || []), []),
       );


### PR DESCRIPTION
With this PR fix, mwoffliner stops putting very obscure[1] article thumbnails on ZIM files' main page &mdash; which teachers and students do not like &mdash; as compared to "top-ranked" articles and their thumbnails.

Problem: currently mwoffliner loses article thumbnails in situations where even a single Wikipedia article has lots of redirects[2] which induces secondary "continue" calls to MediaWiki's API.

This PR has been tested to fix all these problems.  Example: if using [200.tsv](https://paste.ubuntu.com/p/9hvfMR3Zff/
) as input from http://download.openzim.org/wp1/enwiki_2021-02/tops/ (essentially, these are the 200 "topmost" articles from English Wikipedia) then mwoffliner run with this PR produces...a graphical-instead-of-textual main page...which is displayed live here: http://iiab.me/kiwix/wp_en_test_200_list_maxi_2021-02/ (i.e. wp_en_test_200_list_maxi_2021-02.zim)

Conclusion: With this PR fix, mwoffliner now correctly puts the 100 "top-ranked" articles-with-thumbnails on any ZIM file's main page &mdash; based on the ordering of articles specified by mwoffliner parameter [--articleList](https://github.com/openzim/mwoffliner/blob/master/src/parameterList.ts#L6).  The 100 resulting from the above example are listed here: https://paste.ubuntu.com/p/RYDnQkDyQ3/
<BR>
[1] Thumbnails are from articles ranked about 20,000 from the top, when mwoffliner (without this PR) runs on English Wikipedia.  Recap: without this PR, mwoffliner loses the thumbnails for all highly-ranked articles, due to the large size of their MediaWiki API results.

This problem also greatly affects many/most of the ~100,000 most highly ranked articles &mdash; i.e. especially if they are ranked right nearby an article having lots of inbound redirects like [[Timeline_of_the_far_future]] summarized below.
<BR>
[2] e.g. https://en.wikipedia.org/wiki/Timeline_of_the_far_future (which is currently the 179th "topmost" article in English Wikipedia) currently has 558 redirects leading to it, as seen in https://en.wikipedia.org/w/api.php?action=query&prop=redirects&titles=Timeline_of_the_far_future&rdlimit=max (which only shows the 1st 500 of 558, hence the need for another MediaWiki API call!)

Even lowering MAX_BATCH_SIZE = 50 (all the way to MAX_BATCH_SIZE = 1) at https://github.com/openzim/mwoffliner/blob/master/src/util/mw-api.ts#L10 does not help to avoid losing thumbnails, in the case of articles that return extensive metadata (e.g. lots of redirects) from MediaWiki's API.