### PR TITLE
Better WebP polyfill

### DIFF
--- a/res/script.js
+++ b/res/script.js
@@ -28,35 +28,19 @@ window.onload = function () {
 }
 
 /* WebP Polyfill */
-var webHeroScripts = ['../-/webpHeroPolyfill.js',
-                      '../-/webpHeroBundle.js'];
-
-var testWebP = function(callback) {
-    var webP = new Image();
-    webP.onload = webP.onerror = function () {
-        callback(webP.height === 2);
-    };
-    webP.src = 'data:image/webp;base64,UklGRjoAAABXRUJQVlA4IC4AAACyAgCdASoCAAIALmk0mk0iIiIiIgBoSygABc6WWgAA/veff/0PP8bA//LwYAAA';
-};
-
-var startWebpMachine = function() {
-    var newScript = document.createElement('script');
-    var inlineScript = document.createTextNode('var webpMachine = new webpHero.WebpMachine(); webpMachine.polyfillDocument()');
-    newScript.appendChild(inlineScript);
-    document.getElementsByTagName('body')[0].appendChild(newScript);
-};
-
-testWebP(function(support) {
-    if (!support) {
-        webHeroScripts.forEach(function(scriptUrl) {
-            var script = document.createElement('script');
-            script.type = 'text/javascript';
-            script.src = typeof(articleId) ? '../'.repeat(articleId.split('/').length - 1) + scriptUrl : scriptUrl;
-            if (webHeroScripts[webHeroScripts.length-1] === scriptUrl) {
-                // Start webpMachine if we have loaded the last script
-                script.onload = startWebpMachine;
-            }
-            document.getElementsByTagName('body')[0].appendChild(script);
-        });
-    }
+var webpScripts = ['../-/webpHeroPolyfill.js',
+                   '../-/webpHeroBundle.js',
+                   '../-/webpHandler.js'];
+webpScripts = webpScripts.map(function(scriptUrl) {
+    return (typeof(articleId)) ? '../'.repeat(articleId.split('/').length - 1) + scriptUrl : scriptUrl;
 });
+var script = document.createElement('script');
+script.type = 'text/javascript';
+script.src = webpScripts.pop();;
+script.onload = function () {
+    new WebPHandler({
+        scripts_urls: webpScripts,
+        on_ready: function (handler) { handler.polyfillDocument(); },
+    });
+}
+document.getElementsByTagName('head')[0].appendChild(script);

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -15,3 +15,4 @@ export const WEBP_CANDIDATE_IMAGE_MIME_TYPE = /image+[/]+(jpeg|png)/;
 export const DEFAULT_WIKI_PATH = 'wiki/';
 export const ALL_READY_FUNCTION = /function allReady\( modules \) {/;
 export const DO_PROPAGATION = /mw\.requestIdleCallback\( doPropagation, \{ timeout: 1 \} \);/;
+export const WEBP_HANDLER_URL = 'https://gist.githubusercontent.com/rgaudin/60bb9cc6f187add506584258028b8ee1/raw/9d575b8e25d67eed2a9c9a91d3e053a0062d2fc7/web-handler.js';

--- a/src/util/dump.ts
+++ b/src/util/dump.ts
@@ -11,7 +11,7 @@ import { ZimCreator, ZimArticle } from '@openzim/libzim';
 import { Dump } from '../Dump';
 import { filesToDownloadXPath } from '../stores';
 import fs from 'fs'
-import { DO_PROPAGATION, ALL_READY_FUNCTION } from './const';
+import { DO_PROPAGATION, ALL_READY_FUNCTION, WEBP_HANDLER_URL } from './const';
 
 export async function getAndProcessStylesheets(downloader: Downloader, links: Array<string | DominoElement>) {
     let finalCss = '';
@@ -149,8 +149,7 @@ export async function importPolyfillModules(zimCreator: ZimCreator) {
         zimCreator.addArticle(article);
     });
 
-    const webpHandlerUrl = 'https://gist.githubusercontent.com/rgaudin/60bb9cc6f187add506584258028b8ee1/raw/9d575b8e25d67eed2a9c9a91d3e053a0062d2fc7/web-handler.js';
-    const content = await axios.get(webpHandlerUrl, {headers: {}, responseType: 'arraybuffer', timeout: 60000, method: 'GET', validateStatus(status) { return (status >= 200 && status < 300) || status === 304; }})
+    const content = await axios.get(WEBP_HANDLER_URL, {responseType: 'arraybuffer', timeout: 60000, validateStatus(status) { return ([200, 302, 304].indexOf(status) > -1); }})
         .then((a) => a.data)
         .catch((err) => {
           throw new Error(`Failed to download webpHandler from [${webpHandlerUrl}]: ${err}`);

--- a/src/util/dump.ts
+++ b/src/util/dump.ts
@@ -2,6 +2,7 @@ import urlParser from 'url';
 import * as pathParser from 'path';
 import async from 'async';
 import logger from '../Logger';
+import axios from 'axios';
 import Downloader from '../Downloader';
 import { getFullUrl, jsPath, cssPath } from '.';
 import { config } from '../config';
@@ -147,4 +148,18 @@ export async function importPolyfillModules(zimCreator: ZimCreator) {
         });
         zimCreator.addArticle(article);
     });
+
+    const webpHandlerUrl = 'https://gist.githubusercontent.com/rgaudin/60bb9cc6f187add506584258028b8ee1/raw/9d575b8e25d67eed2a9c9a91d3e053a0062d2fc7/web-handler.js';
+    const content = await axios.get(webpHandlerUrl, {headers: {}, responseType: 'arraybuffer', timeout: 60000, method: 'GET', validateStatus(status) { return (status >= 200 && status < 300) || status === 304; }})
+        .then((a) => a.data)
+        .catch((err) => {
+          throw new Error(`Failed to download webpHandler from [${webpHandlerUrl}]: ${err}`);
+        });
+
+    const article = new ZimArticle({
+        url: jsPath('webpHandler'),
+        data: content,
+        ns: '-'
+    });
+    zimCreator.addArticle(article);
 }


### PR DESCRIPTION
The Webp Hero polyfill has a major drawback: it can only convert a WebP at once.
It seems to be a limitation of the emscripten-based libwebp but Webp Hero doesn't do
much about it except throwing an exception.
Given the `polyfillDocument()` method iterates over all `<img />` of the document
to request convertion, it can be very frequent that images are not decoded and thus
just skipped.

The actual behavior is unpredictable as it depends a lot on how quickly the DOM is parsed
by the browser. I believe using lazy loading really helped in the case of mwoffliner
as images are frequently scattered around the page and thus not loaded alltogether.

This replaces the use of the WebPMachine from Webp Hero by a custom one that decodes
one by one (using Webp Hero's code) using a pending list.
It's quite naive but seems to do the job.

This Handler's code currently reside in a gist and is thus downloaded from there.
I've noticed there is no other such dependency in mwoffliner, so if you think it should
be published as a regular npm lib, we can go down this extra road. Let me know