### PR TITLE
corrected tree structure for sections

### DIFF
--- a/res/templates/section_wrapper.html
+++ b/res/templates/section_wrapper.html
@@ -1,4 +1,4 @@
-<details data-level="2" open>
+<details data-level="{{ section_index }}" open>
     <summary class='section-heading'><h2 id="{{ section_anchor }}">{% autoescape false %}{{ section_line }}{% endautoescape %}</h2></summary>
     {% autoescape false %}{{ section_text }}{% endautoescape %}
     __SUB_LEVEL_SECTION_{{ section_index }}__

--- a/res/templates/section_wrapper.html
+++ b/res/templates/section_wrapper.html
@@ -3,3 +3,4 @@
     {% autoescape false %}{{ section_text }}{% endautoescape %}
     __SUB_LEVEL_SECTION_{{ section_index }}__
 </details>
+__SAME_LEVEL_SECTION_{{ section_index }}__

--- a/res/templates/section_wrapper.html
+++ b/res/templates/section_wrapper.html
@@ -3,4 +3,3 @@
     {% autoescape false %}{{ section_text }}{% endautoescape %}
     __SUB_LEVEL_SECTION_{{ section_index }}__
 </details>
-__SAME_LEVEL_SECTION_{{ section_index }}__

--- a/res/templates/subsection_wrapper.html
+++ b/res/templates/subsection_wrapper.html
@@ -1,5 +1,0 @@
-<details data-level="{{ section_toclevel }}" open>
-    <summary class='section-heading'><h{{ section_toclevel }} id="{{ section_anchor }}">{% autoescape false %}{{ section_line }}{% endautoescape %}</h{{ section_toclevel }}></summary>
-    {% autoescape false %}{{ section_text }}{% endautoescape %}
-</details>
-__SUB_LEVEL_SECTION_{{ section_index }}__

--- a/src/Templates.ts
+++ b/src/Templates.ts
@@ -12,7 +12,6 @@ function readTemplate(t: string) {
 const footerTemplate = swig.compile(readTemplate(config.output.templates.footer));
 const leadSectionTemplate = swig.compile(readTemplate(config.output.templates.lead_section_wrapper));
 const sectionTemplate = swig.compile(readTemplate(config.output.templates.section_wrapper));
-const subSectionTemplate = swig.compile(readTemplate(config.output.templates.subsection_wrapper));
 const categoriesTemplate = swig.compile(readTemplate(config.output.templates.categories));
 const subCategoriesTemplate = swig.compile(readTemplate(config.output.templates.subCategories));
 const subPagesTemplate = swig.compile(readTemplate(config.output.templates.subPages));
@@ -37,7 +36,6 @@ export {
     footerTemplate,
     leadSectionTemplate,
     sectionTemplate,
-    subSectionTemplate,
     htmlTemplateCode,
     articleListHomeTemplate,
     categoriesTemplate,

--- a/src/config.ts
+++ b/src/config.ts
@@ -100,10 +100,7 @@ const config = {
       lead_section_wrapper: './templates/lead_section_wrapper.html',
 
       /* Template for wrapping all other toplevel sections */
-      section_wrapper: './templates/section_wrapper.html',
-
-      /* Template for wrapping subsections */
-      subsection_wrapper: './templates/subsection_wrapper.html',
+      section_wrapper: './templates/section_wrapper.html'
     },
   },
 };

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -5,8 +5,8 @@ import tmp from 'tmp';
 import pathParser from 'path';
 import { sanitize_customFlavour } from 'src/sanitize-argument';
 import { encodeArticleIdForZimHtmlUrl, interpolateTranslationString, getFullUrl } from 'src/util';
-import { testHtmlRewritingE2e } from 'test/util';
-import { getMediaBase, normalizeMwResponse, getSectionHtml } from '../../src/util/';
+import { testHtmlRewritingE2e, sectionGenerator } from 'test/util';
+import { getMediaBase, normalizeMwResponse, getSectionsHtml } from '../../src/util/';
 import axios from 'axios';
 import { Dump } from '../../src/Dump';
 
@@ -46,45 +46,15 @@ test('Encoding ArticleId for Zim HTML Url', async(t) => {
 
 test('Article section rendering', async (t) => {
     const dump: Dump = new Dump('', {} as any, {} as any);
-    const sections = [
-        {
-          id: 1,
-          text: 'level 1',
-          toclevel: 1,
-          line: 'Approximate Hamiltonians',
-          anchor: 'Approximate_Hamiltonians'
-        },
-        {
-          id: 2,
-          text: 'level 1',
-          toclevel: 1,
-          line: 'Applying perturbation theory',
-          anchor: 'Applying_perturbation_theory'
-        },
-        {
-          id: 3,
-          text: 'level 2',
-          toclevel: 2,
-          line: 'Limitations',
-          anchor: 'Limitations'
-        },
-        {
-          id: 4,
-          text: 'level 3',
-          toclevel: 3,
-          line: 'Large perturbations',
-          anchor: 'Large_perturbations'
-        },
-        {
-          id: 5,
-          text: 'level 3',
-          toclevel: 3,
-          line: 'Non-adiabatic states',
-          anchor: 'Non-adiabatic_states'
-        }
-    ];
-    t.equal(getSectionHtml(sections, 1, dump), `<details data-level="2" open>\n    <summary class=\'section-heading\'><h2 id="Approximate_Hamiltonians">Approximate Hamiltonians</h2></summary>\n    level 1\n    \n</details><details data-level="2" open>\n    <summary class=\'section-heading\'><h2 id="Applying_perturbation_theory">Applying perturbation theory</h2></summary>\n    level 1\n    <details data-level="2" open>\n    <summary class=\'section-heading\'><h2 id="Limitations">Limitations</h2></summary>\n    level 2\n    <details data-level="2" open>\n    <summary class=\'section-heading\'><h2 id="Large_perturbations">Large perturbations</h2></summary>\n    level 3\n    \n</details><details data-level="2" open>\n    <summary class=\'section-heading\'><h2 id="Non-adiabatic_states">Non-adiabatic states</h2></summary>\n    level 3\n    \n</details>\n</details>\n</details>`,
-        'Tree structure in article sections');
+    [
+        [1, 1, 1, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1, 1, 4],
+        [1, 4, 1, 4, 1, 4, 1],
+        [4, 4, 4, 4, 4, 4, 4],
+        [4, 1, 4, 1, 4, 1, 4]
+    ].forEach((sectionList: number[]) => {
+        t.equal(getSectionsHtml(sectionGenerator(sectionList), dump).match(/<\/h2>/g).length, sectionList.length, 'Tree structure in article sections');
+    });
 });
 
 test('wikitext comparison', async(t) => {

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -6,8 +6,9 @@ import pathParser from 'path';
 import { sanitize_customFlavour } from 'src/sanitize-argument';
 import { encodeArticleIdForZimHtmlUrl, interpolateTranslationString, getFullUrl } from 'src/util';
 import { testHtmlRewritingE2e } from 'test/util';
-import { getMediaBase, normalizeMwResponse } from '../../src/util/';
+import { getMediaBase, normalizeMwResponse, getSectionHtml } from '../../src/util/';
 import axios from 'axios';
+import { Dump } from '../../src/Dump';
 
 test('util -> interpolateTranslationString', async (t) => {
     t.equals(interpolateTranslationString('Hello world', {}), 'Hello world');
@@ -41,6 +42,49 @@ test('Encoding ArticleId for Zim HTML Url', async(t) => {
         const   encoded = articles.shift();
         t.equal(encoded, encodeArticleIdForZimHtmlUrl(unencoded), `encodeArticleIdForZimHtmlUrl() encoding`);
     }
+});
+
+test('Article section rendering', async (t) => {
+    const dump: Dump = new Dump('', {} as any, {} as any);
+    const sections = [
+        {
+          id: 1,
+          text: 'level 1',
+          toclevel: 1,
+          line: 'Approximate Hamiltonians',
+          anchor: 'Approximate_Hamiltonians'
+        },
+        {
+          id: 2,
+          text: 'level 1',
+          toclevel: 1,
+          line: 'Applying perturbation theory',
+          anchor: 'Applying_perturbation_theory'
+        },
+        {
+          id: 3,
+          text: 'level 2',
+          toclevel: 2,
+          line: 'Limitations',
+          anchor: 'Limitations'
+        },
+        {
+          id: 4,
+          text: 'level 3',
+          toclevel: 3,
+          line: 'Large perturbations',
+          anchor: 'Large_perturbations'
+        },
+        {
+          id: 5,
+          text: 'level 3',
+          toclevel: 3,
+          line: 'Non-adiabatic states',
+          anchor: 'Non-adiabatic_states'
+        }
+    ];
+    t.equal(getSectionHtml(sections, 1, dump), `<details data-level="2" open>\n    <summary class=\'section-heading\'><h2 id="Approximate_Hamiltonians">Approximate Hamiltonians</h2></summary>\n    level 1\n    \n</details><details data-level="2" open>\n    <summary class=\'section-heading\'><h2 id="Applying_perturbation_theory">Applying perturbation theory</h2></summary>\n    level 1\n    <details data-level="2" open>\n    <summary class=\'section-heading\'><h2 id="Limitations">Limitations</h2></summary>\n    level 2\n    <details data-level="2" open>\n    <summary class=\'section-heading\'><h2 id="Large_perturbations">Large perturbations</h2></summary>\n    level 3\n    \n</details><details data-level="2" open>\n    <summary class=\'section-heading\'><h2 id="Non-adiabatic_states">Non-adiabatic states</h2></summary>\n    level 3\n    \n</details>\n</details>\n</details>`,
+        'Tree structure in article sections');
 });
 
 test('wikitext comparison', async(t) => {

--- a/test/util.ts
+++ b/test/util.ts
@@ -85,3 +85,15 @@ export async function testHtmlRewritingE2e(t: any, wikicode: string, html: strin
     const resultHtml = await convertWikicodeToHtml(wikicode, 'https://en.wikipedia.org/');
     t.equal(html, resultHtml.data, comment);
 }
+
+export function sectionGenerator(sectionList: number[]) {
+    return sectionList.map((tocLevel: number, index: number) => {
+        return {
+            'id': index,
+            'toclevel': tocLevel,
+            'anchor': tocLevel,
+            'line': tocLevel,
+            'text': tocLevel
+        };
+    });
+}


### PR DESCRIPTION
@kelson42 this fixes #1501, fixes #1501.
The main approach used here is a bit complex I will elaborate it here in points for better understanding -
1) section template now has 2 anchors one for subsection addition another for same level anchor additions
2) I have used a stack to implement the tree structure, The sections received from API are in a specific tree structure order so if we consider various toclevel to be `1 1 2 1` for an example case, we can clearly use stack to store which parent sections are present for a specific sub-section so that we can close a section anchor and subsection anchors.
3) for the first section we receive I am directly adding it to HTML and pushing its toclevel to the stack so, according to our example HTML content would look like 
```
<>
section level 1 text
__SUB_LEVEL_SECTION_2__
</>
__SAME_LEVEL_SECTION_2__
```
and the stack is [1]
note - I am adding a level of an anchor with +1 to the current toclevel just so that I don't have to use another value in the template (it works fine according to test cases I created).
4) for any section which has the same value as the top of the stack I simply remove the sub-level section anchor as no other subsection could be created for that tag and we are moving on to fill the next tag so in our case. So In our case, HTML content would be like -
```
<>
section level 1 text
</>
<>
section level 1 text (2nd section)
__SUB_LEVEL_SECTION_2__
</>
__SAME_LEVEL_SECTION_2__
```
and the stack is [1]
for the same level, I am not pushing anything upon stack as for any level, we will only have one sub section anchor and one same level anchor to track so no need to push twice.
5) if a section has a value greater than the value at the top of the stack add it as a sub-section using the anchor tag and the value at the top of the stack refer -> L161 of `utils/articleRenderer.ts`.
so according to our example, HTML content will be like -
```
<>
section level 1 text
</>
<>
section level 1 text (2nd section)
    <>
         section level 2 text
         __SUB_LEVEL_SECTION_3__
    </>
    __SAME_LEVEL_SECTION_3__
</>
__SAME_LEVEL_SECTION_2__
```
and the stack is - [1, 2]
6) if a section has a value less than the value at the top of the stack it means for the current level there are no more sections that are on the same level or are the subsection under this parent so we remove the sub-level section anchor as well as same level section anchors and then use the above-mentioned condition in point 4 and 5 to create the tree structure further.
so according to our example, HTML content will be like - 
```
<>
section level 1 text
</>
<>
section level 1 text (2nd section)
    <>
         section level 2 text
    </>
</>
<>
section level 1 text(3rd section)
__SUB_LEVEL_SECTION_2__
</>
__SAME_LEVEL_SECTION_2__
```
and the stack is - 1
7) remove all remaining anchors using the remaining values in the stack.
P.S. - sorry for the detailed and long explanation😅, but I think was needed to keep my points clearly in one go.