### PR TITLE
config: add scripts for Wiktionary's show/hide toggles

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -63,7 +63,9 @@ const config = {
           'mediawiki.page.gallery.styles',
           'mediawiki.skinning.content.parsoid'].join('|'),
       ],
-      js: ['startup', 'jquery', 'mediawiki.base', 'site', 'mediawiki.util', 'mediawiki.page.ready'],
+      js: ['startup', 'jquery', 'mediawiki.base', 'site', 'mediawiki.util', 'mediawiki.page.ready',
+        'jquery.cookie', 'mediawiki.cookie', 'mediawiki.storage', 'ext.gadget.VisibilityToggles',
+        'ext.gadget.defaultVisibilityToggles'],
     },
 
     // Output directories for storing mw related js and css resources


### PR DESCRIPTION
This fixes #1033.

The `ext.gadget.VisibilityToggles` and `ext.gadget.defaultVisibilityToggles` only seem to exist on Wiktionary: when I tested with English Wiktionary, they fixed the toggles. When I tested with English Wikipedia, the scripts returned `mw.loader.state({
    "ext.gadget.defaultVisibilityToggles": "missing"
});`

I can't find any good way to determine whether a wiki uses toggles: https://phabricator.wikimedia.org/T161278 seems to suggest that the API doesn't surface gadgets in `modulescripts`?

@ MananJethwani found that it's not possible to scrape them from `RLPAGEMODULES` either, at least through the API: https://www.mediawiki.org/wiki/Topic:W2g7t4u4whlmkqho

Is there a way to add these for Wiktionary only, maybe via Wiktionary's Zimfarm config instead? Or maybe pull the wiki's homepage via the regular, non-API endpoint and check for gadget scripts?