### PR TITLE
add skipBroken argument to skip erroneous articles

### DIFF
--- a/articles
+++ b/articles
@@ -1,0 +1,4 @@
+Warden
+Bedrock_Edition_data_values/Metadata_table
+Resource_pack/Folders
+Creeper

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -443,7 +443,7 @@ async function execute(argv: any) {
     await getMainPage(dump, zimCreator, downloader);
 
     logger.log(`Getting articles`);
-    const { jsModuleDependencies, cssModuleDependencies } = await saveArticles(zimCreator, downloader, mw, dump);
+    const { jsModuleDependencies, cssModuleDependencies } = await saveArticles(zimCreator, downloader, mw, dump, !!argv.skipBroken);
 
     logger.log(`Found [${jsModuleDependencies.size}] js module dependencies`);
     logger.log(`Found [${cssModuleDependencies.size}] style module dependencies`);

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -29,6 +29,7 @@ export const parameterDescriptions = {
   verbose: 'Print debug information to the stdout',
   withoutZimFullTextIndex: 'Don\'t include a fulltext search index to the ZIM',
   webp: 'Convert all jpeg, png and gif images to webp format',
+  skipBroken: 'Skip articles that cause errors',
   addNamespaces: 'Force additional namespace (comma separated numbers)',
   getCategories: '[WIP] Download category pages',
   noLocalParserFallback: 'Don\'t fall back to a local MCS or Parsoid, only use remote APIs',

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -159,7 +159,7 @@ async function getAllArticlesToKeep(downloader: Downloader, mw: MediaWiki, dump:
     );
 }
 
-export async function saveArticles(zimCreator: ZimCreator, downloader: Downloader, mw: MediaWiki, dump: Dump) {
+export async function saveArticles(zimCreator: ZimCreator, downloader: Downloader, mw: MediaWiki, dump: Dump, skipBroken: boolean) {
     const jsModuleDependencies = new Set<string>();
     const cssModuleDependencies = new Set<string>();
     let jsConfigVars = '';
@@ -256,7 +256,7 @@ export async function saveArticles(zimCreator: ZimCreator, downloader: Downloade
                 } catch (err) {
                     dump.status.articles.fail += 1;
                     logger.error(`Error downloading article ${articleId}`);
-                    if ((!err.response || err.response.status !== 404) && err.message !== DELETED_ARTICLE_ERROR) {
+                    if (!skipBroken && (!err.response || err.response.status !== 404) && err.message !== DELETED_ARTICLE_ERROR) {
                         throw err;
                     }
                 }


### PR DESCRIPTION
Adds a --skipBroken argument in order to just skip Articles that throws errors

Usecase:
When creating ZIM file from fandom wikis, the backend sometimes throws errors when the Article is too complex for their backend and it returns 503, like [Minecraft:Bedrock Edition data values/Metadata_table](https://minecraft.fandom.com/wiki/Bedrock_Edition_data_values/Metadata_table)
I need to skip those (very few, like 2 out of 8k) to successfully run mwoffliner.