### PR TITLE
Remove last pieces of local Parsoid code

### DIFF
--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -71,8 +71,6 @@ interface DownloaderOpts {
   uaString: string;
   speed: number;
   reqTimeout: number;
-  noLocalParserFallback: boolean;
-  forceLocalParser: boolean;
   optimisationCacheUrl: string;
   s3?: S3;
   webp: boolean;
@@ -108,8 +106,6 @@ class Downloader {
   private activeRequests = 0;
   private maxActiveRequests = 1;
   private readonly requestTimeout: number;
-  private readonly noLocalParserFallback: boolean = false;
-  private readonly forceLocalParser: boolean = false;
   private readonly urlPartCache: KVS<string> = {};
   private readonly backoffOptions: BackoffOptions;
   private readonly optimisationCacheUrl: string;
@@ -120,15 +116,13 @@ class Downloader {
   public streamRequestOptions: AxiosRequestConfig;
 
 
-  constructor({ mw, uaString, speed, reqTimeout, noLocalParserFallback, forceLocalParser: forceLocalParser, optimisationCacheUrl, s3, webp, backoffOptions }: DownloaderOpts) {
+  constructor({ mw, uaString, speed, reqTimeout, optimisationCacheUrl, s3, webp, backoffOptions }: DownloaderOpts) {
     this.mw = mw;
     this.uaString = uaString;
     this.speed = speed;
     this.maxActiveRequests = speed * 10;
     this.requestTimeout = reqTimeout;
     this.loginCookie = '';
-    this.noLocalParserFallback = noLocalParserFallback;
-    this.forceLocalParser = forceLocalParser;
     this.optimisationCacheUrl = optimisationCacheUrl;
     this.webp = webp;
     this.s3 = s3;
@@ -231,12 +225,10 @@ class Downloader {
     this.baseUrl = this.mwCapabilities.mobileRestApiAvailable ? this.mw.mobileRestApiUrl.href :
                    this.mwCapabilities.desktopRestApiAvailable ? this.mw.desktopRestApiUrl.href :
                    this.mwCapabilities.veApiAvailable ? this.mw.veApiUrl.href :
-                   !this.noLocalParserFallback && this.mwCapabilities.apiAvailable ? `http://localhost:6927/${this.mw.webUrl.hostname}/v1/page/mobile-sections/` :
                    undefined;
 
     this.baseUrlForMainPage = this.mwCapabilities.desktopRestApiAvailable ? this.mw.desktopRestApiUrl.href :
                               this.mwCapabilities.veApiAvailable ? this.mw.veApiUrl.href :
-                              !this.noLocalParserFallback && this.mwCapabilities.apiAvailable ? `http://localhost:8000/${this.mw.webUrl.hostname}/v3/page/pagebundle/` :
                               undefined;
 
     logger.log('Base Url: ', this.baseUrl);

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -110,8 +110,6 @@ async function execute(argv: any) {
     addNamespaces: _addNamespaces,
     customZimFavicon: _customZimFavicon,
     optimisationCacheUrl,
-    noLocalParserFallback,
-    forceLocalParser,
     customFlavour
   } = argv;
 
@@ -186,8 +184,6 @@ async function execute(argv: any) {
     uaString: `${config.userAgent} (${adminEmail})`,
     speed,
     reqTimeout: requestTimeout * 1000 || config.defaults.requestTimeout,
-    noLocalParserFallback,
-    forceLocalParser,
     optimisationCacheUrl,
     s3,
     webp,

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -32,8 +32,6 @@ export const parameterDescriptions = {
   webp: 'Convert all jpeg, png and gif images to webp format',
   addNamespaces: 'Force additional namespace (comma separated numbers)',
   getCategories: '[WIP] Download category pages',
-  noLocalParserFallback: 'Don\'t fall back to a local MCS or Parsoid, only use remote APIs',
-  forceLocalParser: 'Use local Parsoid instance even if remote one available',
   osTmpDir: 'Override default operating system temporary directory path environment variable',
   customFlavour: 'A custom processor that can filter and process articles (see extensions/*.js)',
   optimisationCacheUrl: 'S3 url, including credentials and bucket name',

--- a/test/unit/downloader.test.ts
+++ b/test/unit/downloader.test.ts
@@ -22,19 +22,11 @@ test('Downloader class', async (t) => {
 
     const cacheDir = `cac/dumps-${Date.now()}/`;
     await mkdirPromise(cacheDir);
-    const downloader = new Downloader({ mw, uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, noLocalParserFallback: false, forceLocalParser: false, webp: true, optimisationCacheUrl: '' });
+    const downloader = new Downloader({ mw, uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' });
 
     await mw.getMwMetaData(downloader);
     await downloader.checkCapabilities();
     await downloader.setBaseUrls();
-
-    // const remoteMcsUrl = downloader.mcsUrl;
-    // const remoteParsoidUrl = downloader.parsoidFallbackUrl;
-
-    // const mcsHandle = await downloader.initLocalMcs();
-
-    // t.notEqual(remoteMcsUrl, downloader.mcsUrl, 'Initializing local MCS changes mcsUrl');
-    // t.notEqual(remoteParsoidUrl, downloader.parsoidFallbackUrl, 'Initializing local Parsoid changes parsoidFallbackUrl');
 
     const queryRet = await downloader.query(`?action=query&meta=siteinfo&siprop=statistics&format=json`);
     t.ok(!!queryRet, 'downloader.query returns valid JSON');
@@ -168,7 +160,7 @@ _test('Downloader class with optimisation', async (t) => {
         keyId: process.env.KEY_ID_TEST,
         secretAccessKey: process.env.SECRET_ACCESS_KEY_TEST,
     });
-    const downloader = new Downloader({ mw, uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, noLocalParserFallback: false, forceLocalParser: false, webp: false, optimisationCacheUrl: 'random-string' , s3});
+    const downloader = new Downloader({ mw, uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: false, optimisationCacheUrl: 'random-string' , s3});
 
     await s3.initialise();
 

--- a/test/unit/mwApi.test.ts
+++ b/test/unit/mwApi.test.ts
@@ -15,7 +15,7 @@ test('MWApi Article Ids', async (t) => {
         getCategories: true,
     } as any);
 
-    const downloader = new Downloader({ mw, uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, noLocalParserFallback: false, forceLocalParser: false, webp: false, optimisationCacheUrl: '' });
+    const downloader = new Downloader({ mw, uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: false, optimisationCacheUrl: '' });
 
     await mw.getMwMetaData(downloader);
     await downloader.checkCapabilities();
@@ -43,7 +43,7 @@ test('MWApi NS', async (t) => {
         getCategories: true,
     } as any);
 
-    const downloader = new Downloader({ mw, uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, noLocalParserFallback: false, forceLocalParser: false, webp: false, optimisationCacheUrl: '' });
+    const downloader = new Downloader({ mw, uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: false, optimisationCacheUrl: '' });
 
     await mw.getMwMetaData(downloader);
     await downloader.checkCapabilities();

--- a/test/util.ts
+++ b/test/util.ts
@@ -35,7 +35,7 @@ export async function setupScrapeClasses({ mwUrl = 'https://en.wikipedia.org', f
         base: mwUrl,
     } as any);
 
-    const downloader = new Downloader({ mw, uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, noLocalParserFallback: false, forceLocalParser: false, webp: false, optimisationCacheUrl: '' });
+    const downloader = new Downloader({ mw, uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: false, optimisationCacheUrl: '' });
 
     await mw.getMwMetaData(downloader);
     await downloader.checkCapabilities();


### PR DESCRIPTION
Fixes #1690 

```bash
$ mw --mwApiPath=/w/api.php --mwModulePath=/w/load.php --mwUrl=https://bulbapedia.bulbagarden.net/ --mwWikiPath=/wiki/ --verbose --webp --articleList=articles
[log] [2023-01-05T15:39:46.138Z] Successfully logged in S3
[log] [2023-01-05T15:39:46.631Z] closing sanitize redis DB
[log] [2023-01-05T15:39:46.632Z] Starting mwoffliner v1.11.12...
[info] [2023-01-05T15:39:46.652Z] Using custom flavour: no
[log] [2023-01-05T15:39:46.997Z] Successfully logged in S3
[log] [2023-01-05T15:39:47.002Z] Getting text direction...
[log] [2023-01-05T15:39:47.004Z] Getting site info...
[log] [2023-01-05T15:39:47.004Z] Getting sub-title...
[info] [2023-01-05T15:39:47.006Z] Downloading [https://bulbapedia.bulbagarden.net/wiki/]
[info] [2023-01-05T15:39:47.008Z] Getting JSON from [https://bulbapedia.bulbagarden.net/w/api.php?action=query&meta=siteinfo&format=json&siprop=general|namespaces|statistics|variables|category|wikidesc]
[info] [2023-01-05T15:39:47.010Z] Downloading [https://bulbapedia.bulbagarden.net/wiki/]
[log] [2023-01-05T15:39:47.445Z] Text direction is [ltr]
[info] [2023-01-05T15:39:49.358Z] Getting JSON from [https://bulbapedia.bulbagarden.net/w/api.php?action=query&format=json&prop=redirects%7Crevisions%7Ccoordinates&rdlimit=max&rdnamespace=]
[info] [2023-01-05T15:39:49.475Z] Coordinates not available on this wiki
[log] [2023-01-05T15:39:49.475Z] Base Url:  undefined
[log] [2023-01-05T15:39:49.476Z] Base Url for Main Page:  undefined
Failed to run mwoffliner after [4s]: {
	"stack": "Error: Unable to find appropriate API end-point to retrieve article HTML\n    at Downloader.<anonymous> (/home/kelson/code/mwoffliner/src/Downloader.ts:238:13)\n    at Generator.next (<anonymous>)\n    at /home/kelson/code/mwoffliner/src/Downloader.ts:27:71\n    at new Promise (<anonymous>)\n    at __awaiter (/home/kelson/code/mwoffliner/src/Downloader.ts:23:12)\n    at Downloader.setBaseUrls (/home/kelson/code/mwoffliner/src/Downloader.ts:233:16)\n    at Object.<anonymous> (/home/kelson/code/mwoffliner/src/mwoffliner.lib.ts:214:20)\n    at Generator.next (<anonymous>)\n    at fulfilled (/home/kelson/code/mwoffliner/src/mwoffliner.lib.ts:26:58)\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)",
	"message": "Unable to find appropriate API end-point to retrieve article HTML"
}


**********

Unable to find appropriate API end-point to retrieve article HTML

**********
```