### PR TITLE
Detect when saveArticles worker freezes

### DIFF
--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -97,6 +97,7 @@ class Downloader {
   public readonly mw: MediaWiki;
   public loginCookie: string = '';
   public readonly speed: number;
+  public readonly requestTimeout: number;
   public baseUrl: string;
   public baseUrlForMainPage: string;
   public cssDependenceUrls: KVS<boolean> = {};
@@ -105,7 +106,6 @@ class Downloader {
   private readonly uaString: string;
   private activeRequests = 0;
   private maxActiveRequests = 1;
-  private readonly requestTimeout: number;
   private readonly urlPartCache: KVS<string> = {};
   private readonly backoffOptions: BackoffOptions;
   private readonly optimisationCacheUrl: string;

--- a/src/util/Timer.ts
+++ b/src/util/Timer.ts
@@ -1,0 +1,33 @@
+/*
+ * timer class that executes callback in
+ * timeout seconds
+ */
+class Timer {
+  public readonly timeout: number;
+
+  private readonly callback: () => void;
+  private timer: NodeJS.Timeout;
+
+  constructor(callback: () => void, timeout: number) {
+    this.timeout = timeout;
+    this.callback = callback;
+    this.start();
+  }
+
+  public clear() {
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+  }
+
+  public reset() {
+    this.clear();
+    this.start();
+  }
+
+  private start() {
+    this.timer = setTimeout(this.callback, this.timeout);
+  }
+}
+
+export default Timer;

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -183,6 +183,10 @@ export async function saveArticles(zimCreator: ZimCreator, downloader: Downloade
       'Creating ZIM arcile',
       'Saving to ZIM',
     ];
+    const timeout = Math.max(
+      downloader.requestTimeout * 2,
+      15 * 60 * 1000,
+    );
 
     await articleDetailXId.iterateItems(
         downloader.speed,
@@ -194,10 +198,6 @@ export async function saveArticles(zimCreator: ZimCreator, downloader: Downloade
                 };
 
                 // detect when worker is frozen
-                const timeout = Math.max(
-                  downloader.requestTimeout * 2,
-                  15 * 60 * 1000,
-                );
                 const timer = new Timer(() => {
                   const errorMessage = `Worker timed out at ${stages[tracker.stage]} ${tracker.articleId}`;
                   logger.error(errorMessage);
@@ -296,7 +296,9 @@ export async function saveArticles(zimCreator: ZimCreator, downloader: Downloade
                         dump.status.articles.fail += 1;
                         logger.error(`Error downloading article ${articleId}`);
                         if ((!err.response || err.response.status !== 404) && err.message !== DELETED_ARTICLE_ERROR) {
-                            throw err;
+                            timer.clear();
+                            reject(err);
+                            return;
                         }
                     }
 


### PR DESCRIPTION
When a saveArticles worker freezes, detect it and throw an error (indicating at what stage the freeze happened) - rather than continuing with the other workers for days and then freezing at 100%.

I will keep this as a draft suggestion.
Can consider it if [wikipedia_en_all_maxi](https://farm.openzim.org/recipes/wikipedia_en_all_maxi) keeps freezing.