### PR TITLE
alternative retry strategy for downloading files

### DIFF
--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -478,11 +478,7 @@ async function execute(argv: any) {
       }),
     )
 
-    await downloadFiles(filesToDownloadXPath, zimCreator, dump, downloader)
-
-    logger.log('Flushing Redis file store')
-    await filesToDownloadXPath.flush()
-    await filesToRetryXPath.flush()
+    await downloadFiles(filesToDownloadXPath, filesToRetryXPath, zimCreator, dump, downloader)
 
     logger.log('Writing Article Redirects')
     await writeArticleRedirects(downloader, dump, zimCreator)

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -17,3 +17,4 @@ export const DEFAULT_WIKI_PATH = 'wiki/'
 export const ALL_READY_FUNCTION = /function allReady\( modules \) {/
 export const DO_PROPAGATION = /mw\.requestIdleCallback\( doPropagation, \{ timeout: 1 \} \);/
 export const WEBP_HANDLER_URL = 'https://gist.githubusercontent.com/rgaudin/60bb9cc6f187add506584258028b8ee1/raw/9d575b8e25d67eed2a9c9a91d3e053a0062d2fc7/web-handler.js'
+export const MAX_FILE_DOWNLOAD_RETRIES = 5


### PR DESCRIPTION
Don't immediately retry failed file requests again.
Instead use the already existing filesToRetryXPath store multiple times to retry after the rest is done.

fixes #1750