### PR TITLE
Move inline JS from html to js file

### DIFF
--- a/res/script.js
+++ b/res/script.js
@@ -1,3 +1,5 @@
+function importScript() { return 1 } // this is to avoid the error from site.js
+
 window.onload = function () {
 
     /* Collapsing of the sections */

--- a/res/script.js
+++ b/res/script.js
@@ -34,6 +34,8 @@ var webpScripts = ['../-/webpHeroPolyfill.js',
                    '../-/webpHeroBundle.js',
                    '../-/webpHandler.js'];
 webpScripts = webpScripts.map(function(scriptUrl) {
+    const articleId = document.getElementById('script-js').dataset.articleId;
+
     return (typeof(articleId)) ? '../'.repeat(articleId.split('/').length - 1) + scriptUrl : scriptUrl;
 });
 var script = document.createElement('script');

--- a/res/templates/article_list_home.html
+++ b/res/templates/article_list_home.html
@@ -5,9 +5,6 @@
     <meta charset="UTF-8" />
     <title></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script>
-        function importScript() { return 1 } // this is to avoid the error from site.js
-    </script>
     <script src="../-/masonry.min.js"></script>
     <script src="../-/script.js"></script>
 </head>

--- a/res/templates/page.html
+++ b/res/templates/page.html
@@ -5,7 +5,6 @@
   <meta charset="UTF-8" />
   <title></title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  __ARTICLE_ID__
   __ARTICLE_CANONICAL_LINK__
   __ARTICLE_CSS_LIST__
   __CSS_LINKS__

--- a/res/templates/page.html
+++ b/res/templates/page.html
@@ -5,9 +5,6 @@
   <meta charset="UTF-8" />
   <title></title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script>
-    function importScript() { return 1 } // this is to avoid the error from site.js
-  </script>
   __ARTICLE_ID__
   __ARTICLE_CANONICAL_LINK__
   __ARTICLE_CSS_LIST__

--- a/src/Templates.ts
+++ b/src/Templates.ts
@@ -28,7 +28,12 @@ const htmlTemplateCode = (articleId: string) => {
   }, '')
 
   const jsScripts = config.output.jsResources.reduce((buf, js) => {
-    return buf + genHeaderScript(config, js, articleId)
+    return (
+      buf +
+      (js === 'script'
+        ? genHeaderScript(config, js, articleId, '', `data-article-id="${articleId.replace(/"/g, '\\\\"')}" id="script-js"`)
+        : genHeaderScript(config, js, articleId))
+    )
   }, '')
 
   return readTemplate(config.output.templates.page).replace('__CSS_LINKS__', cssLinks).replace('__JS_SCRIPTS__', jsScripts)

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -193,12 +193,12 @@ export function genHeaderCSSLink(config: Config, css: string, articleId: string,
   const upStr = '../'.repeat(slashesInUrl + 1)
   return `<link href="${upStr}${resourceNamespace}/${cssPath(css, subDirectory)}" rel="stylesheet" type="text/css"/>`
 }
-export function genHeaderScript(config: Config, js: string, articleId: string, subDirectory = '') {
+export function genHeaderScript(config: Config, js: string, articleId: string, subDirectory = '', attributes = '') {
   const resourceNamespace = '-'
   const slashesInUrl = articleId.split('/').length - 1
   const upStr = '../'.repeat(slashesInUrl + 1)
   const path = isNodeModule(js) ? normalizeModule(js) : js
-  return `<script src="${upStr}${resourceNamespace}/${jsPath(path, subDirectory)}"></script>`
+  return `<script ${attributes} src="${upStr}${resourceNamespace}/${jsPath(path, subDirectory)}"></script>`
 }
 export function genCanonicalLink(config: Config, webUrl: string, articleId: string) {
   return `<link rel="canonical" href="${webUrl}${encodeURIComponent(articleId)}" />`

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -182,6 +182,9 @@ export async function saveArticles(zimCreator: ZimCreator, downloader: Downloade
             continue
           }
 
+          const jsWithArticleId = new ZimArticle({ url: jsPath(articleId, config.output.dirs.mediawiki), data: `let articleId = '${articleId}';`, ns: '-' })
+          zimCreator.addArticle(jsWithArticleId)
+
           const { articleDoc: _articleDoc, mediaDependencies, subtitles } = await processArticleHtml(articleHtml, downloader, mw, dump, articleId)
           let articleDoc = _articleDoc
 
@@ -867,7 +870,7 @@ async function templateArticle(parsoidDoc: DominoElement, moduleDependencies: an
         '__ARTICLE_CSS_LIST__',
         styleDependenciesList.length !== 0 ? styleDependenciesList.map((oneCssDep) => genHeaderCSSLink(config, oneCssDep, articleId, config.output.dirs.mediawiki)).join('\n') : '',
       )
-      .replace('__ARTICLE_ID__', `<script>let articleId = '${articleId}'</script>`),
+      .replace('__ARTICLE_ID__', genHeaderScript(config, encodeURIComponent(articleId), articleId, config.output.dirs.mediawiki)),
   )
 
   /* Create final document by merging template and parsoid documents */

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -182,9 +182,6 @@ export async function saveArticles(zimCreator: ZimCreator, downloader: Downloade
             continue
           }
 
-          const jsWithArticleId = new ZimArticle({ url: jsPath(articleId, config.output.dirs.mediawiki), data: `let articleId = '${articleId}';`, ns: '-' })
-          zimCreator.addArticle(jsWithArticleId)
-
           const { articleDoc: _articleDoc, mediaDependencies, subtitles } = await processArticleHtml(articleHtml, downloader, mw, dump, articleId)
           let articleDoc = _articleDoc
 
@@ -869,8 +866,7 @@ async function templateArticle(parsoidDoc: DominoElement, moduleDependencies: an
       .replace(
         '__ARTICLE_CSS_LIST__',
         styleDependenciesList.length !== 0 ? styleDependenciesList.map((oneCssDep) => genHeaderCSSLink(config, oneCssDep, articleId, config.output.dirs.mediawiki)).join('\n') : '',
-      )
-      .replace('__ARTICLE_ID__', genHeaderScript(config, encodeURIComponent(articleId), articleId, config.output.dirs.mediawiki)),
+      ),
   )
 
   /* Create final document by merging template and parsoid documents */


### PR DESCRIPTION
Setting variable articleId was removed from HTML.
Article ID was added to DOM element attribute to read it from javascript.
Fixes #1578 