### PR TITLE
The sequence of the js files loading was changed to fix the "unknown variable" error

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -73,8 +73,8 @@ const config = {
         'startup',
         'jquery',
         'mediawiki.base',
-        'site',
         'mediawiki.util',
+        'site',
         'mediawiki.page.ready',
 
         // Gadget resources are not shared by Parsoid API https://phabricator.wikimedia.org/T161278


### PR DESCRIPTION
site.js script should be loaded after mediawiki.util.js to fix the error: "Cannot read properties of undefined (reading 'getParamValue')" 

Fixture: #1662 