### PR TITLE
treatment links with *.oga file

### DIFF
--- a/src/util/rewriteUrls.ts
+++ b/src/util/rewriteUrls.ts
@@ -97,7 +97,7 @@ function rewriteUrlNoArticleCheck(articleId: string, mw: MediaWiki, dump: Dump, 
       lat = parts[4]
       lon = parts[5]
     } else if (rel === 'mw:MediaLink') {
-      const shouldScrape = (href.includes('.pdf') && !dump.nopdf) || (href.includes('.ogg') && !dump.nopic && !dump.novid && !dump.nodet)
+      const shouldScrape = (href.includes('.pdf') && !dump.nopdf) || ((href.includes('.ogg') || href.includes('.oga')) && !dump.nopic && !dump.novid && !dump.nodet)
 
       if (shouldScrape) {
         try {
@@ -110,6 +110,8 @@ function rewriteUrlNoArticleCheck(articleId: string, mw: MediaWiki, dump: Dump, 
           logger.warn('Error parsing url:', err)
           DU.deleteNode(linkNode)
         }
+      } else if (href.includes('.ogg') || href.includes('.oga')) {
+        linkNode.outerHTML = linkNode.innerHTML
       }
       return null
     }

--- a/test/unit/urlRewriting.test.ts
+++ b/test/unit/urlRewriting.test.ts
@@ -46,6 +46,9 @@ describe('Styles', () => {
     const $resourceLink = makeLink($doc, '//upload.wikimedia.org/wikipedia/commons/c/c6/De-Z%C3%BCrich.ogg', '', 'De-Z%C3%BCrich.ogg', 'Zurich', {
       resource: './Media:De-Zürich.ogg',
     })
+    const $ogaResourceLink = makeLink($doc, '//upload.wikimedia.org/wikipedia/commons/7/7e/Fr-Laissez-faire.oga', '', 'Fr-Laissez-faire.oga', 'listen', {
+      resource: './Media:Fr-Laissez-faire.oga',
+    })
 
     await rewriteUrl(complexParentArticleId, redisStore, mw, dump, $geo)
     // Geo is still a link
@@ -122,6 +125,12 @@ describe('Styles', () => {
     expect($resourceLink.nodeName).toEqual('A')
     // resourceLink has been re-written
     expect($resourceLink.getAttribute('href')).toEqual('../../I/De-Z%C3%BCrich.ogg')
+
+    await rewriteUrl(complexParentArticleId, redisStore, mw, dump, $ogaResourceLink)
+    // ogaResourceLink is still a link
+    expect($ogaResourceLink.nodeName).toEqual('A')
+    // ogaResourceLink has been re-written
+    expect($ogaResourceLink.getAttribute('href')).toEqual('../../I/Fr-Laissez-faire.oga')
   })
 
   test('e2e url rewriting', async () => {


### PR DESCRIPTION
Save oga files with the same behavior as ogg.
If novid format is set then replace <a> tag with HTML text.