### PR TITLE
if <script> with 'mw.config.set' is not found then grab <script> with config variables

### DIFF
--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -369,7 +369,7 @@ export async function saveArticles(zimCreator: ZimCreator, downloader: Downloade
   }
 }
 
-async function getModuleDependencies(articleId: string, mw: MediaWiki, downloader: Downloader) {
+export async function getModuleDependencies(articleId: string, mw: MediaWiki, downloader: Downloader) {
   /* These vars will store the list of js and css dependencies for
     the article we are downloading. */
   let jsConfigVars = ''

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -411,10 +411,12 @@ async function getModuleDependencies(articleId: string, mw: MediaWiki, downloade
   for (let i = 0; i < scriptTags.length; i += 1) {
     if (scriptTags[i].text.includes('mw.config.set')) {
       jsConfigVars = regex.exec(scriptTags[i].text)[0] || ''
+      jsConfigVars = `(window.RLQ=window.RLQ||[]).push(function() {${jsConfigVars}});`
+    } else if (scriptTags[i].text.includes('RLCONF') || scriptTags[i].text.includes('RLSTATE') || scriptTags[i].text.includes('RLPAGEMODULES')) {
+      jsConfigVars = scriptTags[i].text
     }
   }
 
-  jsConfigVars = `(window.RLQ=window.RLQ||[]).push(function() {${jsConfigVars}});`
   jsConfigVars = jsConfigVars.replace('nosuchaction', 'view') // to replace the wgAction config that is set to 'nosuchaction' from api but should be 'view'
 
   return { jsConfigVars, jsDependenciesList, styleDependenciesList }

--- a/test/unit/saveArticles.test.ts
+++ b/test/unit/saveArticles.test.ts
@@ -2,7 +2,7 @@ import { startRedis, stopRedis, redisStore } from './bootstrap.js'
 import domino from 'domino'
 
 import { setupScrapeClasses, convertWikicodeToHtml, testHtmlRewritingE2e } from '../util.js'
-import { saveArticles, treatMedias, applyOtherTreatments, treatSubtitle, treatVideo } from '../../src/util/saveArticles.js'
+import { saveArticles, getModuleDependencies, treatMedias, applyOtherTreatments, treatSubtitle, treatVideo } from '../../src/util/saveArticles.js'
 import { ZimArticle } from '@openzim/libzim'
 import { Dump } from '../../src/Dump'
 import { mwRetToArticleDetail, renderDesktopArticle, DELETED_ARTICLE_ERROR } from '../../src/util/index.js'
@@ -348,5 +348,30 @@ describe('saveArticles', () => {
     }
     // Throwing error if article is deleted
     expect(() => renderDesktopArticle(articleJsonObject, 'deletedArticle', { title: 'deletedArticle' })).toThrow(new Error(DELETED_ARTICLE_ERROR))
+  })
+
+  test('Load inline js from HTML', async () => {
+    const { downloader, mw } = await setupScrapeClasses() // en wikipedia
+
+    const _moduleDependencies = await getModuleDependencies('Potato', mw, downloader)
+    // next variables declared to avoid "variable is not defined" errors
+    let RLCONF: any
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    let RLSTATE: any
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    let RLPAGEMODULES: any
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const document: any = { documentElement: { className: '' }, cookie: '' }
+
+    // eslint-disable-next-line no-eval
+    eval(_moduleDependencies.jsConfigVars)
+    expect(RLCONF).toMatchObject({
+      wgPageName: 'Potato',
+      wgTitle: 'Potato',
+      wgPageContentLanguage: 'en',
+      wgPageContentModel: 'wikitext',
+      wgRelevantPageName: 'Potato',
+      wgRelevantArticleId: 23501,
+    })
   })
 })


### PR DESCRIPTION
Scraper takes article configuration from <script> tag of HTML page.
Right now API is not provided such configuration.
With this PR the configuration takes in another way.
Fixes #1662 