### PR TITLE
Ignore (wrong) webp mime-type from S3

### DIFF
--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -605,6 +605,17 @@ class Downloader {
           }
           const mwResp = await axios(url, this.arrayBufferRequestOptions)
 
+          /* TODO: Code to remove in a few months (February 2023). For
+          some reason, it seems a few pictures have 'image/webp'
+          mime-type in S3 although they are png, ... This leads to
+          having the following code not assuming they should be
+          converted to wepb. To avoid this, as a temporary solution,
+          such scneario are ignored and mime-type definition relies
+          only on url and Mediawiki header. */
+          if (s3Resp?.Metadata?.contenttype === 'image/webp') {
+            s3Resp.Metadata.contenttype = undefined
+          }
+
           // sanitize Content-Type
           mwResp.headers['content-type'] = getMimeType(url, s3Resp?.Metadata?.contenttype || mwResp.headers['content-type'])
 


### PR DESCRIPTION
Fixes #1772

Root cause of the problem seems not a broken code but wrong values in the S3. Many PNG/JPG images have a mime-type of `image/webp` in S3 which is wrong. I guess that during the developement of milestone `1.12.0` a regression has been introduced at some point and then fixed. But it was long enough there that test runs have polluted the bucket. With this fix it should work and after a bit, we could remove the patch from our source code because (most?) values should be fixed in the S3. 