### PR TITLE
Fixes to download articles thumbnails

### DIFF
--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -285,10 +285,7 @@ class Downloader {
       let processedResponse = resp.query ? normalizeMwResponse(resp.query) : {}
       if (resp.continue) {
         continuation = resp.continue
-        const queryContinueOpts: any = shouldGetThumbnail ? { pageimages: queryOpts.picontinue } : {}
-        const relevantDetails = this.stripNonContinuedProps(processedResponse, queryContinueOpts)
-
-        finalProcessedResp = finalProcessedResp === undefined ? relevantDetails : deepmerge(finalProcessedResp, relevantDetails)
+        finalProcessedResp = finalProcessedResp === undefined ? processedResponse : deepmerge(finalProcessedResp, processedResponse)
       } else {
         if (this.mw.getCategories) {
           processedResponse = await this.setArticleSubCategories(processedResponse)
@@ -345,9 +342,7 @@ class Downloader {
       if (!queryComplete) {
         queryContinuation = resp['query-continue']
 
-        const relevantDetails = this.stripNonContinuedProps(processedResponse)
-
-        finalProcessedResp = finalProcessedResp === undefined ? relevantDetails : deepmerge(finalProcessedResp, relevantDetails)
+        finalProcessedResp = finalProcessedResp === undefined ? processedResponse : deepmerge(finalProcessedResp, processedResponse)
       } else {
         if (this.mw.getCategories) {
           processedResponse = await this.setArticleSubCategories(processedResponse)
@@ -437,32 +432,6 @@ class Downloader {
 
   private getArticleUrl(articleId: string, isMainPage: boolean): string {
     return `${isMainPage ? this.baseUrlForMainPage : this.baseUrl}${encodeURIComponent(articleId)}`
-  }
-
-  private stripNonContinuedProps(articleDetails: QueryMwRet, cont: QueryContinueOpts | ContinueOpts = {}): QueryMwRet {
-    const propsMap: KVS<string[]> = {
-      pageimages: ['thumbnail', 'pageimage'],
-      coordinates: ['coordinates'],
-      categories: ['categories'],
-    }
-    const keysToKeep: string[] = ['subCategories', 'revisions', 'redirects'].concat(Object.keys(cont).reduce((acc, key) => acc.concat(propsMap[key] || []), []))
-    const items = Object.entries(articleDetails).map(([aId, detail]) => {
-      const newDetail = keysToKeep.reduce((acc, key) => {
-        const val = (detail as any)[key]
-        if (!val) {
-          return acc
-        } else {
-          return {
-            ...acc,
-            [key]: val,
-          }
-        }
-      }, {})
-      return [aId, newDetail]
-    })
-    return items.reduce((acc, [key, detail]: any[]) => {
-      return { ...acc, [key]: detail }
-    }, {})
   }
 
   private static handleMWWarningsAndErrors(resp: MwApiResponse): void {

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -265,7 +265,7 @@ class Downloader {
     let finalProcessedResp: QueryMwRet
 
     while (true) {
-      const queryOpts = {
+      const queryOpts: KVS<any> = {
         ...this.getArticleQueryOpts(shouldGetThumbnail, true),
         titles: articleIds.join('|'),
         ...(this.mwCapabilities.coordinatesAvailable ? { colimit: 'max' } : {}),
@@ -285,7 +285,8 @@ class Downloader {
       let processedResponse = resp.query ? normalizeMwResponse(resp.query) : {}
       if (resp.continue) {
         continuation = resp.continue
-        const relevantDetails = this.stripNonContinuedProps(processedResponse)
+        const queryContinueOpts: any = shouldGetThumbnail ? { pageimages: queryOpts.picontinue } : {}
+        const relevantDetails = this.stripNonContinuedProps(processedResponse, queryContinueOpts)
 
         finalProcessedResp = finalProcessedResp === undefined ? relevantDetails : deepmerge(finalProcessedResp, relevantDetails)
       } else {


### PR DESCRIPTION
You can see random article thumbnails on the main page of ZIM with the top 1 million Wikipedia pages. But these articles should be sorted in order from the most popular.

The problem in the process of retrieving article details. In most cases, mwoffliner cant get articles details from API with one request. Wikimedia API provides a mechanism with which we need to send multiple requests to retrieve all articles details.

Mwoffliner takes thumbnails only for articles that are retrieved with one request. But for articles that retrieve with multiple requests, the mwoffliner does not take thumbnails.
The mwoffliner has a piece of code that allows us to retrieve thumbnails of the articles with multiple requests, but this code was not used for a while.
With this PR I am turning on a mechanism to take thumbnails for articles that are retrieved with multiple requests.
These changes can't be affected much by the performance because it does not generate additional API requests.

fixes: #1786 