### PR TITLE
Use comma separated URL's as value for --articleList parameter

### DIFF
--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -2,6 +2,7 @@ import * as path from 'path'
 import * as urlParser from 'url'
 import deepmerge from 'deepmerge'
 import * as backoff from 'backoff'
+import { config } from './config.js'
 import { default as imagemin } from 'imagemin'
 import imageminAdvPng from 'imagemin-advpng'
 import type { BackoffStrategy } from 'backoff'
@@ -75,6 +76,18 @@ export interface MWCapabilities {
   coordinatesAvailable: boolean
   desktopRestApiAvailable: boolean
   mobileRestApiAvailable: boolean
+}
+
+export const defaultStreamRequestOptions: AxiosRequestConfig = {
+  headers: {
+    accept: 'application/octet-stream',
+    'cache-control': 'public, max-stale=86400',
+    'accept-encoding': 'gzip, deflate',
+    'user-agent': config.userAgent,
+  },
+  responseType: 'stream',
+  timeout: config.defaults.requestTimeout,
+  method: 'GET',
 }
 
 class Downloader {
@@ -164,19 +177,16 @@ class Downloader {
 
     this.streamRequestOptions = {
       // HTTP agent pools with 'keepAlive' to reuse TCP connections, so it's faster
+      ...defaultStreamRequestOptions,
       httpAgent: new http.Agent({ keepAlive: true }),
       httpsAgent: new https.Agent({ keepAlive: true }),
 
       headers: {
-        accept: 'application/octet-stream',
-        'cache-control': 'public, max-stale=86400',
-        'accept-encoding': 'gzip, deflate',
+        ...defaultStreamRequestOptions.headers,
         'user-agent': this.uaString,
         cookie: this.loginCookie,
       },
-      responseType: 'stream',
       timeout: this.requestTimeout,
-      method: 'GET',
     }
   }
 

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -38,7 +38,7 @@ import {
   saveStaticFiles,
   writeFilePromise,
   importPolyfillModules,
-  readFileOrUrlByLine,
+  extractArticleList,
   getTmpDirectory,
 } from './util/index.js'
 import S3 from './S3.js'
@@ -274,7 +274,7 @@ async function execute(argv: any) {
   let articleListToIgnoreLines: string[]
   if (articleListToIgnore) {
     try {
-      articleListToIgnoreLines = await readFileOrUrlByLine(articleListToIgnore)
+      articleListToIgnoreLines = await extractArticleList(articleListToIgnore)
       logger.info(`ArticleListToIgnore has [${articleListToIgnoreLines.length}] items`)
     } catch (err) {
       logger.error(`Failed to read articleListToIgnore from [${articleListToIgnore}]`, err)
@@ -285,7 +285,7 @@ async function execute(argv: any) {
   let articleListLines: string[]
   if (articleList) {
     try {
-      articleListLines = await readFileOrUrlByLine(articleList)
+      articleListLines = await extractArticleList(articleList)
       if (articleListToIgnore) {
         articleListLines = articleListLines.filter((title: string) => !articleListToIgnoreLines.includes(title))
       }

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -39,6 +39,7 @@ import {
   writeFilePromise,
   importPolyfillModules,
   readFileOrUrlByLine,
+  getTmpDirectory,
 } from './util/index.js'
 import S3 from './S3.js'
 import RedisStore from './RedisStore.js'
@@ -205,14 +206,7 @@ async function execute(argv: any) {
   logger.log(`Using output directory ${outputDirectory}`)
 
   // Temporary directory
-  const tmpDirectory = path.resolve(os.tmpdir(), `mwoffliner-${Date.now()}`)
-  try {
-    logger.info(`Creating temporary directory [${tmpDirectory}]`)
-    await mkdirPromise(tmpDirectory)
-  } catch (err) {
-    logger.error('Failed to create temporary directory, exiting', err)
-    throw err
-  }
+  const tmpDirectory = await getTmpDirectory()
   logger.log(`Using temporary directory ${tmpDirectory}`)
 
   process.on('exit', async (code) => {
@@ -280,7 +274,7 @@ async function execute(argv: any) {
   let articleListToIgnoreLines: string[]
   if (articleListToIgnore) {
     try {
-      articleListToIgnoreLines = await readFileOrUrlByLine(articleListToIgnore, downloader.streamRequestOptions, tmpDirectory)
+      articleListToIgnoreLines = await readFileOrUrlByLine(articleListToIgnore)
       logger.info(`ArticleListToIgnore has [${articleListToIgnoreLines.length}] items`)
     } catch (err) {
       logger.error(`Failed to read articleListToIgnore from [${articleListToIgnore}]`, err)
@@ -291,7 +285,7 @@ async function execute(argv: any) {
   let articleListLines: string[]
   if (articleList) {
     try {
-      articleListLines = await readFileOrUrlByLine(articleList, downloader.streamRequestOptions, tmpDirectory)
+      articleListLines = await readFileOrUrlByLine(articleList)
       if (articleListToIgnore) {
         articleListLines = articleListLines.filter((title: string) => !articleListToIgnoreLines.includes(title))
       }

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -38,6 +38,7 @@ import {
   saveStaticFiles,
   writeFilePromise,
   importPolyfillModules,
+  readFileOrUrlByLine,
 } from './util/index.js'
 import S3 from './S3.js'
 import RedisStore from './RedisStore.js'
@@ -279,7 +280,7 @@ async function execute(argv: any) {
   let articleListToIgnoreLines: string[]
   if (articleListToIgnore) {
     try {
-      articleListToIgnoreLines = await readFileOrUrlByLine(articleListToIgnore)
+      articleListToIgnoreLines = await readFileOrUrlByLine(articleListToIgnore, downloader.streamRequestOptions, tmpDirectory)
       logger.info(`ArticleListToIgnore has [${articleListToIgnoreLines.length}] items`)
     } catch (err) {
       logger.error(`Failed to read articleListToIgnore from [${articleListToIgnore}]`, err)
@@ -290,7 +291,7 @@ async function execute(argv: any) {
   let articleListLines: string[]
   if (articleList) {
     try {
-      articleListLines = await readFileOrUrlByLine(articleList)
+      articleListLines = await readFileOrUrlByLine(articleList, downloader.streamRequestOptions, tmpDirectory)
       if (articleListToIgnore) {
         articleListLines = articleListLines.filter((title: string) => !articleListToIgnoreLines.includes(title))
       }
@@ -532,39 +533,6 @@ async function execute(argv: any) {
     const logoContent = await downloader.downloadContent(logoUrl)
     await writeFilePromise(faviconPath, logoContent.content, null)
     return saveFavicon(zimCreator, faviconPath)
-  }
-
-  async function readFileOrUrlByLine(resourcePath: string): Promise<string[]> {
-    if (resourcePath.includes('http')) {
-      const fileName = resourcePath.split('/').slice(-1)[0]
-      const { data: contentStream } = await axios.get(resourcePath, downloader.streamRequestOptions)
-      resourcePath = path.join(tmpDirectory, fileName)
-      const writeStream = fs.createWriteStream(resourcePath)
-      await new Promise((resolve, reject) => {
-        contentStream
-          .pipe(writeStream)
-          .on('error', (err: any) => reject(err))
-          .on('close', resolve)
-      })
-    }
-
-    if (!fs.existsSync(resourcePath)) {
-      return resourcePath
-        .split(',')
-        .filter((part) => part !== '')
-        .map((part) => part.trim())
-    }
-
-    const fileLines: string[] = resourcePath
-      ? fs
-          .readFileSync(resourcePath)
-          .toString()
-          .split('\n')
-          .map((a) => a.replace(/\r/gm, ''))
-          .filter((a) => a)
-      : []
-
-    return fileLines
   }
 
   function getMainPage(dump: Dump, zimCreator: ZimCreator, downloader: Downloader) {

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -447,11 +447,18 @@ export async function extractArticleList(articleList: string): Promise<string[]>
       .map(async (part) => {
         let item: string | string[] = part.trim()
         if (item.indexOf('http') === 0) {
+          let url: URL
           try {
-            const url = new URL(item)
-            item = await downloadListByUrl(url.toString())
+            url = new URL(item)
           } catch (e) {
-            // URL is not valid continue processing
+            // URL is not valid. Continue processing
+          }
+          if (url && url.href) {
+            try {
+              item = await downloadListByUrl(url.href)
+            } catch (e) {
+              throw new Error(`Failed to read articleList from URL: ${url.href}`)
+            }
           }
         }
         if (fs.existsSync(item)) {

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -11,7 +11,7 @@ import {
   getMimeType,
   isWebpCandidateImageMimeType,
   cleanupAxiosError,
-  readFileOrUrlByLine,
+  extractArticleList,
   mkdirPromise,
   writeFilePromise,
 } from '../../src/util/index.js'
@@ -344,7 +344,7 @@ describe('Utils', () => {
     }
   })
 
-  describe('readFileOrUrlByLine', () => {
+  describe('extractArticleList', () => {
     const now = new Date()
     const dirname = path.join(process.cwd(), `mwo-test-${+now}`)
 
@@ -364,22 +364,22 @@ describe('Utils', () => {
     })
 
     test('One string as parameter', async () => {
-      const result: string[] = await readFileOrUrlByLine('testString')
+      const result: string[] = await extractArticleList('testString')
       expect(result).toEqual(['testString'])
     })
 
     test('Comma separated strings as parameter', async () => {
-      const result: string[] = await readFileOrUrlByLine(argumentsList.join(','))
+      const result: string[] = await extractArticleList(argumentsList.join(','))
       expect(result).toEqual(argumentsList)
     })
 
     test('Filename string as parameter', async () => {
-      const result: string[] = await readFileOrUrlByLine(filePath)
+      const result: string[] = await extractArticleList(filePath)
       expect(result).toEqual(argumentsList)
     })
 
     test('Comma separated filenames string as parameter', async () => {
-      const result: string[] = await readFileOrUrlByLine(`${filePath},${anotherFilePath}`)
+      const result: string[] = await extractArticleList(`${filePath},${anotherFilePath}`)
       expect(result.sort()).toEqual(argumentsList.concat(anotherArgumentsList))
     })
 
@@ -387,7 +387,7 @@ describe('Utils', () => {
       jest.spyOn(axios, 'get').mockResolvedValue({
         data: fs.createReadStream(filePath),
       })
-      const result: string[] = await readFileOrUrlByLine('http://test.com/strings')
+      const result: string[] = await extractArticleList('http://test.com/strings')
       expect(result).toEqual(argumentsList)
     })
 
@@ -398,8 +398,13 @@ describe('Utils', () => {
       jest.spyOn(axios, 'get').mockResolvedValueOnce({
         data: fs.createReadStream(anotherFilePath),
       })
-      const result: string[] = await readFileOrUrlByLine('http://test.com/strings,http://test.com/another-strings')
+      const result: string[] = await extractArticleList('http://test.com/strings,http://test.com/another-strings')
       expect(result.sort()).toEqual(argumentsList.concat(anotherArgumentsList))
+    })
+
+    test('The parameter starts from HTTP but it is not the URL', async () => {
+      const result: string[] = await extractArticleList('http-test')
+      expect(result).toEqual(['http-test'])
     })
   })
 })

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -406,5 +406,10 @@ describe('Utils', () => {
       const result: string[] = await extractArticleList('http-test')
       expect(result).toEqual(['http-test'])
     })
+
+    test('Error if trying to get articleList from wrong URL ', async () => {
+      jest.spyOn(axios, 'get').mockRejectedValue({})
+      await expect(extractArticleList('http://valid-wrong-url.com/')).rejects.toThrow('Failed to read articleList from URL: http://valid-wrong-url.com/')
+    })
   })
 })

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -11,12 +11,18 @@ import {
   getMimeType,
   isWebpCandidateImageMimeType,
   cleanupAxiosError,
+  readFileOrUrlByLine,
+  mkdirPromise,
+  writeFilePromise,
 } from '../../src/util/index.js'
 import { testHtmlRewritingE2e } from '../util.js'
 import axios from 'axios'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
 import { jest } from '@jest/globals'
+import Downloader from '../../src/Downloader.js'
+import fs from 'fs'
+import rimraf from 'rimraf'
 
 jest.setTimeout(10000)
 
@@ -337,5 +343,78 @@ describe('Utils', () => {
       const cleanupedError = cleanupAxiosError(err)
       expect(cleanupedError).toEqual(result)
     }
+  })
+
+  describe('readFileOrUrlByLine', () => {
+    test('one value', async () => {
+      const result: string[] = await readFileOrUrlByLine('testString', {}, '')
+      expect(result).toEqual(['testString'])
+    })
+
+    test('comma separated values', async () => {
+      const result: string[] = await readFileOrUrlByLine('testString1,testString2, testString3', {}, '')
+      expect(result).toEqual(['testString1', 'testString2', 'testString3'])
+    })
+  })
+
+  describe('readFileOrUrlByLine', () => {
+    const now = new Date()
+    const dirname = path.join(process.cwd(), `mwo-test-${+now}`)
+
+    const argumentsList = ['testString1', 'testString2', 'testString3']
+    const anotherArgumentsList = ['testString4', 'testString5', 'testString6']
+    const filePath = path.join(dirname, 'articles1.txt')
+    const anotherFilePath = path.join(dirname, 'articles2.txt')
+
+    beforeAll(async () => {
+      await mkdirPromise(dirname)
+      await writeFilePromise(filePath, argumentsList.join('\n'))
+      await writeFilePromise(anotherFilePath, anotherArgumentsList.join('\n'))
+    })
+
+    afterAll(() => {
+      rimraf.sync(dirname)
+    })
+
+    test('One string as parameter', async () => {
+      const result: string[] = await readFileOrUrlByLine('testString', {}, '')
+      expect(result).toEqual(['testString'])
+    })
+
+    test('Comma separated strings as parameter', async () => {
+      const result: string[] = await readFileOrUrlByLine(argumentsList.join(','), {}, '')
+      expect(result).toEqual(argumentsList)
+    })
+
+    test('Filename string as parameter', async () => {
+      const result: string[] = await readFileOrUrlByLine(filePath, {}, '')
+      expect(result).toEqual(argumentsList)
+    })
+
+    test('Comma separated filenames string as parameter', async () => {
+      const result: string[] = await readFileOrUrlByLine(`${filePath},${anotherFilePath}`, {}, '')
+      expect(result.sort()).toEqual(argumentsList.concat(anotherArgumentsList))
+    })
+
+    test('URL as parameter', async () => {
+      jest.spyOn(axios, 'get').mockResolvedValue({
+        data: fs.createReadStream(filePath),
+      })
+      const downloader = new Downloader({} as any)
+      const result: string[] = await readFileOrUrlByLine('http://test.com/strings', downloader.streamRequestOptions, dirname)
+      expect(result).toEqual(argumentsList)
+    })
+
+    test("Comma separated URL's as parameter", async () => {
+      jest.spyOn(axios, 'get').mockResolvedValueOnce({
+        data: fs.createReadStream(filePath),
+      })
+      jest.spyOn(axios, 'get').mockResolvedValueOnce({
+        data: fs.createReadStream(anotherFilePath),
+      })
+      const downloader = new Downloader({} as any)
+      const result: string[] = await readFileOrUrlByLine('http://test.com/strings,http://test.com/another-strings', downloader.streamRequestOptions, dirname)
+      expect(result.sort()).toEqual(argumentsList.concat(anotherArgumentsList))
+    })
   })
 })

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -20,7 +20,6 @@ import axios from 'axios'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
 import { jest } from '@jest/globals'
-import Downloader from '../../src/Downloader.js'
 import fs from 'fs'
 import rimraf from 'rimraf'
 
@@ -346,18 +345,6 @@ describe('Utils', () => {
   })
 
   describe('readFileOrUrlByLine', () => {
-    test('one value', async () => {
-      const result: string[] = await readFileOrUrlByLine('testString', {}, '')
-      expect(result).toEqual(['testString'])
-    })
-
-    test('comma separated values', async () => {
-      const result: string[] = await readFileOrUrlByLine('testString1,testString2, testString3', {}, '')
-      expect(result).toEqual(['testString1', 'testString2', 'testString3'])
-    })
-  })
-
-  describe('readFileOrUrlByLine', () => {
     const now = new Date()
     const dirname = path.join(process.cwd(), `mwo-test-${+now}`)
 
@@ -377,22 +364,22 @@ describe('Utils', () => {
     })
 
     test('One string as parameter', async () => {
-      const result: string[] = await readFileOrUrlByLine('testString', {}, '')
+      const result: string[] = await readFileOrUrlByLine('testString')
       expect(result).toEqual(['testString'])
     })
 
     test('Comma separated strings as parameter', async () => {
-      const result: string[] = await readFileOrUrlByLine(argumentsList.join(','), {}, '')
+      const result: string[] = await readFileOrUrlByLine(argumentsList.join(','))
       expect(result).toEqual(argumentsList)
     })
 
     test('Filename string as parameter', async () => {
-      const result: string[] = await readFileOrUrlByLine(filePath, {}, '')
+      const result: string[] = await readFileOrUrlByLine(filePath)
       expect(result).toEqual(argumentsList)
     })
 
     test('Comma separated filenames string as parameter', async () => {
-      const result: string[] = await readFileOrUrlByLine(`${filePath},${anotherFilePath}`, {}, '')
+      const result: string[] = await readFileOrUrlByLine(`${filePath},${anotherFilePath}`)
       expect(result.sort()).toEqual(argumentsList.concat(anotherArgumentsList))
     })
 
@@ -400,8 +387,7 @@ describe('Utils', () => {
       jest.spyOn(axios, 'get').mockResolvedValue({
         data: fs.createReadStream(filePath),
       })
-      const downloader = new Downloader({} as any)
-      const result: string[] = await readFileOrUrlByLine('http://test.com/strings', downloader.streamRequestOptions, dirname)
+      const result: string[] = await readFileOrUrlByLine('http://test.com/strings')
       expect(result).toEqual(argumentsList)
     })
 
@@ -412,8 +398,7 @@ describe('Utils', () => {
       jest.spyOn(axios, 'get').mockResolvedValueOnce({
         data: fs.createReadStream(anotherFilePath),
       })
-      const downloader = new Downloader({} as any)
-      const result: string[] = await readFileOrUrlByLine('http://test.com/strings,http://test.com/another-strings', downloader.streamRequestOptions, dirname)
+      const result: string[] = await readFileOrUrlByLine('http://test.com/strings,http://test.com/another-strings')
       expect(result.sort()).toEqual(argumentsList.concat(anotherArgumentsList))
     })
   })


### PR DESCRIPTION
Added availability to set --articleList value equal to comma-separated URL's with articles list with one title per line

fix #1729