### PR TITLE
Take the protocol for logo URL from parameter --mwUrl

### DIFF
--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -528,7 +528,7 @@ async function execute(argv: any) {
 
     const parsedUrl = urlParser.parse(entries.logo)
     const faviconPath = path.join(tmpDirectory, 'favicon.png')
-    const logoUrl = parsedUrl.protocol ? entries.logo : 'http:' + entries.logo
+    const logoUrl = parsedUrl.protocol ? entries.logo : mw.baseUrl.protocol + entries.logo
     const logoContent = await downloader.downloadContent(logoUrl)
     await writeFilePromise(faviconPath, logoContent.content, null)
     return saveFavicon(zimCreator, faviconPath)

--- a/test/unit/styles.test.ts
+++ b/test/unit/styles.test.ts
@@ -21,7 +21,7 @@ describe('Styles', () => {
     await articleDetailXId.setMany(articlesDetail)
 
     const offlineCSSUrl = 'https://wiki.kiwix.org/w/index.php?title=Mediawiki:offline.css&action=raw'
-    const siteStylesUrl = 'http://en.wikipedia.org/w/load.php?lang=en&modules=site.styles&only=styles&skin=vector'
+    const siteStylesUrl = 'https://en.wikipedia.org/w/load.php?lang=en&modules=site.styles&only=styles&skin=vector'
 
     const { data: offlineCSSContent } = await Axios.get(offlineCSSUrl)
     const { data: siteStylesContent } = await Axios.get(siteStylesUrl)


### PR DESCRIPTION
MediaWiki doesn't allow downloading the logo from a URL with the http protocol.
Take the protocol for logo URL from parameter --mwUrl

#1799 