### PR TITLE
Strip html tags from title

### DIFF
--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -280,13 +280,13 @@ export function getMediaBase(url: string, escape: boolean) {
 }
 
 export function getStrippedTitleFromHtml(html: string) {
-  const doc = domino.createDocument(html)
-  const titleEl = doc.querySelector('title')
-  if (titleEl) {
-    return titleEl.textContent.replace(/<[^>]*>?/gm, '')
-  } else {
-    return ''
+  let [, , title = ''] = html.match(/<title( [^>]*)?>(.*)<[/]title>/i) || []
+  if (!title) {
+    const doc = domino.createDocument(html)
+    const titleEl = doc.querySelector('title')
+    title = titleEl ? titleEl.textContent : ''
   }
+  return title.replace(/<[^>]*>?/gm, '')
 }
 
 export function zip(...args: any[][]) {

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -283,7 +283,7 @@ export function getStrippedTitleFromHtml(html: string) {
   const doc = domino.createDocument(html)
   const titleEl = doc.querySelector('title')
   if (titleEl) {
-    return titleEl.textContent
+    return titleEl.textContent.replace(/<[^>]*>?/gm, '')
   } else {
     return ''
   }

--- a/test/unit/misc.test.ts
+++ b/test/unit/misc.test.ts
@@ -1,0 +1,71 @@
+import { contains, getStrippedTitleFromHtml } from '../../src/util/misc.js'
+import domino from 'domino'
+import { jest } from '@jest/globals'
+
+describe('Misc utility', () => {
+  test('contains', async () => {
+    const arr = [1, 2, 3]
+    const bool = contains(arr, 3)
+    expect(bool).toBeTruthy()
+  })
+
+  describe('getStrippedTitleFromHtml', () => {
+    const html = (title = 'Example') => {
+      return `<!DOCTYPE html>
+      <html>
+          <head>
+              <title>${title}</title>
+          </head>
+          <body>
+              <p>This is an example of a simple HTML page with one paragraph.</p>
+          </body>
+      </html>`
+    }
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    test('empty html', async () => {
+      const createDocumentSpy = jest.spyOn(domino, 'createDocument')
+      const title = getStrippedTitleFromHtml('')
+      expect(title).toBe('')
+      expect(createDocumentSpy).toBeCalledTimes(1)
+    })
+
+    test('not valid html', async () => {
+      const createDocumentSpy = jest.spyOn(domino, 'createDocument')
+      const title = getStrippedTitleFromHtml('this is not valid HTML')
+      expect(title).toBe('')
+      expect(createDocumentSpy).toBeCalledTimes(1)
+    })
+
+    test('empty title', async () => {
+      const createDocumentSpy = jest.spyOn(domino, 'createDocument')
+      const title = getStrippedTitleFromHtml(html(''))
+      expect(title).toBe('')
+      expect(createDocumentSpy).toBeCalledTimes(1)
+    })
+
+    test('title as plain text', async () => {
+      const createDocumentSpy = jest.spyOn(domino, 'createDocument')
+      const title = getStrippedTitleFromHtml(html())
+      expect(title).toBe('Example')
+      expect(createDocumentSpy).not.toBeCalled()
+    })
+
+    test('title with different tags', async () => {
+      const createDocumentSpy = jest.spyOn(domino, 'createDocument')
+      const title1 = getStrippedTitleFromHtml(html('<i>Example</i>'))
+      expect(title1).toBe('Example')
+
+      const title2 = getStrippedTitleFromHtml(html('Example<script>alert("hello world!")</script>'))
+      expect(title2).toBe('Examplealert("hello world!")')
+
+      const title3 = getStrippedTitleFromHtml(html('Example<script\r>alert(test)</script\r>'))
+      expect(title3).toBe('Examplealert(test)')
+
+      expect(createDocumentSpy).toBeCalledTimes(1) // only last one can't be parsed with regex
+    })
+  })
+})

--- a/test/unit/sanity.test.ts
+++ b/test/unit/sanity.test.ts
@@ -1,9 +1,0 @@
-import { contains } from '../../src/util/misc.js'
-
-describe('Sanity tests', () => {
-  test('Symple sanity test', async () => {
-    const arr = [1, 2, 3]
-    const bool = contains(arr, 3)
-    expect(bool).toBeTruthy()
-  })
-})


### PR DESCRIPTION
Strip HTML tags from the title to avoid HTML tags in the search results

fix: #1797 