### PR TITLE
Strip html tags from title

### DIFF
--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -286,7 +286,7 @@ export function getStrippedTitleFromHtml(html: string) {
     const titleEl = doc.querySelector('title')
     title = titleEl ? titleEl.textContent : ''
   }
-  return title.replace(/<[^>]*>?/gm, '')
+  return title.replace(/(<|&lt;)[^>]*(>|&gt;)?/gm, '')
 }
 
 export function zip(...args: any[][]) {

--- a/test/unit/misc.test.ts
+++ b/test/unit/misc.test.ts
@@ -56,6 +56,9 @@ describe('Misc utility', () => {
 
     test('title with different tags', async () => {
       const createDocumentSpy = jest.spyOn(domino, 'createDocument')
+      const title0 = getStrippedTitleFromHtml(html('&lt;i>Terminalia chebula&lt;/i>'))
+      expect(title0).toBe('Terminalia chebula')
+
       const title1 = getStrippedTitleFromHtml(html('<i>Example</i>'))
       expect(title1).toBe('Example')
 


### PR DESCRIPTION
Strip html tags with htmlentities from the title
Fix: #1797 