### PR TITLE
Remove part of code which redirects the page

### DIFF
--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -17,5 +17,6 @@ export const DEFAULT_WIKI_PATH = 'wiki/'
 export const ALL_READY_FUNCTION = /function allReady\( modules \) {/
 export const DO_PROPAGATION = /mw\.requestIdleCallback\( doPropagation, \{ timeout: 1 \} \);/
 export const LOAD_PHP = /script.src = ".*load\.php.*";/
+export const RULE_TO_REDIRECT = /window\.top !== window\.self/
 export const WEBP_HANDLER_URL = 'https://gist.githubusercontent.com/rgaudin/60bb9cc6f187add506584258028b8ee1/raw/9d575b8e25d67eed2a9c9a91d3e053a0062d2fc7/web-handler.js'
 export const MAX_FILE_DOWNLOAD_RETRIES = 5


### PR DESCRIPTION
Some Wikimedia sources return js with code that is not allowed to show pages in the iframe. This code makes an unexpected page redirect.
This PR replaced part of the code to avoid auto-redirect.

Fix: #1803 