### PR TITLE
Stop script and throw error if used same cli parameter twice

### DIFF
--- a/src/sanitize-argument.ts
+++ b/src/sanitize-argument.ts
@@ -10,6 +10,7 @@ import * as QueryStringParser from 'querystring'
 import { isValidEmail } from './util/index.js'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
+import { parameterDescriptions } from './parameterList.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -17,6 +18,8 @@ const __dirname = path.dirname(__filename)
 export async function sanitize_all(argv: any) {
   // extracting all arguments
   const { articleList, addNamespaces, speed: _speed, adminEmail, mwUrl, customZimFavicon, optimisationCacheUrl, verbose, customZimLongDescription, customZimDescription } = argv
+
+  sanitizeDoubleUsedParameters(argv)
 
   sanitize_articlesList_addNamespaces(articleList, addNamespaces)
 
@@ -96,6 +99,16 @@ export function sanitize_verbose(verbose: logger.LogLevel | true) {
 export function sanitize_articlesList_addNamespaces(articlesList: string, addNamespaces: string) {
   if (articlesList && addNamespaces) {
     throw new Error('options --articlesList and --addNamespaces cannot be used together')
+  }
+}
+
+export function sanitizeDoubleUsedParameters(options: object) {
+  const parameterKeys = Object.keys(parameterDescriptions)
+  const parametersWithArrayType = ['articleList', 'articleListToIgnore', 'addNamespaces']
+  for (const [optionKey, optionValue] of Object.entries(options)) {
+    if (parameterKeys.includes(optionKey) && !parametersWithArrayType.includes(optionKey) && Array.isArray(optionValue)) {
+      throw new Error(`Parameter ${optionKey} can't take value "${JSON.stringify(optionValue)}"`)
+    }
   }
 }
 

--- a/src/sanitize-argument.ts
+++ b/src/sanitize-argument.ts
@@ -14,6 +14,7 @@ import { parameterDescriptions } from './parameterList.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
+const parametersWithArrayType = ['format']
 
 export async function sanitize_all(argv: any) {
   // extracting all arguments
@@ -104,10 +105,9 @@ export function sanitize_articlesList_addNamespaces(articlesList: string, addNam
 
 export function sanitizeDoubleUsedParameters(options: object) {
   const parameterKeys = Object.keys(parameterDescriptions)
-  const parametersWithArrayType = ['articleList', 'articleListToIgnore', 'addNamespaces']
   for (const [optionKey, optionValue] of Object.entries(options)) {
     if (parameterKeys.includes(optionKey) && !parametersWithArrayType.includes(optionKey) && Array.isArray(optionValue)) {
-      throw new Error(`Parameter ${optionKey} can't take value "${JSON.stringify(optionValue)}"`)
+      throw new Error(`Parameter ${optionKey} can only be used once`)
     }
   }
 }

--- a/src/sanitize-argument.ts
+++ b/src/sanitize-argument.ts
@@ -107,7 +107,7 @@ export function sanitizeDoubleUsedParameters(options: object) {
   const parameterKeys = Object.keys(parameterDescriptions)
   for (const [optionKey, optionValue] of Object.entries(options)) {
     if (parameterKeys.includes(optionKey) && !parametersWithArrayType.includes(optionKey) && Array.isArray(optionValue)) {
-      throw new Error(`Parameter ${optionKey} can only be used once`)
+      throw new Error(`Parameter '--${optionKey}' can only be used once`)
     }
   }
 }

--- a/test/e2e/bm.e2e.test.ts
+++ b/test/e2e/bm.e2e.test.ts
@@ -31,7 +31,7 @@ describe('bm', () => {
     for (const dump of outFiles) {
       if (dump.nopic) {
         // nopic has enough files
-        expect(dump.status.files.success).toBeGreaterThan(16)
+        expect(dump.status.files.success).toBeGreaterThan(15)
         // nopic has enough redirects
         expect(dump.status.redirects.written).toBeGreaterThan(170)
         // nopic has enough articles

--- a/test/e2e/cmd.e2e.test.ts
+++ b/test/e2e/cmd.e2e.test.ts
@@ -32,10 +32,10 @@ describe('Exec Command With Bash', () => {
 
     test('Exec Command With doubled options', async () => {
       await expect(execa(`${mwo} --verbose --mwUrl="https://en.wikipedia.org" --adminEmail="test@test.test" --verbose=info`, { shell: true })).rejects.toThrow(
-        /Parameter verbose can't take value \"\[true,\"info\"\]\"/,
+        /Parameter verbose can only be used once/,
       )
       await expect(execa(`${mwo} --verbose --mwUrl="https://en.wikipedia.org" --adminEmail="test@test.test" --mwUrl="https://en.wikipedia.org"`, { shell: true })).rejects.toThrow(
-        /Parameter mwUrl can't take value \"\[\"https:\/\/en.wikipedia.org\",\"https:\/\/en.wikipedia.org\"\]\"/,
+        /Parameter mwUrl can only be used once/,
       )
     })
   })

--- a/test/e2e/cmd.e2e.test.ts
+++ b/test/e2e/cmd.e2e.test.ts
@@ -29,14 +29,5 @@ describe('Exec Command With Bash', () => {
         /\"anyString\" is not a valid value for option verbose. It should be empty or one of \[info, log, warn, error, quiet\]/,
       )
     })
-
-    test('Exec Command With doubled options', async () => {
-      await expect(execa(`${mwo} --verbose --mwUrl="https://en.wikipedia.org" --adminEmail="test@test.test" --verbose=info`, { shell: true })).rejects.toThrow(
-        /Parameter verbose can only be used once/,
-      )
-      await expect(execa(`${mwo} --verbose --mwUrl="https://en.wikipedia.org" --adminEmail="test@test.test" --mwUrl="https://en.wikipedia.org"`, { shell: true })).rejects.toThrow(
-        /Parameter mwUrl can only be used once/,
-      )
-    })
   })
 })

--- a/test/e2e/cmd.e2e.test.ts
+++ b/test/e2e/cmd.e2e.test.ts
@@ -29,5 +29,14 @@ describe('Exec Command With Bash', () => {
         /\"anyString\" is not a valid value for option verbose. It should be empty or one of \[info, log, warn, error, quiet\]/,
       )
     })
+
+    test('Exec Command With doubled options', async () => {
+      await expect(execa(`${mwo} --verbose --mwUrl="https://en.wikipedia.org" --adminEmail="test@test.test" --verbose=info`, { shell: true })).rejects.toThrow(
+        /Parameter verbose can't take value \"\[true,\"info\"\]\"/,
+      )
+      await expect(execa(`${mwo} --verbose --mwUrl="https://en.wikipedia.org" --adminEmail="test@test.test" --mwUrl="https://en.wikipedia.org"`, { shell: true })).rejects.toThrow(
+        /Parameter mwUrl can't take value \"\[\"https:\/\/en.wikipedia.org\",\"https:\/\/en.wikipedia.org\"\]\"/,
+      )
+    })
   })
 })

--- a/test/e2e/en10.e2e.test.ts
+++ b/test/e2e/en10.e2e.test.ts
@@ -34,7 +34,7 @@ describe('en10', () => {
     for (const dump of outFiles) {
       if (dump.nopic) {
         // nopic has enough files
-        expect(dump.status.files.success).toBeGreaterThan(18)
+        expect(dump.status.files.success).toBeGreaterThan(17)
         expect(dump.status.files.success).toBeLessThan(25)
         // nopic has enough redirects
         expect(dump.status.redirects.written).toBeGreaterThan(480)

--- a/test/unit/sanitize-argument.test.ts
+++ b/test/unit/sanitize-argument.test.ts
@@ -1,0 +1,47 @@
+import { sanitize_all } from '../../src/sanitize-argument.js'
+
+describe('Sanitize parameters', () => {
+  test('sanitizing usage of the same parameter more than one time', async () => {
+    // equivalent to command: node lib/cli.js --verbose --mwUrl="https://en.wikipedia.org" --adminEmail="test@test.test" --verbose=info
+    const twoVerboseParameters = {
+      _: [],
+      verbose: [true, 'info'],
+      mwUrl: 'https://en.wikipedia.org',
+      'mw-url': 'https://en.wikipedia.org',
+      adminEmail: 'test@test.test',
+      'admin-email': 'test@test.test',
+      $0: 'node_modules/ts-node/dist/child/child-entrypoint.js',
+    }
+
+    await expect(sanitize_all(twoVerboseParameters)).rejects.toThrow(/Parameter '--verbose' can only be used once/)
+
+    // equivalent to command: node lib/cli.js --verbose --mwUrl="https://en.wikipedia.org" --adminEmail="test@test.test" --mwUrl="https://en.wikipedia.org"
+    const twoUrlParameters = {
+      _: [],
+      verbose: true,
+      mwUrl: ['https://en.wikipedia.org', 'https://en.wikipedia.org'],
+      'mw-url': ['https://en.wikipedia.org', 'https://en.wikipedia.org'],
+      adminEmail: 'test@test.test',
+      'admin-email': 'test@test.test',
+      $0: 'node_modules/ts-node/dist/child/child-entrypoint.js',
+    }
+
+    await expect(sanitize_all(twoUrlParameters)).rejects.toThrow(/Parameter '--mwUrl' can only be used once/)
+
+    // equivalent to command: node lib/cli.js --verbose=info --adminEmail="est@test.test" --articleList="User:Kelson/MWoffliner_CI_reference" --mwUrl="https://en.m.wikipedia.org/" --format=nopic --format=nopdf --format=novid
+    const threeFormatParameters = {
+      _: [],
+      verbose: 'info',
+      adminEmail: 'test@test.test',
+      'admin-email': 'test@test.test',
+      articleList: 'User:Kelson/MWoffliner_CI_reference',
+      'article-list': 'User:Kelson/MWoffliner_CI_reference',
+      mwUrl: 'https://en.m.wikipedia.org/',
+      'mw-url': 'https://en.m.wikipedia.org/',
+      format: ['nopic', 'nopdf', 'novid'],
+      $0: 'node_modules/ts-node/dist/child/child-entrypoint.js',
+    }
+
+    expect(await sanitize_all(threeFormatParameters)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
When the user accidentally passes to the command line the same parameter more than one time then he can get unexpected scraper behavior.

This PR is checking parameters and if one parameter is used more than one time then the script stops and an error throws.

fix: #1818