### PR TITLE
Use "parsoid" in query string to retrieve CSS/JS dependencies

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -156,6 +156,7 @@ interface MWMetaData {
   creator: string
   mainPage: string
   textDir: TextDirection
+  mwVersion: string
 
   baseUrl: string
   wikiPath: string

--- a/test/unit/saveArticles.test.ts
+++ b/test/unit/saveArticles.test.ts
@@ -355,9 +355,10 @@ describe('saveArticles', () => {
   })
 
   test('Load inline js from HTML', async () => {
-    const { downloader, mw } = await setupScrapeClasses() // en wikipedia
+    const { downloader, mw, dump } = await setupScrapeClasses() // en wikipedia
+    await downloader.setBaseUrls()
 
-    const _moduleDependencies = await getModuleDependencies('Potato', mw, downloader)
+    const _moduleDependencies = await getModuleDependencies('Potato', mw, downloader, dump)
     // next variables declared to avoid "variable is not defined" errors
     let RLCONF: any
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/test/unit/saveArticles.test.ts
+++ b/test/unit/saveArticles.test.ts
@@ -5,7 +5,7 @@ import { setupScrapeClasses, convertWikicodeToHtml, testHtmlRewritingE2e } from 
 import { saveArticles, getModuleDependencies, treatMedias, applyOtherTreatments, treatSubtitle, treatVideo } from '../../src/util/saveArticles.js'
 import { ZimArticle } from '@openzim/libzim'
 import { Dump } from '../../src/Dump'
-import { mwRetToArticleDetail, renderDesktopArticle, DELETED_ARTICLE_ERROR } from '../../src/util/index.js'
+import { mwRetToArticleDetail, renderDesktopArticle, DELETED_ARTICLE_ERROR, ApiUrlType } from '../../src/util/index.js'
 import { jest } from '@jest/globals'
 
 jest.setTimeout(40000)
@@ -347,7 +347,8 @@ describe('saveArticles', () => {
 
   test('Test deleted article rendering', async () => {
     const articleJsonObject = {
-      visualeditor: { oldid: 0 },
+      type: ApiUrlType.VE,
+      data: { visualeditor: { oldid: 0 } },
     }
     // Throwing error if article is deleted
     expect(() => renderDesktopArticle(articleJsonObject, 'deletedArticle', { title: 'deletedArticle' })).toThrow(new Error(DELETED_ARTICLE_ERROR))


### PR DESCRIPTION
- Keep API type alongside API URL so we can properly label download results
- Add new 'UseParsoid' API type, and prefer it over MCS API
