### PR TITLE
Temporary disable VisualEditor capability check

### DIFF
--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -213,7 +213,8 @@ async function execute(argv: any) {
   await MediaWiki.hasCoordinates(downloader)
   await MediaWiki.hasWikimediaDesktopApi()
   const hasWikimediaMobileApi = await MediaWiki.hasWikimediaMobileApi()
-  await MediaWiki.hasVisualEditorApi()
+  // TODO: Enable back once regression Phabricator:T350117 fixed
+  // await MediaWiki.hasVisualEditorApi()
   await downloader.setBaseUrls(forceRender)
 
   RedisStore.setOptions(argv.redis || config.defaults.redisPath)

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -20,4 +20,5 @@ export const RULE_TO_REDIRECT = /window\.top !== window\.self/
 export const WEBP_HANDLER_URL = 'https://gist.githubusercontent.com/rgaudin/60bb9cc6f187add506584258028b8ee1/raw/9d575b8e25d67eed2a9c9a91d3e053a0062d2fc7/web-handler.js'
 export const MAX_FILE_DOWNLOAD_RETRIES = 5
 export const BLACKLISTED_NS = ['Story'] // 'Story' Wikipedia namespace is content, but not indgestable by Parsoid https://github.com/openzim/mwoffliner/issues/1853
-export const RENDERERS_LIST = ['WikimediaDesktop', 'VisualEditor', 'WikimediaMobile']
+// TODO: Enable back once regression Phabricator:T350117 fixed
+export const RENDERERS_LIST = ['WikimediaDesktop', /* 'VisualEditor',*/ 'WikimediaMobile']

--- a/test/unit/downloader.test.ts
+++ b/test/unit/downloader.test.ts
@@ -37,7 +37,8 @@ describe('Downloader class', () => {
     await MediaWiki.hasCoordinates(downloader)
     await MediaWiki.hasWikimediaDesktopApi()
     await MediaWiki.hasWikimediaMobileApi()
-    await MediaWiki.hasVisualEditorApi()
+    // TODO: Enable back once regression Phabricator:T350117 fixed
+    // await MediaWiki.hasVisualEditorApi()
     await downloader.setBaseUrls()
   })
 

--- a/test/unit/mwApi.test.ts
+++ b/test/unit/mwApi.test.ts
@@ -19,7 +19,8 @@ const initMW = async (downloader: Downloader) => {
   await MediaWiki.getMwMetaData(downloader)
   await MediaWiki.hasCoordinates(downloader)
   await MediaWiki.hasWikimediaDesktopApi()
-  await MediaWiki.hasVisualEditorApi()
+  // TODO: Enable back once regression Phabricator:T350117 fixed
+  // await MediaWiki.hasVisualEditorApi()
 
   await MediaWiki.getNamespaces([], downloader)
 }

--- a/test/unit/renderers/renderer.builder.test.ts
+++ b/test/unit/renderers/renderer.builder.test.ts
@@ -83,7 +83,8 @@ describe('RendererBuilder', () => {
     await MediaWiki.hasCoordinates(downloader)
     await MediaWiki.hasWikimediaDesktopApi()
     await MediaWiki.hasWikimediaMobileApi()
-    await MediaWiki.hasVisualEditorApi()
+    // TODO: Enable back once regression Phabricator:T350117 fixed
+    // await MediaWiki.hasVisualEditorApi()
     await downloader.setBaseUrls()
 
     const rendererBuilderOptions = {

--- a/test/unit/saveArticles.test.ts
+++ b/test/unit/saveArticles.test.ts
@@ -40,7 +40,8 @@ describe('saveArticles', () => {
       await MediaWiki.hasCoordinates(downloader)
       await MediaWiki.hasWikimediaDesktopApi()
       await MediaWiki.hasWikimediaMobileApi()
-      await MediaWiki.hasVisualEditorApi()
+      // TODO: Enable back once regression Phabricator:T350117 fixed
+      // await MediaWiki.hasVisualEditorApi()
       await downloader.setBaseUrls(renderer)
       const _articlesDetail = await downloader.getArticleDetailsIds(['London'])
       const articlesDetail = mwRetToArticleDetail(_articlesDetail)

--- a/test/util.ts
+++ b/test/util.ts
@@ -39,7 +39,8 @@ export async function setupScrapeClasses({ mwUrl = 'https://en.wikipedia.org', f
   await MediaWiki.hasCoordinates(downloader)
   await MediaWiki.hasWikimediaDesktopApi()
   await MediaWiki.hasWikimediaMobileApi()
-  await MediaWiki.hasVisualEditorApi()
+  // TODO: Enable back once regression Phabricator:T350117 fixed
+  // await MediaWiki.hasVisualEditorApi()
 
   const dump = new Dump(format, {} as any, MediaWiki.metaData)
 


### PR DESCRIPTION
This is a temporary PR that disables VisualEditor regression described in https://phabricator.wikimedia.org/T350117#9296451
It should be merged into the main, and then https://github.com/openzim/mwoffliner/pull/1939 should be rebased on top of it because https://github.com/openzim/mwoffliner/pull/1939 fixes other regressions.
Once upstream changes in MW core around VisualEditor are fixed, changes from this PR should be reverted, check https://github.com/openzim/mwoffliner/issues/1940 
