### PR TITLE
Adding insecure option to disable client certificate verification

### DIFF
--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -121,6 +121,8 @@ class Downloader {
     this.apiUrlDirector = new ApiURLDirector(MediaWiki.actionApiUrl.href)
     this.insecure = insecure
 
+    console.log('Insecure: ',this.insecure)
+
     this.backoffOptions = {
       strategy: new backoff.ExponentialStrategy(),
       failAfter: 7,

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -121,7 +121,7 @@ class Downloader {
     this.apiUrlDirector = new ApiURLDirector(MediaWiki.actionApiUrl.href)
     this.insecure = insecure
 
-    console.log('Insecure: ',this.insecure)
+    console.log('Insecure: ',this.insecure)  // printing for testing purpose
 
     this.backoffOptions = {
       strategy: new backoff.ExponentialStrategy(),

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -106,8 +106,7 @@ class Downloader {
 
   private articleUrlDirector: URLDirector
   private mainPageUrlDirector: URLDirector
-
-  private readonly insecure: boolean
+  private readonly insecure: boolean = false
 
   constructor({ uaString, speed, reqTimeout, optimisationCacheUrl, s3, webp, backoffOptions, insecure }: DownloaderOpts) {
     this.uaString = uaString
@@ -136,7 +135,7 @@ class Downloader {
     this.arrayBufferRequestOptions = {
       // HTTP agent pools with 'keepAlive' to reuse TCP connections, so it's faster
       httpAgent: new http.Agent({ keepAlive: true }),
-      httpsAgent: new https.Agent({ keepAlive: true, rejectUnauthorized: !this.insecure }), // rejectUnauthorized: false disables SSL verification
+      httpsAgent: new https.Agent({ keepAlive: true, rejectUnauthorized: !this.insecure }), // rejectUnauthorized: false disables TLS
 
       headers: {
         'cache-control': 'public, max-stale=86400',

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -121,7 +121,7 @@ class Downloader {
     this.apiUrlDirector = new ApiURLDirector(MediaWiki.actionApiUrl.href)
     this.insecure = insecure
 
-    console.log('Insecure: ',this.insecure)  // printing for testing purpose
+    console.log('Insecure: ', this.insecure) // printing for testing purpose
 
     this.backoffOptions = {
       strategy: new backoff.ExponentialStrategy(),
@@ -136,7 +136,7 @@ class Downloader {
     this.arrayBufferRequestOptions = {
       // HTTP agent pools with 'keepAlive' to reuse TCP connections, so it's faster
       httpAgent: new http.Agent({ keepAlive: true }),
-      httpsAgent: new https.Agent({ keepAlive: true , rejectUnauthorized: !this.insecure}),  // rejectUnauthorized: false disables SSL verification
+      httpsAgent: new https.Agent({ keepAlive: true, rejectUnauthorized: !this.insecure }), // rejectUnauthorized: false disables SSL verification
 
       headers: {
         'cache-control': 'public, max-stale=86400',
@@ -154,7 +154,7 @@ class Downloader {
     this.jsonRequestOptions = {
       // HTTP agent pools with 'keepAlive' to reuse TCP connections, so it's faster
       httpAgent: new http.Agent({ keepAlive: true }),
-      httpsAgent: new https.Agent({ keepAlive: true , rejectUnauthorized: !this.insecure}),
+      httpsAgent: new https.Agent({ keepAlive: true, rejectUnauthorized: !this.insecure }),
 
       headers: {
         accept: 'application/json',
@@ -172,7 +172,7 @@ class Downloader {
       // HTTP agent pools with 'keepAlive' to reuse TCP connections, so it's faster
       ...defaultStreamRequestOptions,
       httpAgent: new http.Agent({ keepAlive: true }),
-      httpsAgent: new https.Agent({ keepAlive: true , rejectUnauthorized: !this.insecure}),
+      httpsAgent: new https.Agent({ keepAlive: true, rejectUnauthorized: !this.insecure }),
 
       headers: {
         ...defaultStreamRequestOptions.headers,

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -120,8 +120,6 @@ class Downloader {
     this.apiUrlDirector = new ApiURLDirector(MediaWiki.actionApiUrl.href)
     this.insecure = insecure
 
-    console.log('Insecure: ', this.insecure) // printing for testing purpose
-
     this.backoffOptions = {
       strategy: new backoff.ExponentialStrategy(),
       failAfter: 7,

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -174,6 +174,7 @@ async function execute(argv: any) {
     optimisationCacheUrl,
     s3,
     webp,
+    insecure: argv.insecure
   })
 
   /* perform login */

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -174,7 +174,7 @@ async function execute(argv: any) {
     optimisationCacheUrl,
     s3,
     webp,
-    insecure: argv.insecure
+    insecure: argv.insecure,
   })
 
   /* perform login */

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -39,7 +39,7 @@ export const parameterDescriptions = {
   optimisationCacheUrl: 'Object Storage URL (including credentials and bucket name) to cache optimised media files',
   forceRender:
     'Force the usage of a specific API end-point/render, automatically chosen otherwise. Accepted values: [ VisualEditor, WikimediaDesktop. WikimediaMobile ]. More details at https://github.com/openzim/mwoffliner/wiki/API-end-points',
-  insecure: 'Allow insecure server connections when using HTTPS',
+  insecure: 'Skip HTTPS server authenticity verification step',
 }
 
 // TODO: Add an interface based on the object above

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -39,7 +39,7 @@ export const parameterDescriptions = {
   optimisationCacheUrl: 'Object Storage URL (including credentials and bucket name) to cache optimised media files',
   forceRender:
     'Force the usage of a specific API end-point/render, automatically chosen otherwise. Accepted values: [ VisualEditor, WikimediaDesktop. WikimediaMobile ]. More details at https://github.com/openzim/mwoffliner/wiki/API-end-points',
-  insecure: 'Allow insecure server connections when using HTTPS'
-  }
+  insecure: 'Allow insecure server connections when using HTTPS',
+}
 
 // TODO: Add an interface based on the object above

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -39,6 +39,7 @@ export const parameterDescriptions = {
   optimisationCacheUrl: 'Object Storage URL (including credentials and bucket name) to cache optimised media files',
   forceRender:
     'Force the usage of a specific API end-point/render, automatically chosen otherwise. Accepted values: [ VisualEditor, WikimediaDesktop. WikimediaMobile ]. More details at https://github.com/openzim/mwoffliner/wiki/API-end-points',
-}
+  insecure: 'Allow insecure server connections when using HTTPS'
+  }
 
 // TODO: Add an interface based on the object above

--- a/src/sanitize-argument.ts
+++ b/src/sanitize-argument.ts
@@ -35,11 +35,7 @@ export async function sanitize_all(argv: any) {
     mwActionApiPath,
     mwRestApiPath,
     mwModulePath,
-    insecure,
   } = argv
-
-  // set insecure to false by default
-  argv.insecure = insecure || false
 
   sanitizeDoubleUsedParameters(argv)
 

--- a/src/sanitize-argument.ts
+++ b/src/sanitize-argument.ts
@@ -35,7 +35,7 @@ export async function sanitize_all(argv: any) {
     mwActionApiPath,
     mwRestApiPath,
     mwModulePath,
-    insecure
+    insecure,
   } = argv
 
   // set insecure to false by default

--- a/src/sanitize-argument.ts
+++ b/src/sanitize-argument.ts
@@ -35,7 +35,11 @@ export async function sanitize_all(argv: any) {
     mwActionApiPath,
     mwRestApiPath,
     mwModulePath,
+    insecure
   } = argv
+
+  // set insecure to false by default
+  argv.insecure = insecure || false
 
   sanitizeDoubleUsedParameters(argv)
 


### PR DESCRIPTION
Added ```--insecure``` option. When provided, disables SSL certificate verification in axios. Fixes #2001 
