### PR TITLE
Fix main page name for wikis with base URL rewritten

### DIFF
--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -418,7 +418,7 @@ class MediaWiki {
     }
 
     // Base will contain the default encoded article id for the wiki.
-    const mainPage = decodeURIComponent(entries.base.split('/').pop())
+    const mainPage = entries.mainpage
     const siteName = entries.sitename
 
     // Gather languages codes (en remove the 'dialect' part)

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -417,8 +417,7 @@ class MediaWiki {
       throw new Error(`Mediawiki version ${mwVersion} not supported should be >=${mwMinimalVersion}`)
     }
 
-    // Base will contain the default encoded article id for the wiki.
-    const mainPage = entries.mainpage
+    const mainPage = entries.mainpage.replace(/ /g, '_')
     const siteName = entries.sitename
 
     // Gather languages codes (en remove the 'dialect' part)


### PR DESCRIPTION
This is a very small change that has been tested on my computer, so I'll just use the web editor.

Fixes #1995.