### PR TITLE
Check for application/json when checking visual editor api

### DIFF
--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -193,7 +193,11 @@ class MediaWiki {
   public async hasVisualEditorApi(): Promise<boolean> {
     if (this.#hasVisualEditorApi === null) {
       this.visualEditorUrlDirector = new VisualEditorURLDirector(this.visualEditorApiUrl.href)
-      this.#hasVisualEditorApi = await checkApiAvailability(this.visualEditorUrlDirector.buildArticleURL(this.apiCheckArticleId))
+      this.#hasVisualEditorApi = await checkApiAvailability(
+        this.visualEditorUrlDirector.buildArticleURL(this.apiCheckArticleId),
+        '' /* empty login cookie */,
+        this.visualEditorUrlDirector.validMimeTypes,
+      )
       return this.#hasVisualEditorApi
     }
     return this.#hasVisualEditorApi

--- a/src/util/builders/url/visual-editor.director.ts
+++ b/src/util/builders/url/visual-editor.director.ts
@@ -13,4 +13,8 @@ export default class VisualEditorURLDirector {
   buildArticleURL(articleId: string) {
     return urlBuilder.setDomain(this.baseDomain).setQueryParams({ page: articleId }, '&').build()
   }
+
+  get validMimeTypes() {
+    return ['application/json']
+  }
 }

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -260,6 +260,7 @@ export function mwRetToArticleDetail(obj: QueryMwRet): KVS<ArticleDetail> {
 
 /**
  * Check for API availability at the given URL.
+ *
  * @param url The URL to check.
  * @param loginCookie A string representing a cookie for login, if necessary.
  * @param allowedMimeTypes An array of allowed mime types for the response. If this is set, the check is only considered a

--- a/test/unit/mwApiCapabilities.test.ts
+++ b/test/unit/mwApiCapabilities.test.ts
@@ -57,8 +57,7 @@ describe('Checking Mediawiki capabilities', () => {
     expect(await MediaWiki.hasVisualEditorApi()).toBe(true)
   })
 
-  // https://github.com/openzim/mwoffliner/issues/2035
-  test.skip('test capabilities of pokemon.fandom.com with default receipt', async () => {
+  test('test capabilities of pokemon.fandom.com with default receipt', async () => {
     MediaWiki.base = 'https://pokemon.fandom.com/'
 
     expect(await MediaWiki.hasWikimediaDesktopApi()).toBe(false)
@@ -67,8 +66,7 @@ describe('Checking Mediawiki capabilities', () => {
     expect(await MediaWiki.hasVisualEditorApi()).toBe(false)
   })
 
-  // https://github.com/openzim/mwoffliner/issues/2035
-  test.skip('test capabilities of pokemon.fandom.com with RestApi receipt', async () => {
+  test('test capabilities of pokemon.fandom.com with RestApi receipt', async () => {
     MediaWiki.base = 'https://pokemon.fandom.com/'
     MediaWiki.wikiPath = '/'
     MediaWiki.restApiPath = 'rest.php'


### PR DESCRIPTION
Fixes #2035 

Add new optional param to `checkApiAvailability`, `allowedMimeTypes` which is a list of MIME types, one of which must be present for the check to pass. If this param is null (the default) the check is skipped.