### PR TITLE
Render mobile images to standard size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "split-by-grapheme": "^1.0.1",
         "swig-templates": "^2.0.3",
         "typescript": "^4.9.4",
+        "url-join": "^5.0.0",
         "utf8-binary-cutter": "^0.9.2",
         "webp-hero": "0.0.2",
         "yargs": "^17.7.1"
@@ -18805,6 +18806,14 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
       "deprecated": "Please see https://github.com/lydell/urix#deprecated"
+    },
+    "node_modules/url-join": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+      "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
     },
     "node_modules/url-parse-lax": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "split-by-grapheme": "^1.0.1",
     "swig-templates": "^2.0.3",
     "typescript": "^4.9.4",
+    "url-join": "^5.0.0",
     "utf8-binary-cutter": "^0.9.2",
     "webp-hero": "0.0.2",
     "yargs": "^17.7.1"

--- a/test/unit/renderers/mobile.renderer.test.ts
+++ b/test/unit/renderers/mobile.renderer.test.ts
@@ -96,5 +96,34 @@ describe('mobile renderer', () => {
       expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/8/8f/Bamako_et_fleuve_Niger.jpg/250px-Bamako_et_fleuve_Niger.jpg')
       expect(imgs[1].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/2/20/Bamako_bridge2.jpg/250px-Bamako_bridge2.jpg')
     })
+
+    test('it uses the data-src when data-data-file-original-src is not available', async () => {
+      const test_window = domino.createWindow(
+        `
+        <span
+          class="mw-file-element gallery-img pcs-widen-image-override pcs-lazy-load-placeholder pcs-lazy-load-placeholder-pending"
+          style="width: 150px"
+          data-class="mw-file-element gallery-img pcs-widen-image-override"
+          data-src="//upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/150px-BMW.svg.png"
+          data-srcset="//upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/225px-BMW.svg.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/300px-BMW.svg.png 2x"
+          data-width="150"
+          data-height="150"
+          data-alt="Logo used in vehicles since 1997"
+          data-data-file-width="1015"
+          data-data-file-height="1015"
+          ><span style="padding-top: 100%">
+        `,
+        'http://en.wikipedia.org/api/rest_v1/page/mobile-html/BMW',
+      )
+      const mobileRenderer = new WikimediaMobileRenderer()
+
+      const actual = mobileRenderer.INTERNAL.convertLazyLoadToImages(test_window.document)
+      const spans = actual.querySelectorAll('.pcs-lazy-load-placeholder')
+      const imgs = actual.querySelectorAll('img')
+
+      expect(spans.length).toBe(0)
+      expect(imgs.length).toBe(1)
+      expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/150px-BMW.svg.png')
+    })
   })
 })

--- a/test/unit/renderers/mobile.renderer.test.ts
+++ b/test/unit/renderers/mobile.renderer.test.ts
@@ -1,0 +1,100 @@
+import * as domino from 'domino'
+
+import { WikimediaMobileRenderer } from '../../../src/renderers/wikimedia-mobile.renderer'
+
+describe('mobile renderer', () => {
+  let window
+
+  describe('image converter', () => {
+    beforeEach(() => {
+      window = domino.createWindow(
+        `
+        <figure typeof="mw:File/Thumb" class="pcs-widen-image-ancestor">
+          <a href="./Fichier:Bamako_et_fleuve_Niger.jpg" class="mw-file-description pcs-widen-image-ancestor">
+            <span class="mw-file-element pcs-widen-image-override pcs-lazy-load-placeholder pcs-lazy-load-placeholder-pending"
+              style="width: 320px;" data-class="mw-file-element pcs-widen-image-override"
+              data-src="//upload.wikimedia.org/wikipedia/commons/thumb/8/8f/Bamako_et_fleuve_Niger.jpg/320px-Bamako_et_fleuve_Niger.jpg"
+              data-srcset="//upload.wikimedia.org/wikipedia/commons/thumb/8/8f/Bamako_et_fleuve_Niger.jpg/480px-Bamako_et_fleuve_Niger.jpg 1.5x"
+              data-width="320" data-height="241" data-data-file-width="600" data-data-file-height="450"
+              data-data-file-original-src="//upload.wikimedia.org/wikipedia/commons/thumb/8/8f/Bamako_et_fleuve_Niger.jpg/250px-Bamako_et_fleuve_Niger.jpg"
+            >
+              <span style="padding-top: 75.3125%;"></span>
+            </span>
+          </a>
+          <figcaption>Bamako</figcaption>
+        </figure>
+        <figure typeof="mw:File/Thumb" class="pcs-widen-image-ancestor">
+          <a href="./Fichier:Bamako_bridge2.jpg" class="mw-file-description pcs-widen-image-ancestor">
+            <span class="mw-file-element pcs-widen-image-override pcs-lazy-load-placeholder pcs-lazy-load-placeholder-pending"
+              style="width: 640px;" data-class="mw-file-element pcs-widen-image-override"
+              data-src="//upload.wikimedia.org/wikipedia/commons/thumb/2/20/Bamako_bridge2.jpg/640px-Bamako_bridge2.jpg"
+              data-width="640" data-height="428" data-data-file-width="800" data-data-file-height="533"
+              data-data-file-original-src="//upload.wikimedia.org/wikipedia/commons/thumb/2/20/Bamako_bridge2.jpg/250px-Bamako_bridge2.jpg"
+            >
+              <span style="padding-top: 66.875%;"></span>
+            </span>
+          </a>
+          <figcaption> Bamako Pont, mi bɛ Niger baw kan</figcaption>
+        </figure>
+
+        <p>
+          San 2021 mɔgɔ 3 000 000 dɛ tun sigin len bɛ Mali faba kɔnɔ. An bɛ yoro mi nan farafina be kono Bamakɔ fanga wili tɔgɔ ka bɔ ni bɛɛ ta ye. wa
+          dumia kɔnɔ a bɛ la wɔrɔ dugu la dɛ la singɛ munu la
+        </p>
+
+        <p><b>bamakɔ</b> dɛ yɛ ka famgadɔda yɛ.wa nafa ka bɔ a lamini mara bɛ ma </p>
+
+        <p>
+          Bamako faaba kila nɛ dɔ ni <b>ki</b> woro dɛ yɛ. ni o niɛmogo tɔgɔ IBRAHIMA N’DIAYE ni ɔ ba fɔ ɔ ma maire
+          Kinw minu bɛ Bamakɔ kɔnɔ:
+        </p>
+        <ul>
+          <li>Hippɔdrɔme (tɔgɔkɔrɔ milliɔnki)</li>
+          <li>Korofina</li>
+          <li>Badalabugu</li>
+          <li>Bamakɔ Kura</li>
+          <li>Jikoroni</li>
+          <li>Bakɔ jikɔrɔni (= derrière le fleuve)</li>
+          <li>Misira</li>
+          <li>Medina Kura</li>
+          <li>Bankɔni</li>
+          <li>Maɲambugu</li>
+          <li>Dravela</li>
+          <li>Jɛlibugu</li>
+          <li>Bolibana</li>
+          <li>Wɔlɔfɔbugu</li>
+          <li>Bajalan I,II,III</li>
+          <li>ɲarela</li>
+          <li>Bagadaji</li>
+          <li>Bozola</li>
+          <li>Falaje</li>
+          <li>ɲamakoro</li>
+          <li>Sɛbenikɔrɔ</li>
+          <li>Quinzanbugu</li>
+          <li>Kinsanbugu</li>
+          <li>Amdalayɛ</li>
+          <li>Sabalibugu</li>
+          <li>Titibugu</li>
+          <li>Lafiabugu</li>
+          <li>Badalabugu</li>
+          <li>Torokɔrɔbugu</li>
+          <li>Quartier du fleuve</li>
+        </ul>`,
+        'http://bm.wikipedia.org/api/rest_v1/page/mobile-html/BamakBamakɔ',
+      )
+    })
+
+    test('it converts lazy load to images with the proper size', async () => {
+      const mobileRenderer = new WikimediaMobileRenderer()
+
+      const actual = mobileRenderer.INTERNAL.convertLazyLoadToImages(window.document)
+      const spans = actual.querySelectorAll('.pcs-lazy-load-placeholder')
+      const imgs = actual.querySelectorAll('img')
+
+      expect(spans.length).toBe(0)
+      expect(imgs.length).toBe(2)
+      expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/8/8f/Bamako_et_fleuve_Niger.jpg/250px-Bamako_et_fleuve_Niger.jpg')
+      expect(imgs[1].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/2/20/Bamako_bridge2.jpg/250px-Bamako_bridge2.jpg')
+    })
+  })
+})


### PR DESCRIPTION
Fixes #1925

In https://phabricator.wikimedia.org/T349972 a solution was given to img `data-src` attributes hardcoding images that are too big. This was the provision of an attribute `data-data-file-original-src` which has the original src size of the image. By hacking this URL, we are able to provide images that are any size we want, in this case 140px is chosen arbitrarily.

Note the use of the `WikimediaMobileRenderer.INTERNAL` object in this PR. This is to provide test access to methods that are, and should remain private. Here, we only want to test the image transformations of the renderer with a fake document. The production implementation uses `this.INTERNAL.convertLazyLoadToImages` to reference the private method, and we do the same in the test. This is the pattern that we have agreed upon in our Typescript codebase at YouTube and I think it works fairly well, though it is a bit ugly. The benefits are clear though from looking at the unit test provided with this PR. It is short and concise and fast, tests only the method being changed, and doesn't require a network connection or setting up a long chain of mwoffliner configs and objects.