### PR TITLE
Increase test timeout to avoid flakiness

### DIFF
--- a/test/unit/mwApiCapabilities.test.ts
+++ b/test/unit/mwApiCapabilities.test.ts
@@ -1,4 +1,7 @@
 import MediaWiki from '../../src/MediaWiki.js'
+import { jest } from '@jest/globals'
+
+jest.setTimeout(30000)
 
 describe('Checking Mediawiki capabilities', () => {
   beforeEach(() => {


### PR DESCRIPTION
We were getting the following in CI:

```
FAIL test/unit/mwApiCapabilities.test.ts (10.2 s)
  ● Checking Mediawiki capabilities › test capabilities of pokemon.fandom.com with RestApi receipt

    thrown: "Exceeded timeout of 5000 ms for a test.
    Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."

      67 |   })
      68 |
    > 69 |   test('test capabilities of pokemon.fandom.com with RestApi receipt', async () => {
         |   ^
      70 |     MediaWiki.base = 'https://pokemon.fandom.com/'
      71 |     MediaWiki.wikiPath = '/'
      72 |     MediaWiki.restApiPath = 'rest.php'

      at test/unit/mwApiCapabilities.test.ts:69:3
      at test/unit/mwApiCapabilities.test.ts:3:1
```

Some of the tests have timeouts of up to 60s, so it seems reasonable to increase this timeout to 30s