### PR TITLE
Re-work image resizing

### DIFF
--- a/src/renderers/wikimedia-mobile.renderer.ts
+++ b/src/renderers/wikimedia-mobile.renderer.ts
@@ -112,7 +112,7 @@ export class WikimediaMobileRenderer extends MobileRenderer {
 
     // Calculate the ratio so we know if we're scaling down in the width or height dimension.
     const widthHeightRatio = preparedData.width / preparedData.height
-    let scaleUsingHeight = widthHeightRatio > 1.0
+    const scaleUsingHeight = widthHeightRatio > 1.0
 
     // The data-data-file-original-src attribute is the URL of the image that was used in the original article.
     // It is preferred over the data-src attribute, which is a "mobile" image that may be scaled up in order to

--- a/src/renderers/wikimedia-mobile.renderer.ts
+++ b/src/renderers/wikimedia-mobile.renderer.ts
@@ -8,7 +8,13 @@ import { RenderOpts, RenderOutput } from './abstract.renderer.js'
 type PipeFunction = (value: DominoElement) => DominoElement | Promise<DominoElement>
 
 const THUMB_WIDTH_REGEX = /\/(\d+)px-[^/]+$/
-const THUMB_MAX_WIDTH = 320
+const THUMB_MAX_DIMENSION = 320
+
+declare interface ImageMetadata {
+  src: string | null
+  width: number
+  height: number
+}
 
 // Represent 'https://{wikimedia-wiki}/api/rest_v1/page/mobile-html/'
 export class WikimediaMobileRenderer extends MobileRenderer {
@@ -96,67 +102,108 @@ export class WikimediaMobileRenderer extends MobileRenderer {
     return doc
   }
 
+  private calculateImageDimensions(span: DominoElement) {
+    // These are the attributes that were "prepared" for us by the mobile-html endpoint.
+    const preparedData = {
+      src: span.getAttribute('data-src'),
+      width: parseInt(span.getAttribute('data-width') || '0', 10),
+      height: parseInt(span.getAttribute('data-height') || '0', 10),
+    }
+
+    // Calculate the ratio so we know if we're scaling down in the width or height dimension.
+    const widthHeightRatio = preparedData.width / preparedData.height
+    let scaleUsingHeight = widthHeightRatio < 1.0
+
+    // The data-data-file-original-src attribute is the URL of the image that was used in the original article.
+    // It is preferred over the data-src attribute, which is a "mobile" image that may be scaled up in order to
+    // be "full width" on mobile devices. However, if the mobile API didn't scale the image up, then the
+    // data-data-file-original-src attribute will be missing, and we should use the data-src.
+    // See https://github.com/openzim/mwoffliner/issues/1925.
+    let originalData: ImageMetadata | undefined
+    const originalSrc = span.getAttribute('data-data-file-original-src')
+    if (originalSrc) {
+      // Try to match against an image URL with a width in it.
+      const match = THUMB_WIDTH_REGEX.exec(originalSrc)
+      if (match) {
+        const originalWidth = parseInt(match[1], 10)
+        originalData = {
+          src: originalSrc,
+          width: originalWidth,
+          height: Math.round(originalWidth / widthHeightRatio),
+        }
+      }
+    }
+
+    let maxData: ImageMetadata | undefined
+    if (scaleUsingHeight) {
+      maxData = {
+        src: null,
+        width: Math.round(THUMB_MAX_DIMENSION * widthHeightRatio),
+        height: THUMB_MAX_DIMENSION,
+      }
+    } else {
+      maxData = {
+        src: null,
+        width: THUMB_MAX_DIMENSION,
+        height: Math.round(THUMB_MAX_DIMENSION / widthHeightRatio),
+      }
+    }
+
+    return {
+      preparedData,
+      originalData,
+      maxData,
+    }
+  }
+
   private convertLazyLoadToImagesImpl(doc: DominoElement) {
     const protocol = 'https://'
     const spans = doc.querySelectorAll('.pcs-lazy-load-placeholder')
 
     spans.forEach((span: DominoElement) => {
+      const { preparedData, originalData, maxData } = this.calculateImageDimensions(span)
+
+      const widthToData = {
+        [preparedData.width]: preparedData,
+        [maxData.width]: maxData,
+        [originalData?.width || 0]: originalData,
+      }
+
+      const minWidth = originalData ? Math.min(preparedData.width, maxData.width, originalData?.width) : Math.min(preparedData.width, maxData.width)
+      let selectedData = widthToData[minWidth]
+
+      if (selectedData === maxData) {
+        // We've decided to scale down the image. Use URL hacking to create an image that scales to the size we want.
+        if (originalData) {
+          const match = THUMB_WIDTH_REGEX.exec(originalData.src)
+          if (match) {
+            selectedData.src = originalData.src.replace(`${match[1]}px`, `${selectedData.width}px`)
+          }
+        } else {
+          // No original src, or original src cannot be URL hacked.
+          const match = THUMB_WIDTH_REGEX.exec(preparedData.src)
+          if (match) {
+            selectedData.src = preparedData.src.replace(`${match[1]}px`, `${selectedData.width}px`)
+          }
+        }
+      }
+
+      if (selectedData.src === null) {
+        // We couldn't find a URL to hack, so use the smaller of the original or prepared data.
+        if (!originalData) {
+          selectedData = preparedData
+        } else {
+          const newMinWidth = Math.min(preparedData.width, originalData.width)
+          selectedData = widthToData[newMinWidth]
+        }
+      }
+
       // Create a new img element
       const img = doc.createElement('img') as DominoElement
-
-      // Set the attributes for the img element based on the data attributes in the span
-
-      // The data-data-file-original-src attribute is the URL of the image that was used in the original article.
-      // It is preferred over the data-src attribute, which is a "mobile" image that may be scaled up in order to
-      // be "full width" on mobile devices. However, if the mobile API didn't scale the image up, then the
-      // data-data-file-original-src attribute will be missing, and we should use the data-src.
-      // See https://github.com/openzim/mwoffliner/issues/1925.
-      let originalWidth: number
-      let match: RegExpMatchArray | undefined
-      const originalSrc = span.getAttribute('data-data-file-original-src')
-      if (originalSrc) {
-        // Try to match against an image URL with a width in it.
-        match = THUMB_WIDTH_REGEX.exec(originalSrc)
-        if (match) {
-          originalWidth = parseInt(match[1], 10)
-        }
-      }
-
-      // These are the attributes that were "prepared" for us by the mobile-html endpoint.
-      const preparedSrc = span.getAttribute('data-src')
-      const preparedWidth = parseInt(span.getAttribute('data-width') || '0', 10)
-      const preparedHeight = parseInt(span.getAttribute('data-height') || '0', 10)
-
-      let imgSrc = preparedSrc
-      let width = preparedWidth
-      if (originalWidth && match && originalWidth < preparedWidth) {
-        // There was a match on the originalSrc, and it is an image that is smaller than the prepared image.
-        width = originalWidth
-        imgSrc = originalSrc
-      }
-      if (THUMB_MAX_WIDTH < originalWidth || (!originalWidth && THUMB_MAX_WIDTH < preparedWidth)) {
-        // If both srcs are too big, try to either use the original URL hacking, or URL hacking on the
-        // "prepared" src, to get an image of the right size.
-        let srcToReplace = originalSrc
-        if (!match) {
-          // Try to match against the prepared URL, it might have sizing information.
-          match = THUMB_WIDTH_REGEX.exec(preparedSrc)
-          srcToReplace = preparedSrc
-        }
-        // If there is no match, we will just use the prepared image as is.
-        if (match) {
-          width = THUMB_MAX_WIDTH
-          imgSrc = srcToReplace.replace(`${match[1]}px`, `${width}px`)
-        }
-      }
-      // If the above ifs didn't execute, we're using the prepared image.
-      // This is a no-op if width == preparedWidth.
-      const height = Math.round((preparedHeight * width) / preparedWidth)
-
-      img.src = urlJoin(protocol, imgSrc)
+      img.src = urlJoin(protocol, selectedData.src)
       img.setAttribute('decoding', 'async')
-      img.width = width
-      img.height = height
+      img.width = selectedData.width
+      img.height = selectedData.height
       img.className = span.getAttribute('data-class')
 
       // Replace the span with the img element
@@ -213,7 +260,7 @@ export class WikimediaMobileRenderer extends MobileRenderer {
   }
 
   public readonly INTERNAL = {
-    convertLazyLoadToImages: this.convertLazyLoadToImagesImpl,
-    unhideSections: this.unhideSectionsImpl,
+    convertLazyLoadToImages: this.convertLazyLoadToImagesImpl.bind(this),
+    unhideSections: this.unhideSectionsImpl.bind(this),
   }
 }

--- a/src/renderers/wikimedia-mobile.renderer.ts
+++ b/src/renderers/wikimedia-mobile.renderer.ts
@@ -7,6 +7,9 @@ import { RenderOpts, RenderOutput } from './abstract.renderer.js'
 
 type PipeFunction = (value: DominoElement) => DominoElement | Promise<DominoElement>
 
+const THUMB_WIDTH_REGEX = /\/(\d+)px-[^/]+$/
+const THUMB_MAX_WIDTH = 320
+
 // Represent 'https://{wikimedia-wiki}/api/rest_v1/page/mobile-html/'
 export class WikimediaMobileRenderer extends MobileRenderer {
   constructor() {
@@ -104,15 +107,55 @@ export class WikimediaMobileRenderer extends MobileRenderer {
       // Set the attributes for the img element based on the data attributes in the span
 
       // The data-data-file-original-src attribute is the URL of the image that was used in the original article.
-      // It is preferred over the data-src attribute, which is a "mobile" image that may be scaled up to 320px
-      // or 640px in order to be "full width" on mobile devices. However, if the mobile API didn't scale the
-      // image up, then the data-data-file-original-src attribute will be missing, and we should use the data-src.
+      // It is preferred over the data-src attribute, which is a "mobile" image that may be scaled up in order to
+      // be "full width" on mobile devices. However, if the mobile API didn't scale the image up, then the
+      // data-data-file-original-src attribute will be missing, and we should use the data-src.
       // See https://github.com/openzim/mwoffliner/issues/1925.
-      const imgSrc = span.getAttribute('data-data-file-original-src') || span.getAttribute('data-src')
+      let originalWidth: number
+      let match: RegExpMatchArray | undefined
+      const originalSrc = span.getAttribute('data-data-file-original-src')
+      if (originalSrc) {
+        // Try to match against an image URL with a width in it.
+        match = THUMB_WIDTH_REGEX.exec(originalSrc)
+        if (match) {
+          originalWidth = parseInt(match[1], 10)
+        }
+      }
+
+      // These are the attributes that were "prepared" for us by the mobile-html endpoint.
+      const preparedSrc = span.getAttribute('data-src')
+      const preparedWidth = parseInt(span.getAttribute('data-width') || '0', 10)
+      const preparedHeight = parseInt(span.getAttribute('data-height') || '0', 10)
+
+      let imgSrc = preparedSrc
+      let width = preparedWidth
+      let height: number
+      if (originalWidth && match && originalWidth < preparedWidth) {
+        // There was a match on the originalSrc, and it is an image that is smaller than the prepared image.
+        width = originalWidth
+        imgSrc = originalSrc
+      }
+      if (THUMB_MAX_WIDTH < originalWidth && THUMB_MAX_WIDTH < preparedWidth) {
+        let srcToReplace = originalSrc
+        if (!match) {
+          // Try to match against the prepared URL, it might have sizing information.
+          match = THUMB_WIDTH_REGEX.exec(preparedSrc)
+          srcToReplace = preparedSrc
+        }
+        // If there is no match, we will just use the prepared image as is.
+        if (match) {
+          width = THUMB_MAX_WIDTH
+          imgSrc = srcToReplace.replace(`${match[1]}px`, `${width}px`)
+        }
+      }
+      // If the above ifs didn't execute, we're using the prepared image.
+      // This is a no-op if width == preparedWidth.
+      height = Math.round((preparedHeight * width) / preparedWidth)
+
       img.src = urlJoin(protocol, imgSrc)
       img.setAttribute('decoding', 'async')
-      img.width = span.getAttribute('data-width')
-      img.height = span.getAttribute('data-height')
+      img.width = width
+      img.height = height
       img.className = span.getAttribute('data-class')
 
       // Replace the span with the img element

--- a/src/renderers/wikimedia-mobile.renderer.ts
+++ b/src/renderers/wikimedia-mobile.renderer.ts
@@ -129,7 +129,6 @@ export class WikimediaMobileRenderer extends MobileRenderer {
 
       let imgSrc = preparedSrc
       let width = preparedWidth
-      let height: number
       if (originalWidth && match && originalWidth < preparedWidth) {
         // There was a match on the originalSrc, and it is an image that is smaller than the prepared image.
         width = originalWidth
@@ -150,7 +149,7 @@ export class WikimediaMobileRenderer extends MobileRenderer {
       }
       // If the above ifs didn't execute, we're using the prepared image.
       // This is a no-op if width == preparedWidth.
-      height = Math.round((preparedHeight * width) / preparedWidth)
+      const height = Math.round((preparedHeight * width) / preparedWidth)
 
       img.src = urlJoin(protocol, imgSrc)
       img.setAttribute('decoding', 'async')

--- a/src/renderers/wikimedia-mobile.renderer.ts
+++ b/src/renderers/wikimedia-mobile.renderer.ts
@@ -112,7 +112,7 @@ export class WikimediaMobileRenderer extends MobileRenderer {
 
     // Calculate the ratio so we know if we're scaling down in the width or height dimension.
     const widthHeightRatio = preparedData.width / preparedData.height
-    let scaleUsingHeight = widthHeightRatio < 1.0
+    let scaleUsingHeight = widthHeightRatio > 1.0
 
     // The data-data-file-original-src attribute is the URL of the image that was used in the original article.
     // It is preferred over the data-src attribute, which is a "mobile" image that may be scaled up in order to

--- a/src/renderers/wikimedia-mobile.renderer.ts
+++ b/src/renderers/wikimedia-mobile.renderer.ts
@@ -134,7 +134,9 @@ export class WikimediaMobileRenderer extends MobileRenderer {
         width = originalWidth
         imgSrc = originalSrc
       }
-      if (THUMB_MAX_WIDTH < originalWidth && THUMB_MAX_WIDTH < preparedWidth) {
+      if (THUMB_MAX_WIDTH < originalWidth || (!originalWidth && THUMB_MAX_WIDTH < preparedWidth)) {
+        // If both srcs are too big, try to either use the original URL hacking, or URL hacking on the
+        // "prepared" src, to get an image of the right size.
         let srcToReplace = originalSrc
         if (!match) {
           // Try to match against the prepared URL, it might have sizing information.

--- a/test/unit/renderers/mobile.renderer.test.ts
+++ b/test/unit/renderers/mobile.renderer.test.ts
@@ -122,8 +122,8 @@ describe('mobile renderer', () => {
       expect(imgs[1].height).toEqual(167)
     })
 
-    describe('when the image needs to be scaled in the width dimension', () => {
-      test('uses max width of 320 when src and data-data-file-original-src are both bigger', async () => {
+    describe('when the image width is greater than the height', () => {
+      test('uses max height of 320 when src and data-data-file-original-src are both bigger', async () => {
         const test_window = domino.createWindow(
           `
           <span
@@ -149,11 +149,11 @@ describe('mobile renderer', () => {
 
         expect(spans.length).toBe(0)
         expect(imgs.length).toBe(1)
-        expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/320px-BMW.svg.png')
-        expect(imgs[0].width).toEqual(320)
-        expect(imgs[0].height).toEqual(256)
+        expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/400px-BMW.svg.png')
+        expect(imgs[0].width).toEqual(400)
+        expect(imgs[0].height).toEqual(320)
       })
-      test('uses max width of 320 when there is no original src and the prepared src is too big', async () => {
+      test('uses max height of 320 when there is no original src and the prepared src is too big', async () => {
         const test_window = domino.createWindow(
           `
           <span
@@ -178,9 +178,9 @@ describe('mobile renderer', () => {
 
         expect(spans.length).toBe(0)
         expect(imgs.length).toBe(1)
-        expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/320px-BMW.svg.png')
-        expect(imgs[0].width).toEqual(320)
-        expect(imgs[0].height).toEqual(256)
+        expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/400px-BMW.svg.png')
+        expect(imgs[0].width).toEqual(400)
+        expect(imgs[0].height).toEqual(320)
       })
       test('uses the prepared src width when it is the smallest', async () => {
         const test_window = domino.createWindow(
@@ -243,7 +243,7 @@ describe('mobile renderer', () => {
       })
     })
 
-    describe('when the image needs to be scaled in the height dimension', () => {
+    describe('when the image height is greater than the width', () => {
       test('uses max height of 320 when src and data-data-file-original-src are both bigger', async () => {
         const test_window = domino.createWindow(
           `
@@ -270,9 +270,9 @@ describe('mobile renderer', () => {
 
         expect(spans.length).toBe(0)
         expect(imgs.length).toBe(1)
-        expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/256px-BMW.svg.png')
-        expect(imgs[0].width).toEqual(256)
-        expect(imgs[0].height).toEqual(320)
+        expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/320px-BMW.svg.png')
+        expect(imgs[0].width).toEqual(320)
+        expect(imgs[0].height).toEqual(400)
       })
       test('uses max height of 320 when there is no original src and the prepared src is too big', async () => {
         const test_window = domino.createWindow(
@@ -299,9 +299,9 @@ describe('mobile renderer', () => {
 
         expect(spans.length).toBe(0)
         expect(imgs.length).toBe(1)
-        expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/256px-BMW.svg.png')
-        expect(imgs[0].width).toEqual(256)
-        expect(imgs[0].height).toEqual(320)
+        expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/320px-BMW.svg.png')
+        expect(imgs[0].width).toEqual(320)
+        expect(imgs[0].height).toEqual(400)
       })
       test('uses the prepared src width when it is the smallest', async () => {
         const test_window = domino.createWindow(

--- a/test/unit/renderers/mobile.renderer.test.ts
+++ b/test/unit/renderers/mobile.renderer.test.ts
@@ -122,123 +122,246 @@ describe('mobile renderer', () => {
       expect(imgs[1].height).toEqual(167)
     })
 
-    test('uses max width of 320 when src and data-data-file-original-src are both bigger', async () => {
-      const test_window = domino.createWindow(
-        `
-        <span
+    describe('when the image needs to be scaled in the width dimension', () => {
+      test('uses max width of 320 when src and data-data-file-original-src are both bigger', async () => {
+        const test_window = domino.createWindow(
+          `
+          <span
           class="mw-file-element gallery-img pcs-widen-image-override pcs-lazy-load-placeholder pcs-lazy-load-placeholder-pending"
           style="width: 1500px"
           data-class="mw-file-element gallery-img pcs-widen-image-override"
           data-src="//upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/1500px-BMW.svg.png"
           data-width="1500"
-          data-height="1500"
+          data-height="1200"
           data-alt="Logo used in vehicles since 1997"
-          data-data-file-width="1815"
-          data-data-file-height="1815"
-          data-data-file-original-src="//upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/800px-BMW.svg.png"
+          data-data-file-width="3000"
+          data-data-file-height="2400"
+          data-data-file-original-src="//upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/750px-BMW.svg.png"
           ><span style="padding-top: 100%">
-        `,
-        'http://en.wikipedia.org/api/rest_v1/page/mobile-html/BMW',
-      )
-      const mobileRenderer = new WikimediaMobileRenderer()
+          `,
+          'http://en.wikipedia.org/api/rest_v1/page/mobile-html/BMW',
+        )
+        const mobileRenderer = new WikimediaMobileRenderer()
 
-      const actual = mobileRenderer.INTERNAL.convertLazyLoadToImages(test_window.document)
-      const spans = actual.querySelectorAll('.pcs-lazy-load-placeholder')
-      const imgs = actual.querySelectorAll('img')
+        const actual = mobileRenderer.INTERNAL.convertLazyLoadToImages(test_window.document)
+        const spans = actual.querySelectorAll('.pcs-lazy-load-placeholder')
+        const imgs = actual.querySelectorAll('img')
 
-      expect(spans.length).toBe(0)
-      expect(imgs.length).toBe(1)
-      expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/320px-BMW.svg.png')
-      expect(imgs[0].width).toEqual(320)
-      expect(imgs[0].height).toEqual(320)
-    })
-    test('uses max width of 320 when there is no original src and the prepared src is too big', async () => {
-      const test_window = domino.createWindow(
-        `
-        <span
+        expect(spans.length).toBe(0)
+        expect(imgs.length).toBe(1)
+        expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/320px-BMW.svg.png')
+        expect(imgs[0].width).toEqual(320)
+        expect(imgs[0].height).toEqual(256)
+      })
+      test('uses max width of 320 when there is no original src and the prepared src is too big', async () => {
+        const test_window = domino.createWindow(
+          `
+          <span
           class="mw-file-element gallery-img pcs-widen-image-override pcs-lazy-load-placeholder pcs-lazy-load-placeholder-pending"
           style="width: 1500px"
           data-class="mw-file-element gallery-img pcs-widen-image-override"
-          data-src="//upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/1000px-BMW.svg.png"
-          data-width="1000"
-          data-height="1000"
+          data-src="//upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/1500px-BMW.svg.png"
+          data-width="1500"
+          data-height="1200"
           data-alt="Logo used in vehicles since 1997"
-          data-data-file-width="1815"
-          data-data-file-height="1815"
+          data-data-file-width="3000"
+          data-data-file-height="2400"
           ><span style="padding-top: 100%">
-        `,
-        'http://en.wikipedia.org/api/rest_v1/page/mobile-html/BMW',
-      )
-      const mobileRenderer = new WikimediaMobileRenderer()
+          `,
+          'http://en.wikipedia.org/api/rest_v1/page/mobile-html/BMW',
+        )
+        const mobileRenderer = new WikimediaMobileRenderer()
 
-      const actual = mobileRenderer.INTERNAL.convertLazyLoadToImages(test_window.document)
-      const spans = actual.querySelectorAll('.pcs-lazy-load-placeholder')
-      const imgs = actual.querySelectorAll('img')
+        const actual = mobileRenderer.INTERNAL.convertLazyLoadToImages(test_window.document)
+        const spans = actual.querySelectorAll('.pcs-lazy-load-placeholder')
+        const imgs = actual.querySelectorAll('img')
 
-      expect(spans.length).toBe(0)
-      expect(imgs.length).toBe(1)
-      expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/320px-BMW.svg.png')
-      expect(imgs[0].width).toEqual(320)
-      expect(imgs[0].height).toEqual(320)
-    })
-    test('uses original src width when it is the smallest', async () => {
-      const test_window = domino.createWindow(
-        `
-        <span
+        expect(spans.length).toBe(0)
+        expect(imgs.length).toBe(1)
+        expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/320px-BMW.svg.png')
+        expect(imgs[0].width).toEqual(320)
+        expect(imgs[0].height).toEqual(256)
+      })
+      test('uses the prepared src width when it is the smallest', async () => {
+        const test_window = domino.createWindow(
+          `
+          <span
           class="mw-file-element gallery-img pcs-widen-image-override pcs-lazy-load-placeholder pcs-lazy-load-placeholder-pending"
           style="width: 1500px"
           data-class="mw-file-element gallery-img pcs-widen-image-override"
           data-src="//upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/150px-BMW.svg.png"
           data-width="150"
-          data-height="150"
+          data-height="120"
           data-alt="Logo used in vehicles since 1997"
-          data-data-file-width="1815"
-          data-data-file-height="1815"
+          data-data-file-width="3000"
+          data-data-file-height="2400"
           data-data-file-original-src="//upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/800px-BMW.svg.png"
           ><span style="padding-top: 100%">
-        `,
-        'http://en.wikipedia.org/api/rest_v1/page/mobile-html/BMW',
-      )
-      const mobileRenderer = new WikimediaMobileRenderer()
+          `,
+          'http://en.wikipedia.org/api/rest_v1/page/mobile-html/BMW',
+        )
+        const mobileRenderer = new WikimediaMobileRenderer()
 
-      const actual = mobileRenderer.INTERNAL.convertLazyLoadToImages(test_window.document)
-      const spans = actual.querySelectorAll('.pcs-lazy-load-placeholder')
-      const imgs = actual.querySelectorAll('img')
+        const actual = mobileRenderer.INTERNAL.convertLazyLoadToImages(test_window.document)
+        const spans = actual.querySelectorAll('.pcs-lazy-load-placeholder')
+        const imgs = actual.querySelectorAll('img')
 
-      expect(spans.length).toBe(0)
-      expect(imgs.length).toBe(1)
-      expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/150px-BMW.svg.png')
-      expect(imgs[0].width).toEqual(150)
-      expect(imgs[0].height).toEqual(150)
-    })
-    test('uses prepared src when there is no original src, and no way to URL hack', async () => {
-      const test_window = domino.createWindow(
-        `
-        <span
+        expect(spans.length).toBe(0)
+        expect(imgs.length).toBe(1)
+        expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/150px-BMW.svg.png')
+        expect(imgs[0].width).toEqual(150)
+        expect(imgs[0].height).toEqual(120)
+      })
+      test('uses prepared src when there is no original src, and no way to URL hack', async () => {
+        const test_window = domino.createWindow(
+          `
+          <span
           class="mw-file-element gallery-img pcs-widen-image-override pcs-lazy-load-placeholder pcs-lazy-load-placeholder-pending"
           style="width: 1500px"
           data-class="mw-file-element gallery-img pcs-widen-image-override"
           data-src="//upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/BMW.svg.png"
           data-width="800"
-          data-height="800"
+          data-height="600"
           data-alt="Logo used in vehicles since 1997"
-          data-data-file-width="1815"
-          data-data-file-height="1815"
+          data-data-file-width="3000"
+          data-data-file-height="2400"
           ><span style="padding-top: 100%">
-        `,
-        'http://en.wikipedia.org/api/rest_v1/page/mobile-html/BMW',
-      )
-      const mobileRenderer = new WikimediaMobileRenderer()
+          `,
+          'http://en.wikipedia.org/api/rest_v1/page/mobile-html/BMW',
+        )
+        const mobileRenderer = new WikimediaMobileRenderer()
 
-      const actual = mobileRenderer.INTERNAL.convertLazyLoadToImages(test_window.document)
-      const spans = actual.querySelectorAll('.pcs-lazy-load-placeholder')
-      const imgs = actual.querySelectorAll('img')
+        const actual = mobileRenderer.INTERNAL.convertLazyLoadToImages(test_window.document)
+        const spans = actual.querySelectorAll('.pcs-lazy-load-placeholder')
+        const imgs = actual.querySelectorAll('img')
 
-      expect(spans.length).toBe(0)
-      expect(imgs.length).toBe(1)
-      expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/BMW.svg.png')
-      expect(imgs[0].width).toEqual(800)
-      expect(imgs[0].height).toEqual(800)
+        expect(spans.length).toBe(0)
+        expect(imgs.length).toBe(1)
+        expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/BMW.svg.png')
+        expect(imgs[0].width).toEqual(800)
+        expect(imgs[0].height).toEqual(600)
+      })
+    })
+
+    describe('when the image needs to be scaled in the height dimension', () => {
+      test('uses max height of 320 when src and data-data-file-original-src are both bigger', async () => {
+        const test_window = domino.createWindow(
+          `
+          <span
+          class="mw-file-element gallery-img pcs-widen-image-override pcs-lazy-load-placeholder pcs-lazy-load-placeholder-pending"
+          style="width: 1500px"
+          data-class="mw-file-element gallery-img pcs-widen-image-override"
+          data-src="//upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/1200px-BMW.svg.png"
+          data-width="1200"
+          data-height="1500"
+          data-alt="Logo used in vehicles since 1997"
+          data-data-file-width="2400"
+          data-data-file-height="3000"
+          data-data-file-original-src="//upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/800px-BMW.svg.png"
+          ><span style="padding-top: 100%">
+          `,
+          'http://en.wikipedia.org/api/rest_v1/page/mobile-html/BMW',
+        )
+        const mobileRenderer = new WikimediaMobileRenderer()
+
+        const actual = mobileRenderer.INTERNAL.convertLazyLoadToImages(test_window.document)
+        const spans = actual.querySelectorAll('.pcs-lazy-load-placeholder')
+        const imgs = actual.querySelectorAll('img')
+
+        expect(spans.length).toBe(0)
+        expect(imgs.length).toBe(1)
+        expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/256px-BMW.svg.png')
+        expect(imgs[0].width).toEqual(256)
+        expect(imgs[0].height).toEqual(320)
+      })
+      test('uses max height of 320 when there is no original src and the prepared src is too big', async () => {
+        const test_window = domino.createWindow(
+          `
+          <span
+          class="mw-file-element gallery-img pcs-widen-image-override pcs-lazy-load-placeholder pcs-lazy-load-placeholder-pending"
+          style="width: 1500px"
+          data-class="mw-file-element gallery-img pcs-widen-image-override"
+          data-src="//upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/1200px-BMW.svg.png"
+          data-width="1200"
+          data-height="1500"
+          data-alt="Logo used in vehicles since 1997"
+          data-data-file-width="2400"
+          data-data-file-height="3000"
+          ><span style="padding-top: 100%">
+          `,
+          'http://en.wikipedia.org/api/rest_v1/page/mobile-html/BMW',
+        )
+        const mobileRenderer = new WikimediaMobileRenderer()
+
+        const actual = mobileRenderer.INTERNAL.convertLazyLoadToImages(test_window.document)
+        const spans = actual.querySelectorAll('.pcs-lazy-load-placeholder')
+        const imgs = actual.querySelectorAll('img')
+
+        expect(spans.length).toBe(0)
+        expect(imgs.length).toBe(1)
+        expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/256px-BMW.svg.png')
+        expect(imgs[0].width).toEqual(256)
+        expect(imgs[0].height).toEqual(320)
+      })
+      test('uses the prepared src width when it is the smallest', async () => {
+        const test_window = domino.createWindow(
+          `
+          <span
+          class="mw-file-element gallery-img pcs-widen-image-override pcs-lazy-load-placeholder pcs-lazy-load-placeholder-pending"
+          style="width: 1500px"
+          data-class="mw-file-element gallery-img pcs-widen-image-override"
+          data-src="//upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/120px-BMW.svg.png"
+          data-width="120"
+          data-height="150"
+          data-alt="Logo used in vehicles since 1997"
+          data-data-file-width="2400"
+          data-data-file-height="3000"
+          data-data-file-original-src="//upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/800px-BMW.svg.png"
+          ><span style="padding-top: 100%">
+          `,
+          'http://en.wikipedia.org/api/rest_v1/page/mobile-html/BMW',
+        )
+        const mobileRenderer = new WikimediaMobileRenderer()
+
+        const actual = mobileRenderer.INTERNAL.convertLazyLoadToImages(test_window.document)
+        const spans = actual.querySelectorAll('.pcs-lazy-load-placeholder')
+        const imgs = actual.querySelectorAll('img')
+
+        expect(spans.length).toBe(0)
+        expect(imgs.length).toBe(1)
+        expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/120px-BMW.svg.png')
+        expect(imgs[0].width).toEqual(120)
+        expect(imgs[0].height).toEqual(150)
+      })
+      test('uses prepared src when there is no original src, and no way to URL hack', async () => {
+        const test_window = domino.createWindow(
+          `
+          <span
+          class="mw-file-element gallery-img pcs-widen-image-override pcs-lazy-load-placeholder pcs-lazy-load-placeholder-pending"
+          style="width: 1500px"
+          data-class="mw-file-element gallery-img pcs-widen-image-override"
+          data-src="//upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/BMW.svg.png"
+          data-width="1200"
+          data-height="1500"
+          data-alt="Logo used in vehicles since 1997"
+          data-data-file-width="2400"
+          data-data-file-height="3000"
+          ><span style="padding-top: 100%">
+          `,
+          'http://en.wikipedia.org/api/rest_v1/page/mobile-html/BMW',
+        )
+        const mobileRenderer = new WikimediaMobileRenderer()
+
+        const actual = mobileRenderer.INTERNAL.convertLazyLoadToImages(test_window.document)
+        const spans = actual.querySelectorAll('.pcs-lazy-load-placeholder')
+        const imgs = actual.querySelectorAll('img')
+
+        expect(spans.length).toBe(0)
+        expect(imgs.length).toBe(1)
+        expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/BMW.svg.png')
+        expect(imgs[0].width).toEqual(1200)
+        expect(imgs[0].height).toEqual(1500)
+      })
     })
   })
 })

--- a/test/unit/renderers/mobile.renderer.test.ts
+++ b/test/unit/renderers/mobile.renderer.test.ts
@@ -152,7 +152,35 @@ describe('mobile renderer', () => {
       expect(imgs[0].width).toEqual(320)
       expect(imgs[0].height).toEqual(320)
     })
+    test('uses max width of 320 when there is no original src and the prepared src is too big', async () => {
+      const test_window = domino.createWindow(
+        `
+        <span
+          class="mw-file-element gallery-img pcs-widen-image-override pcs-lazy-load-placeholder pcs-lazy-load-placeholder-pending"
+          style="width: 1500px"
+          data-class="mw-file-element gallery-img pcs-widen-image-override"
+          data-src="//upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/1000px-BMW.svg.png"
+          data-width="1000"
+          data-height="1000"
+          data-alt="Logo used in vehicles since 1997"
+          data-data-file-width="1815"
+          data-data-file-height="1815"
+          ><span style="padding-top: 100%">
+        `,
+        'http://en.wikipedia.org/api/rest_v1/page/mobile-html/BMW',
+      )
+      const mobileRenderer = new WikimediaMobileRenderer()
 
+      const actual = mobileRenderer.INTERNAL.convertLazyLoadToImages(test_window.document)
+      const spans = actual.querySelectorAll('.pcs-lazy-load-placeholder')
+      const imgs = actual.querySelectorAll('img')
+
+      expect(spans.length).toBe(0)
+      expect(imgs.length).toBe(1)
+      expect(imgs[0].src).toEqual('https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/BMW.svg/320px-BMW.svg.png')
+      expect(imgs[0].width).toEqual(320)
+      expect(imgs[0].height).toEqual(320)
+    })
     test('uses original src width when it is the smallest', async () => {
       const test_window = domino.createWindow(
         `


### PR DESCRIPTION
Fixes #1925
Fixes #2071

Re-work image sizing algorithm. It now enforces a maximum image width of 320px.

This value is chosen because it is a reasonable size on both mobile and desktop, but saves bandwidth compared to "full size" images (which was what the code might have been grabbing from `data-data-original-file-src` before). This should give us a nice tradeoff between efficiency and quality. We can always adjust this value later, of course, but the logic for retrieving and resizing the image URLs remains the same.

Of note, it takes the smallest of:

* The `src` attribute set on the `<span>` itself that will become the image
* The `data-data-original-file-src` attribute, of the original size the image was in the article
* 320px, provided it can look at one of the previous two URLs and find a URL that is hackable to set the image size.

Tests have been added/adjusted.

EDIT:

Additionally, based on feedback in this thread, I have modified the algorithm to refrain from scaling *any* dimension smaller than 320px. So for large panorama images such as in the enwiki Paris article, the image does not get destroyed because it is so wide (because scaling to a width of 320px leaves a height of 50px)