### PR TITLE
Relocate inline <body> scripts to their own tag in the <head>

### DIFF
--- a/res/templates/inline_js_to_head_wrapper.html
+++ b/res/templates/inline_js_to_head_wrapper.html
@@ -1,0 +1,8 @@
+<script>
+(function () {
+  // Scripts taken from inline JS, concatenated, and moved here.
+  document.addEventListener('DOMContentLoaded', function () {
+    {{ jsContent | safe }}
+  })
+})()
+</script>

--- a/res/templates/pageWikimediaDesktop.html
+++ b/res/templates/pageWikimediaDesktop.html
@@ -1,10 +1,10 @@
-<!DOCTYPE html>
-<html class='client-js'>
+<!doctype html>
+<html class="client-js">
   <head>
-    <meta charset="UTF-8"/>
+    <meta charset="UTF-8" />
     <title></title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/> __ARTICLE_CANONICAL_LINK__ __ARTICLE_CSS_LIST__
-    __CSS_LINKS__ __JS_SCRIPTS__
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    __ARTICLE_CANONICAL_LINK__ __ARTICLE_CSS_LIST__ __CSS_LINKS__ __JS_SCRIPTS__ __RELOCATED_INLINE_JS__
   </head>
   <body class="mediawiki mw-hide-empty-elt ns-0 ns-subject stable skin-minerva action-view animations">
     <div id="mw-mf-viewport" class="feature-header-v2">
@@ -12,13 +12,12 @@
         <div id="content" class="mw-body">
           <a id="top"></a>
           <div id="bodyContent" class="content mw-parser-output">
-            <h1 id="titleHeading" style="background-color: white; margin: 0;"></h1>
+            <h1 id="titleHeading" style="background-color: white; margin: 0"></h1>
             <div id="mw-content-text"></div>
           </div>
         </div>
       </div>
     </div>
-    __ARTICLE_CONFIGVARS_LIST__
-    __ARTICLE_JS_LIST__
+    __ARTICLE_CONFIGVARS_LIST__ __ARTICLE_JS_LIST__
   </body>
 </html>

--- a/res/templates/pageWikimediaMobile.html
+++ b/res/templates/pageWikimediaMobile.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8"/>
     <title></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/> __ARTICLE_CANONICAL_LINK__ __ARTICLE_CSS_LIST__
-    __CSS_LINKS__ __ARTICLE_JS_LIST__
+    __CSS_LINKS__ __ARTICLE_JS_LIST__ __RELOCATED_INLINE_JS__
   </head>
   <body class="mediawiki mw-hide-empty-elt ns-0 ns-subject stable skin-minerva action-view animations">
     <div id="mw-mf-viewport" class="feature-header-v2">

--- a/src/Templates.ts
+++ b/src/Templates.ts
@@ -20,6 +20,7 @@ const subSectionTemplate = swig.compile(readTemplate(config.output.templates.sub
 const categoriesTemplate = swig.compile(readTemplate(config.output.templates.categories))
 const subCategoriesTemplate = swig.compile(readTemplate(config.output.templates.subCategories))
 const subPagesTemplate = swig.compile(readTemplate(config.output.templates.subPages))
+const inlineJsToHeadWrapperTemplate = swig.compile(readTemplate(config.output.templates.inlineJsToHeadWrapper))
 
 const htmlWikimediaMobileTemplateCode = () => {
   return readTemplate(config.output.templates.pageWikimediaMobile)
@@ -42,4 +43,5 @@ export {
   categoriesTemplate,
   subCategoriesTemplate,
   subPagesTemplate,
+  inlineJsToHeadWrapperTemplate,
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -103,6 +103,7 @@ const config = {
     templates: {
       /* In these files, the following replacements will occur:
        * __ARTICLE_JS_LIST__  ==> list of script tags linking to all the js modules dependencies
+       * __RELOCATED_INLINE_JS__ ==> inline js code that was moved to the head
        * __ARTICLE_CSS_LIST__ ==> list of link tags linking to all the css modules dependencies
        * __CSS_LINKS__        ==> list of link tags for config.output.cssResources
        */
@@ -128,6 +129,9 @@ const config = {
 
       /* Template for wrapping subsections */
       subsection_wrapper: './templates/subsection_wrapper.html',
+
+      /** HTML snippet used when moving inline JS to a head <script> tag */
+      inlineJsToHeadWrapper: './templates/inline_js_to_head_wrapper.html',
     },
   },
 }

--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -689,11 +689,12 @@ export abstract class Renderer {
    * Because of CSP, some ZIM reader environments do not allow inline JS. Create a new JS script by combining
    * all of the inline scripts. Not sure if the JS will still work, but it's better than just deleting it. See
    * https://github.com/openzim/mwoffliner/issues/2096
+   *
    * @param parsoidDoc
    */
   private collectInlineJsImpl(parsoidDoc: DominoElement): string {
     const scripts = Array.from(parsoidDoc.getElementsByTagName('script')) as DominoElement[]
-    let collectedJs = []
+    const collectedJs = []
     for (const script of scripts) {
       if (script.innerHTML) {
         collectedJs.push(script.innerHTML)

--- a/src/renderers/abstractDesktop.render.ts
+++ b/src/renderers/abstractDesktop.render.ts
@@ -33,7 +33,7 @@ export abstract class DesktopRenderer extends Renderer {
     return wikimediaDesktopModuleDependencies
   }
 
-  public templateDesktopArticle(moduleDependencies: any, articleId: string): Document {
+  public templateDesktopArticle(moduleDependencies: any, articleId: string, collectedInlineJs: string): Document {
     const { jsConfigVars, jsDependenciesList, styleDependenciesList } = moduleDependencies as {
       jsConfigVars
       jsDependenciesList: string[]
@@ -62,6 +62,7 @@ export abstract class DesktopRenderer extends Renderer {
         '__ARTICLE_JS_LIST__',
         jsDependenciesList.length !== 0 ? jsDependenciesList.map((oneJsDep) => genHeaderScript(config, oneJsDep, articleId, config.output.dirs.mediawiki)).join('\n') : '',
       )
+      .replace('__RELOCATED_INLINE_JS__', collectedInlineJs ? this.genWikimediaMobileOverrideInlineScript(collectedInlineJs) : '')
       .replace(
         '__ARTICLE_CSS_LIST__',
         styleDependenciesList.length !== 0 ? styleDependenciesList.map((oneCssDep) => genHeaderCSSLink(config, oneCssDep, articleId, config.output.dirs.mediawiki)).join('\n') : '',

--- a/src/renderers/abstractMobile.render.ts
+++ b/src/renderers/abstractMobile.render.ts
@@ -39,7 +39,7 @@ export abstract class MobileRenderer extends Renderer {
     return `<script src='../-/${js}.js'></script>`
   }
 
-  public templateMobileArticle(moduleDependencies: any, articleId: string): Document {
+  public templateMobileArticle(moduleDependencies: any, articleId: string, collectedInlineJs: string): Document {
     const { jsDependenciesList, styleDependenciesList } = moduleDependencies
 
     const htmlTemplateString = htmlWikimediaMobileTemplateCode()
@@ -51,6 +51,7 @@ export abstract class MobileRenderer extends Renderer {
         '__ARTICLE_JS_LIST__',
         jsDependenciesList.length !== 0 ? jsDependenciesList.map((oneJsDep: string) => genHeaderScript(config, oneJsDep, articleId, config.output.dirs.mediawiki)).join('\n') : '',
       )
+      .replace('__RELOCATED_INLINE_JS__', collectedInlineJs ? this.genWikimediaMobileOverrideInlineScript(collectedInlineJs) : '')
       .replace(
         '__ARTICLE_CSS_LIST__',
         styleDependenciesList.length !== 0

--- a/src/renderers/wikimedia-mobile.renderer.ts
+++ b/src/renderers/wikimedia-mobile.renderer.ts
@@ -40,7 +40,6 @@ export class WikimediaMobileRenderer extends MobileRenderer {
         const moduleDependenciesFiltered = super.filterWikimediaMobileModules(_moduleDependencies)
         let mediaDependenciesVal
         let subtitlesVal
-        let inlineJsScriptTagVal
         const mobileHTML = domino.createDocument(data)
         const finalHTMLMobile = await this.pipeMobileTransformations(
           mobileHTML,

--- a/src/renderers/wikimedia-mobile.renderer.ts
+++ b/src/renderers/wikimedia-mobile.renderer.ts
@@ -40,6 +40,7 @@ export class WikimediaMobileRenderer extends MobileRenderer {
         const moduleDependenciesFiltered = super.filterWikimediaMobileModules(_moduleDependencies)
         let mediaDependenciesVal
         let subtitlesVal
+        let inlineJsScriptTagVal
         const mobileHTML = domino.createDocument(data)
         const finalHTMLMobile = await this.pipeMobileTransformations(
           mobileHTML,
@@ -225,9 +226,7 @@ export class WikimediaMobileRenderer extends MobileRenderer {
   private unhideSectionsImpl(doc: DominoElement) {
     const sections = doc.querySelectorAll('section')
     Array.from(sections).forEach((section: DominoElement) => {
-      // Domino doesn't allow us to easily manipulate specific styles. Rather than trying to parse
-      // the style attribute and remove display: none, we just clobber the whole thing.
-      section.style = ''
+      section.style.removeProperty('display')
     })
     return doc
   }

--- a/test/unit/renderers/abstract.renderer.test.ts
+++ b/test/unit/renderers/abstract.renderer.test.ts
@@ -3,7 +3,7 @@ import * as domino from 'domino'
 import { Renderer } from '../../../src/renderers/abstract.renderer'
 
 class ConcreteRenderer extends Renderer {
-  public async render(renderOpts: any): Promise<any> {
+  public async render(): Promise<any> {
     return Promise.resolve(null)
   }
 }

--- a/test/unit/renderers/abstract.renderer.test.ts
+++ b/test/unit/renderers/abstract.renderer.test.ts
@@ -1,0 +1,47 @@
+import * as domino from 'domino'
+
+import { Renderer } from '../../../src/renderers/abstract.renderer'
+
+class ConcreteRenderer extends Renderer {
+  public async render(renderOpts: any): Promise<any> {
+    return Promise.resolve(null)
+  }
+}
+
+describe('Abstract Renderer', () => {
+  let renderer: Renderer
+  beforeEach(() => {
+    renderer = new ConcreteRenderer()
+  })
+
+  describe('collectInlineJs', () => {
+    let test_window
+    beforeEach(() => {
+      // Snippet of an article with nested hidden sections.
+      test_window = domino.createWindow(
+        `
+        <html>
+        <head>
+          <title>Test Article</title>
+        </head>
+        <body>
+          <div>
+            <script>console.log('This is a script tag')</script>
+            <div>
+              <div>
+                <script>console.log('This is another script tag')</script>
+              </div>
+            </div>
+          </div>
+          <script>console.log('Final script tag')</script>
+        </body>
+        </html>`,
+        'https://bm.wikipedia.org/api/rest_v1/page/mobile-html/Mali',
+      )
+    })
+    it('should collect all inline scripts in the article', () => {
+      const actual = renderer.INTERNAL.collectInlineJs(test_window.document)
+      expect(actual).toEqual("console.log('This is a script tag')\nconsole.log('This is another script tag')\nconsole.log('Final script tag')")
+    })
+  })
+})

--- a/test/unit/renderers/abstract.renderer.test.ts
+++ b/test/unit/renderers/abstract.renderer.test.ts
@@ -40,7 +40,7 @@ describe('Abstract Renderer', () => {
       )
     })
     it('should collect all inline scripts in the article', () => {
-      const actual = renderer.INTERNAL.collectInlineJs(test_window.document)
+      const actual = renderer.ABSTRACT_INTERNAL.collectInlineJs(test_window.document)
       expect(actual).toEqual("console.log('This is a script tag')\nconsole.log('This is another script tag')\nconsole.log('Final script tag')")
     })
   })

--- a/test/unit/renderers/mobile.renderer.test.ts
+++ b/test/unit/renderers/mobile.renderer.test.ts
@@ -1,7 +1,6 @@
 import * as domino from 'domino'
 
 import { WikimediaMobileRenderer } from '../../../src/renderers/wikimedia-mobile.renderer'
-import exp from 'constants'
 
 describe('mobile renderer', () => {
   describe('unhiding sections', () => {

--- a/test/unit/saveArticles.test.ts
+++ b/test/unit/saveArticles.test.ts
@@ -12,7 +12,6 @@ import { VisualEditorRenderer } from '../../src/renderers/visual-editor.renderer
 import { WikimediaMobileRenderer } from '../../src/renderers/wikimedia-mobile.renderer.js'
 import { RestApiRenderer } from '../../src/renderers/rest-api.renderer.js'
 import { RENDERERS_LIST } from '../../src/util/const.js'
-import { MobileRenderer } from 'src/renderers/abstractMobile.render.js'
 
 jest.setTimeout(40000)
 
@@ -239,7 +238,6 @@ describe('saveArticles', () => {
 
       const articleDoc = domino.createDocument(result[0].html)
 
-      let foundInlineJsScript = false
       for (const scriptTag of Array.from(articleDoc.querySelectorAll('head > script'))) {
         if (scriptTag.textContent.includes('// Scripts taken')) {
           expect(scriptTag.textContent.includes('onBodyStart')).toBe(true)


### PR DESCRIPTION
Fixes #2096 

In the abstract Renderer, we create a method, collectInlineJs, which grabs any `<script>` tags that are in the body of the article, takes the actual JavaScript inside, and collects it into a string. The original `<body>` `<script>` tags are removed in the process. This string is passed to the callback of `processHtml`, where the concrete Renderers convert the intermediate `<body>` HTML into a full HTML document, and put in the `<head>`.

We introduce a new template, `inline_js_to_head_wrapper.html`, which contains a single script tag, with the body scripts wrapped in a `DOMContentLoaded` listener. This means that the scripts will still execute, in supported environments, after the page has loaded. It is unclear the proper function of these scripts, but the thought is that we might as well try to run them since we're already including scripts such as `pcs.js` in the page.