### PR TITLE
Remove inline scripts from scraped articles

### DIFF
--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -698,6 +698,14 @@ export abstract class Renderer {
       }
     })
 
+    /*
+     * Because of CSP, some ZIM reader environments do not allow inline JS. See issues/2096.
+     */
+    const scripts = Array.from(parsoidDoc.getElementsByTagName('script')) as DominoElement[]
+    for (const script of scripts) {
+      script.parentNode.removeChild(script)
+    }
+
     /* Force display of element with that CSS class */
     filtersConfig.cssClassDisplayList.map((classname: string) => {
       const nodes: DominoElement[] = Array.from(parsoidDoc.getElementsByClassName(classname))

--- a/test/unit/saveArticles.test.ts
+++ b/test/unit/saveArticles.test.ts
@@ -238,7 +238,7 @@ describe('saveArticles', () => {
 
       const articleDoc = domino.createDocument(result[0].html)
 
-      // Document has scripts that we added, but shouldn't have any with a `src`.
+      // Document has scripts that we added, but shouldn't have any without a `src` (inline).
       const remainingInlineScripts = Array.from(articleDoc.querySelectorAll('script:not([src])'))
       expect(remainingInlineScripts.length).toBe(0)
     })


### PR DESCRIPTION
Fixes #2096 

Simply find and remove all script tags from scraped HTML when rendering the article. This doesn't affect "module dependencies", because they are calculated before and re-added later.