### PR TITLE
Add email sending step for failed scheduled CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,16 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
         run: npm run test-without-coverage
 
+      - name: Mailgun Action
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        uses: vineetchoudhary/mailgun-action@v1.1
+        with:
+          api-key: ${{ secrets.MAILGUN_API_KEY }}
+          domain: ${{ secrets.MAILGUN_DOMAIN }}
+          from: 'mwoffliner-github-alert'
+          to: ${{ secrets.CI_SCHEDULED_FAIL_EMAIL_TO }}
+          subject: 'mwoffliner scheduled CI run FAILED (silent)'
+
       - name: Uploading Codecov stats
         uses: codecov/codecov-action@v4
         if: ${{ matrix.node-version == '18.x' }}


### PR DESCRIPTION
We have been running scheduled CI tests every day for quite a while. However, it is widely documented that when these tests fail, the only person who gets an email is the "last person who touched the yml" or something along those lines.

This PR adds a step that sends an email if the action was scheduled and there is a failure, to the comma-separated list of email addresses in the repo secret `CI_SCHEDULED_FAIL_EMAIL_TO`.