### PR TITLE
Remove S3 upload concurrency

### DIFF
--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -588,7 +588,7 @@ class Downloader {
           // Check for the ETag and upload to cache
           const etag = this.removeEtagWeakPrefix(mwResp.headers.etag)
           if (etag) {
-            this.s3.uploadBlob(stripHttpFromUrl(url), mwResp.data, etag, mwResp.headers['content-type'], this.webp ? 'webp' : '1')
+            await this.s3.uploadBlob(stripHttpFromUrl(url), mwResp.data, etag, mwResp.headers['content-type'], this.webp ? 'webp' : '1')
           }
 
           // Proceed with image

--- a/src/S3.ts
+++ b/src/S3.ts
@@ -3,9 +3,6 @@ import * as logger from './Logger.js'
 import { Readable } from 'stream'
 import { publicIpv4 } from 'public-ip'
 
-import * as https from 'https'
-import { NodeHttpHandler } from '@smithy/node-http-handler'
-
 interface BucketParams {
   Bucket: string
   Key: string
@@ -37,11 +34,6 @@ class S3 {
   }
 
   public async initialise() {
-    const requestHandler = new NodeHttpHandler({
-      httpsAgent: new https.Agent({
-        maxSockets: 250,
-      }),
-    })
     const s3UrlBase: any = new URL(this.url)
     this.s3Handler = new S3Client({
       credentials: {
@@ -51,7 +43,6 @@ class S3 {
       endpoint: s3UrlBase.href,
       forcePathStyle: s3UrlBase.protocol === 'http:',
       region: this.region,
-      requestHandler,
     })
 
     return this.bucketExists(this.bucketName)


### PR DESCRIPTION
Fix #2118

Changes:
- revert increase of sockets from #2093, this was not needed in the past, and I don't expect this to be needed if we do not push too many concurrent requests (which we shouldn't)
- await upload of image to S3: while not awaiting the upload could help save some crawling time, it cannot be efficiently handled without proper queue size management (otherwise we end-up with current situation where too many uploads are queued at once). Implementing proper queue management is not worth it

Nota: we might want to open an issue to support async S3 upload with proper queue management on the medium/long term. I'm not convinced at all this is worth to implement, most (all?) Python scrapers work pretty well without it and I do not expect much benefit (i.e. price to pay is too high)