### PR TITLE
Add logs for API checks

### DIFF
--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -175,7 +175,9 @@ class MediaWiki {
   public async hasWikimediaDesktopApi(): Promise<boolean> {
     if (this.#hasWikimediaDesktopApi === null) {
       this.wikimediaDesktopUrlDirector = new WikimediaDesktopURLDirector(this.wikimediaDesktopApiUrl.href)
-      this.#hasWikimediaDesktopApi = await checkApiAvailability(this.wikimediaDesktopUrlDirector.buildArticleURL(this.apiCheckArticleId))
+      const checkUrl = this.wikimediaDesktopUrlDirector.buildArticleURL(this.apiCheckArticleId)
+      this.#hasWikimediaDesktopApi = await checkApiAvailability(checkUrl)
+      logger.log('Checking for WikimediaDesktopApi at', checkUrl, '-- result is: ', this.#hasWikimediaDesktopApi)
       return this.#hasWikimediaDesktopApi
     }
     return this.#hasWikimediaDesktopApi
@@ -184,7 +186,9 @@ class MediaWiki {
   public async hasWikimediaMobileApi(): Promise<boolean> {
     if (this.#hasWikimediaMobileApi === null) {
       this.wikimediaMobileUrlDirector = new WikimediaMobileURLDirector(this.wikimediaMobileApiUrl.href)
-      this.#hasWikimediaMobileApi = await checkApiAvailability(this.wikimediaMobileUrlDirector.buildArticleURL(this.apiCheckArticleId))
+      const checkUrl = this.wikimediaMobileUrlDirector.buildArticleURL(this.apiCheckArticleId)
+      this.#hasWikimediaMobileApi = await checkApiAvailability(checkUrl)
+      logger.log('Checking for WikimediaMobileApi at', checkUrl, '-- result is: ', this.#hasWikimediaMobileApi)
       return this.#hasWikimediaMobileApi
     }
     return this.#hasWikimediaMobileApi
@@ -193,11 +197,9 @@ class MediaWiki {
   public async hasVisualEditorApi(): Promise<boolean> {
     if (this.#hasVisualEditorApi === null) {
       this.visualEditorUrlDirector = new VisualEditorURLDirector(this.visualEditorApiUrl.href)
-      this.#hasVisualEditorApi = await checkApiAvailability(
-        this.visualEditorUrlDirector.buildArticleURL(this.apiCheckArticleId),
-        '' /* empty login cookie */,
-        this.visualEditorUrlDirector.validMimeTypes,
-      )
+      const checkUrl = this.visualEditorUrlDirector.buildArticleURL(this.apiCheckArticleId)
+      this.#hasVisualEditorApi = await checkApiAvailability(checkUrl, '' /* empty login cookie */, this.visualEditorUrlDirector.validMimeTypes)
+      logger.log('Checking for VisualEditorApi at', checkUrl, '-- result is: ', this.#hasVisualEditorApi)
       return this.#hasVisualEditorApi
     }
     return this.#hasVisualEditorApi
@@ -206,7 +208,9 @@ class MediaWiki {
   public async hasRestApi(): Promise<boolean> {
     if (this.#hasRestApi === null) {
       this.restApiUrlDirector = new RestApiURLDirector(this.restApiUrl.href)
-      this.#hasRestApi = await checkApiAvailability(this.restApiUrlDirector.buildArticleURL(this.apiCheckArticleId))
+      const checkUrl = this.restApiUrlDirector.buildArticleURL(this.apiCheckArticleId)
+      this.#hasRestApi = await checkApiAvailability(checkUrl)
+      logger.log('Checking for RestApi at', checkUrl, '-- result is: ', this.#hasRestApi)
       return this.#hasRestApi
     }
     return this.#hasRestApi

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -177,7 +177,7 @@ class MediaWiki {
       this.wikimediaDesktopUrlDirector = new WikimediaDesktopURLDirector(this.wikimediaDesktopApiUrl.href)
       const checkUrl = this.wikimediaDesktopUrlDirector.buildArticleURL(this.apiCheckArticleId)
       this.#hasWikimediaDesktopApi = await checkApiAvailability(checkUrl)
-      logger.log('Checking for WikimediaDesktopApi at', checkUrl, '-- result is: ', this.#hasWikimediaDesktopApi)
+      logger.log('Checked for WikimediaDesktopApi at', checkUrl, '-- result is: ', this.#hasWikimediaDesktopApi)
       return this.#hasWikimediaDesktopApi
     }
     return this.#hasWikimediaDesktopApi
@@ -188,7 +188,7 @@ class MediaWiki {
       this.wikimediaMobileUrlDirector = new WikimediaMobileURLDirector(this.wikimediaMobileApiUrl.href)
       const checkUrl = this.wikimediaMobileUrlDirector.buildArticleURL(this.apiCheckArticleId)
       this.#hasWikimediaMobileApi = await checkApiAvailability(checkUrl)
-      logger.log('Checking for WikimediaMobileApi at', checkUrl, '-- result is: ', this.#hasWikimediaMobileApi)
+      logger.log('Checked for WikimediaMobileApi at', checkUrl, '-- result is: ', this.#hasWikimediaMobileApi)
       return this.#hasWikimediaMobileApi
     }
     return this.#hasWikimediaMobileApi
@@ -199,7 +199,7 @@ class MediaWiki {
       this.visualEditorUrlDirector = new VisualEditorURLDirector(this.visualEditorApiUrl.href)
       const checkUrl = this.visualEditorUrlDirector.buildArticleURL(this.apiCheckArticleId)
       this.#hasVisualEditorApi = await checkApiAvailability(checkUrl, '' /* empty login cookie */, this.visualEditorUrlDirector.validMimeTypes)
-      logger.log('Checking for VisualEditorApi at', checkUrl, '-- result is: ', this.#hasVisualEditorApi)
+      logger.log('Checked for VisualEditorApi at', checkUrl, '-- result is: ', this.#hasVisualEditorApi)
       return this.#hasVisualEditorApi
     }
     return this.#hasVisualEditorApi
@@ -210,7 +210,7 @@ class MediaWiki {
       this.restApiUrlDirector = new RestApiURLDirector(this.restApiUrl.href)
       const checkUrl = this.restApiUrlDirector.buildArticleURL(this.apiCheckArticleId)
       this.#hasRestApi = await checkApiAvailability(checkUrl)
-      logger.log('Checking for RestApi at', checkUrl, '-- result is: ', this.#hasRestApi)
+      logger.log('Checked for RestApi at', checkUrl, '-- result is: ', this.#hasRestApi)
       return this.#hasRestApi
     }
     return this.#hasRestApi

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -254,6 +254,8 @@ export async function saveArticles(zimCreator: ZimCreator, downloader: Downloade
       renderType: hasWikimediaMobileApi ? 'mobile' : 'auto',
     })
   }
+  logger.log(`Using ${mainPageRenderer.constructor.name} for main page renderer`)
+  logger.log(`Using ${articlesRenderer.constructor.name} for articles renderer`)
   downloader.setUrlsDirectors(mainPageRenderer, articlesRenderer)
 
   if (dump.customProcessor?.shouldKeepArticle) {


### PR DESCRIPTION
This will help debugging when we get a message along the lines of "No available [foo] renderer".