### PR TITLE
Publish container image on release event

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,8 @@
 name: Docker
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - v*
+  release:
+    types: [published]
 
 jobs:
   build-and-push:


### PR DESCRIPTION
By publishing `1.14.0` I saw that this workflow what not OK. I suspect we will have to release an `1.14.1` to get everything done properly.