### PR TITLE
Change log level of S3 missing keys message

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,6 @@
 Unreleased:
 * FIX: Ensure AWS SDK has access to object size when issuing an upload (@benoit #2117)
+* FIX: Change log level of S3 missing keys message (@benoit #2144)
 
 1.14.0:
 * FIX: Remove S3 upload concurrency to avoid 'RequestTimeTooSkewed' errors (@benoi74 #2118)

--- a/src/S3.ts
+++ b/src/S3.ts
@@ -104,7 +104,7 @@ class S3 {
         .catch((err: any) => {
           // For 404 error handle AWS service-specific exception
           if (err && err.name === 'NoSuchKey') {
-            logger.log(`The specified key '${key}' does not exist in the cache.`)
+            logger.info(`The specified key '${key}' does not exist in the cache.`)
             resolve(null)
           } else {
             logger.error(`Error (${err}) while downloading the object '${key}' from the cache.`)


### PR DESCRIPTION
To me these messages about key not being present in S3 are clearly debug message, so should be visible only at `info` level, not `log` level.