### PR TITLE
Ensure AWS SDK has access to object size when issuing an upload

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,5 @@
 Unreleased:
+* FIX: Ensure AWS SDK has access to object size when issuing an upload (@benoit #2117)
 
 1.14.0:
 * FIX: Remove S3 upload concurrency to avoid 'RequestTimeTooSkewed' errors (@benoi74 #2118)

--- a/src/S3.ts
+++ b/src/S3.ts
@@ -1,6 +1,5 @@
 import { S3Client, PutObjectCommand, GetObjectCommand, DeleteObjectCommand, HeadBucketCommand } from '@aws-sdk/client-s3'
 import * as logger from './Logger.js'
-import { Readable } from 'stream'
 import { publicIpv4 } from 'public-ip'
 
 interface BucketParams {
@@ -71,7 +70,7 @@ class S3 {
       Bucket: this.bucketName,
       Key: key,
       Metadata: { etag: eTag, contenttype: contentType, version },
-      Body: this.bufferToStream(data),
+      Body: data,
     })
 
     return new Promise((resolve, reject) => {
@@ -126,15 +125,6 @@ class S3 {
           logger.error('Error while deleting object in the cache', err)
           reject(err)
         })
-    })
-  }
-
-  private bufferToStream(binary: Buffer) {
-    return new Readable({
-      read() {
-        this.push(binary)
-        this.push(null)
-      },
     })
   }
 }


### PR DESCRIPTION
Fix #2117 

`data` is a buffer in our usage of the S3 class, and SDK prefer buffer to streams when it comes to `PubObject` command, so let's simplify things.

Tested locally with forced upload to S3 (by manipulating the `If-None-Match` value passed to upstream get). Before the change, I have the usual warnings, after the change they are gone.