### PR TITLE
Fix eslint warnings

### DIFF
--- a/test/e2e/vikidia.e2e.test.ts
+++ b/test/e2e/vikidia.e2e.test.ts
@@ -1,3 +1,9 @@
+test('skipped vikidia test', () => {
+  return
+})
+
+/*
+// https://github.com/openzim/mwoffliner/issues/2039
 import { execa } from 'execa'
 import rimraf from 'rimraf'
 import { testRenders } from '../testRenders.js'
@@ -15,12 +21,6 @@ const parameters = {
   customZimDescription: 'Alaska article',
 }
 
-test('skipped vikidia test', () => {
-  return
-})
-
-/*
-// https://github.com/openzim/mwoffliner/issues/2039
 await testRenders(
   parameters,
   async (outFiles) => {

--- a/test/unit/renderers/mobile.renderer.test.ts
+++ b/test/unit/renderers/mobile.renderer.test.ts
@@ -1,7 +1,6 @@
 import * as domino from 'domino'
 
 import { WikimediaMobileRenderer } from '../../../src/renderers/wikimedia-mobile.renderer'
-import exp from 'constants'
 
 describe('mobile renderer', () => {
   describe('unhiding sections', () => {


### PR DESCRIPTION
Removing unused constant in `mobile.renderer.test.ts`, and commented the whole vikidia file.

Both were raising unneeded warnings:

![image](https://github.com/user-attachments/assets/6dbdd0c7-e926-4e79-a0cb-a0eb4a6bde2f)
