### PR TITLE
Pre-install all Node.JS dependencies to make image smaller/faster

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,14 +11,15 @@ RUN apt-get update && \
 # Install mwoffliner
 WORKDIR /tmp/mwoffliner
 COPY *.json ./
+COPY dev dev
+RUN npm --global config set user root
+RUN npm config set unsafe-perm true
+RUN npm i
 COPY src src
 COPY res res
 COPY translation translation
 COPY extensions extensions
 COPY index.js .
-COPY dev dev
-RUN npm --global config set user root
-RUN npm config set unsafe-perm true
 RUN npm i
 RUN npm i -g .
 


### PR DESCRIPTION
Since Node.JS dependencies rarely need to be changed during successive builds of the Docker image, it is way better to first install only dependencies without mwoffliner code, and then install mwoffliner itself. Any change to the codebase will hence only update few things without having to re-download again all dependencies.

Edit: to be merged to main once https://github.com/openzim/mwoffliner/pull/2143 is merged