### PR TITLE
Enhance handling of HTTP settings and TCP sockets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ mwo-test-*
 .vscode
 .tool-versions
 output/
+src/version.ts

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && \
 WORKDIR /tmp/mwoffliner
 COPY *.json ./
 COPY dev dev
+RUN mkdir src
 RUN npm --global config set user root
 RUN npm config set unsafe-perm true
 RUN npm i

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint": "eslint -c .eslintrc.cjs --ext .ts .",
     "lint-fix": "eslint -c .eslintrc.cjs --ext .ts --fix .",
     "format": "prettier --write './**/*.ts'",
+    "prebuild": "node -p \"'export const LIB_VERSION = \\'' + require('./package.json').version + '\\''\" > src/version.ts",
     "build": "./dev/build.sh",
     "watch": "./dev/watch.sh",
     "prepublish": "npm run build",

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -274,6 +274,7 @@ class MediaWiki {
 
       // Logging in
       await axios(this.actionApiUrl.href, {
+        ...downloader.arrayBufferRequestOptions,
         data: qs.stringify({
           action: 'login',
           format: 'json',

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -2,8 +2,7 @@ import * as pathParser from 'path'
 import * as logger from './Logger.js'
 import * as util from './util/index.js'
 import * as domino from 'domino'
-import type Downloader from './Downloader.js'
-import axios from 'axios'
+import Downloader from './Downloader.js'
 import qs from 'querystring'
 import semver from 'semver'
 import basicURLDirector from './util/builders/url/basic.director.js'
@@ -172,44 +171,44 @@ class MediaWiki {
     this.initializeMediaWikiDefaults()
   }
 
-  public async hasWikimediaDesktopApi(): Promise<boolean> {
+  public async hasWikimediaDesktopApi(downloader: Downloader): Promise<boolean> {
     if (this.#hasWikimediaDesktopApi === null) {
       this.wikimediaDesktopUrlDirector = new WikimediaDesktopURLDirector(this.wikimediaDesktopApiUrl.href)
       const checkUrl = this.wikimediaDesktopUrlDirector.buildArticleURL(this.apiCheckArticleId)
-      this.#hasWikimediaDesktopApi = await checkApiAvailability(checkUrl)
+      this.#hasWikimediaDesktopApi = await checkApiAvailability(downloader, checkUrl)
       logger.log('Checked for WikimediaDesktopApi at', checkUrl, '-- result is: ', this.#hasWikimediaDesktopApi)
       return this.#hasWikimediaDesktopApi
     }
     return this.#hasWikimediaDesktopApi
   }
 
-  public async hasWikimediaMobileApi(): Promise<boolean> {
+  public async hasWikimediaMobileApi(downloader: Downloader): Promise<boolean> {
     if (this.#hasWikimediaMobileApi === null) {
       this.wikimediaMobileUrlDirector = new WikimediaMobileURLDirector(this.wikimediaMobileApiUrl.href)
       const checkUrl = this.wikimediaMobileUrlDirector.buildArticleURL(this.apiCheckArticleId)
-      this.#hasWikimediaMobileApi = await checkApiAvailability(checkUrl)
+      this.#hasWikimediaMobileApi = await checkApiAvailability(downloader, checkUrl)
       logger.log('Checked for WikimediaMobileApi at', checkUrl, '-- result is: ', this.#hasWikimediaMobileApi)
       return this.#hasWikimediaMobileApi
     }
     return this.#hasWikimediaMobileApi
   }
 
-  public async hasVisualEditorApi(): Promise<boolean> {
+  public async hasVisualEditorApi(downloader: Downloader): Promise<boolean> {
     if (this.#hasVisualEditorApi === null) {
       this.visualEditorUrlDirector = new VisualEditorURLDirector(this.visualEditorApiUrl.href)
       const checkUrl = this.visualEditorUrlDirector.buildArticleURL(this.apiCheckArticleId)
-      this.#hasVisualEditorApi = await checkApiAvailability(checkUrl, '' /* empty login cookie */, this.visualEditorUrlDirector.validMimeTypes)
+      this.#hasVisualEditorApi = await checkApiAvailability(downloader, checkUrl, this.visualEditorUrlDirector.validMimeTypes)
       logger.log('Checked for VisualEditorApi at', checkUrl, '-- result is: ', this.#hasVisualEditorApi)
       return this.#hasVisualEditorApi
     }
     return this.#hasVisualEditorApi
   }
 
-  public async hasRestApi(): Promise<boolean> {
+  public async hasRestApi(downloader: Downloader): Promise<boolean> {
     if (this.#hasRestApi === null) {
       this.restApiUrlDirector = new RestApiURLDirector(this.restApiUrl.href)
       const checkUrl = this.restApiUrlDirector.buildArticleURL(this.apiCheckArticleId)
-      this.#hasRestApi = await checkApiAvailability(checkUrl)
+      this.#hasRestApi = await checkApiAvailability(downloader, checkUrl)
       logger.log('Checked for RestApi at', checkUrl, '-- result is: ', this.#hasRestApi)
       return this.#hasRestApi
     }
@@ -270,24 +269,25 @@ class MediaWiki {
       }
 
       // Getting token to login.
-      const { content, setCookie } = await downloader.downloadContent(url + 'action=query&meta=tokens&type=login&format=json&formatversion=2', 'data')
+      const { content } = await downloader.downloadContent(url + 'action=query&meta=tokens&type=login&format=json&formatversion=2', 'data')
 
       // Logging in
-      await axios(this.actionApiUrl.href, {
-        ...downloader.arrayBufferRequestOptions,
-        data: qs.stringify({
-          action: 'login',
-          format: 'json',
-          lgname: this.#username,
-          lgpassword: this.#password,
-          lgtoken: JSON.parse(content.toString()).query.tokens.logintoken,
-        }),
-        headers: {
-          Cookie: setCookie,
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        method: 'POST',
-      })
+      await downloader
+        .request({
+          url: this.actionApiUrl.href,
+          ...downloader.arrayBufferRequestOptions,
+          data: qs.stringify({
+            action: 'login',
+            format: 'json',
+            lgname: this.#username,
+            lgpassword: this.#password,
+            lgtoken: JSON.parse(content.toString()).query.tokens.logintoken,
+          }),
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          method: 'POST',
+        })
         .then(async (resp) => {
           if (resp.data.login.result !== 'Success') {
             throw new Error('Login Failed')

--- a/src/S3.ts
+++ b/src/S3.ts
@@ -49,6 +49,7 @@ class S3 {
       forcePathStyle: s3UrlBase.protocol === 'http:',
       region: this.region,
       requestHandler: new NodeHttpHandler({
+        connectionTimeout: this.reqTimeout,
         requestTimeout: this.reqTimeout,
         httpAgent: new Agent({ keepAlive: true }),
         httpsAgent: new Agent({ keepAlive: true, rejectUnauthorized: !this.insecure }), // rejectUnauthorized: false disables TLS

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 const config = {
-  userAgent: 'MWOffliner/HEAD',
+  userAgent: 'MWOffliner/dev',
 
   defaults: {
     publisher: 'openZIM',

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,7 @@
+import { LIB_VERSION } from './version.js'
+
 const config = {
-  userAgent: 'MWOffliner/dev',
+  userAgent: `MWOffliner/${LIB_VERSION}`,
 
   defaults: {
     publisher: 'openZIM',

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -146,7 +146,7 @@ async function execute(argv: any) {
     const s3UrlObj = urlParser.parse(optimisationCacheUrl)
     const queryReader = QueryStringParser.parse(s3UrlObj.query)
     const s3Url = (s3UrlObj.protocol || 'https:') + '//' + (s3UrlObj.host || '') + (s3UrlObj.pathname || '')
-    s3Obj = new S3(s3Url, queryReader)
+    s3Obj = new S3(s3Url, queryReader, requestTimeout * 1000 || config.defaults.requestTimeout, argv.insecure)
     await s3Obj.initialise().then(() => {
       logger.log('Successfully logged in S3')
     })

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -265,7 +265,7 @@ async function execute(argv: any) {
   let articleListToIgnoreLines: string[]
   if (articleListToIgnore) {
     try {
-      articleListToIgnoreLines = await extractArticleList(articleListToIgnore)
+      articleListToIgnoreLines = await extractArticleList(articleListToIgnore, downloader)
       logger.info(`ArticleListToIgnore has [${articleListToIgnoreLines.length}] items`)
     } catch (err) {
       logger.error(`Failed to read articleListToIgnore from [${articleListToIgnore}]`, err)
@@ -276,7 +276,7 @@ async function execute(argv: any) {
   let articleListLines: string[]
   if (articleList) {
     try {
-      articleListLines = await extractArticleList(articleList)
+      articleListLines = await extractArticleList(articleList, downloader)
       if (articleListToIgnore) {
         articleListLines = articleListLines.filter((title: string) => !articleListToIgnoreLines.includes(title))
       }
@@ -434,7 +434,7 @@ async function execute(argv: any) {
 
     if (downloader.webp) {
       logger.log('Downloading polyfill module')
-      await importPolyfillModules(zimCreator)
+      await importPolyfillModules(downloader, zimCreator)
     }
 
     logger.log('Downloading module dependencies')

--- a/src/renderers/renderer.builder.ts
+++ b/src/renderers/renderer.builder.ts
@@ -6,16 +6,17 @@ import { WikimediaMobileRenderer } from './wikimedia-mobile.renderer.js'
 import { RestApiRenderer } from './rest-api.renderer.js'
 import { RendererBuilderOptions } from './abstract.renderer.js'
 import * as logger from './../Logger.js'
+import Downloader from 'src/Downloader.js'
 
 export class RendererBuilder {
-  public async createRenderer(options: RendererBuilderOptions): Promise<Renderer> {
+  public async createRenderer(downloader: Downloader, options: RendererBuilderOptions): Promise<Renderer> {
     const { renderType, renderName } = options
 
     const [hasVisualEditorApi, hasWikimediaDesktopApi, hasWikimediaMobileApi, hasRestApi] = await Promise.all([
-      MediaWiki.hasVisualEditorApi(),
-      MediaWiki.hasWikimediaDesktopApi(),
-      MediaWiki.hasWikimediaMobileApi(),
-      MediaWiki.hasRestApi(),
+      MediaWiki.hasVisualEditorApi(downloader),
+      MediaWiki.hasWikimediaDesktopApi(downloader),
+      MediaWiki.hasWikimediaMobileApi(downloader),
+      MediaWiki.hasRestApi(downloader),
     ])
 
     switch (renderType) {

--- a/src/sanitize-argument.ts
+++ b/src/sanitize-argument.ts
@@ -68,7 +68,7 @@ export async function sanitize_all(argv: any) {
       const s3UrlObj = urlParser.parse(optimisationCacheUrl)
       const queryReader = QueryStringParser.parse(s3UrlObj.query)
       const s3Url = (s3UrlObj.protocol || 'https:') + '//' + (s3UrlObj.host || '') + (s3UrlObj.pathname || '')
-      const s3Obj = new S3(s3Url, queryReader)
+      const s3Obj = new S3(s3Url, queryReader, 1000 * 60, argv.insecure)
       await s3Obj.initialise().then(() => {
         logger.log('Successfully logged in S3')
       })

--- a/src/util/dump.ts
+++ b/src/util/dump.ts
@@ -167,7 +167,7 @@ export async function downloadAndSaveModule(zimCreator: ZimCreator, downloader: 
 }
 
 // URLs should be kept the same as Kiwix JS relies on it.
-export async function importPolyfillModules(zimCreator: ZimCreator) {
+export async function importPolyfillModules(downloader: Downloader, zimCreator: ZimCreator) {
   ;[
     { name: 'webpHeroPolyfill', path: path.join(__dirname, '../../node_modules/webp-hero/dist-cjs/polyfills.js') },
     { name: 'webpHeroBundle', path: path.join(__dirname, '../../node_modules/webp-hero/dist-cjs/webp-hero.bundle.js') },
@@ -181,13 +181,7 @@ export async function importPolyfillModules(zimCreator: ZimCreator) {
   })
 
   const content = await axios
-    .get(WEBP_HANDLER_URL, {
-      responseType: 'arraybuffer',
-      timeout: 60000,
-      validateStatus(status) {
-        return [200, 302, 304].indexOf(status) > -1
-      },
-    })
+    .get(WEBP_HANDLER_URL, downloader.arrayBufferRequestOptions)
     .then((a) => a.data)
     .catch((err) => {
       throw new Error(`Failed to download webpHandler from [${WEBP_HANDLER_URL}]: ${err}`)

--- a/src/util/dump.ts
+++ b/src/util/dump.ts
@@ -2,7 +2,6 @@ import urlParser from 'url'
 import * as pathParser from 'path'
 import async from 'async'
 import * as logger from '../Logger.js'
-import axios from 'axios'
 import Downloader from '../Downloader.js'
 import RedisStore from '../RedisStore.js'
 import { getFullUrl, jsPath, cssPath } from './index.js'
@@ -180,8 +179,8 @@ export async function importPolyfillModules(downloader: Downloader, zimCreator: 
     zimCreator.addArticle(article)
   })
 
-  const content = await axios
-    .get(WEBP_HANDLER_URL, downloader.arrayBufferRequestOptions)
+  const content = await downloader
+    .request({ url: WEBP_HANDLER_URL, method: 'GET', ...downloader.arrayBufferRequestOptions })
     .then((a) => a.data)
     .catch((err) => {
       throw new Error(`Failed to download webpHandler from [${WEBP_HANDLER_URL}]: ${err}`)

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -21,7 +21,7 @@ import {
   WEBP_CANDIDATE_IMAGE_MIME_TYPE,
 } from './const.js'
 import { fileURLToPath } from 'url'
-import axios, { AxiosError } from 'axios'
+import { AxiosError } from 'axios'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -386,7 +386,7 @@ export function cleanupAxiosError(err: AxiosError) {
 
 async function downloadListByUrl(url: string, downloader: Downloader): Promise<string> {
   const fileName = url.split('/').slice(-1)[0]
-  const { data: contentStream } = await axios.get(url, downloader.streamRequestOptions)
+  const { data: contentStream } = await downloader.request({ url, method: 'GET', ...downloader.streamRequestOptions })
   const filePath = path.join(await getTmpDirectory(), fileName)
   const writeStream = fs.createWriteStream(filePath)
   await new Promise((resolve, reject) => {

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto'
 import domino from 'domino'
-import { defaultStreamRequestOptions } from '../Downloader.js'
+import Downloader from '../Downloader.js'
 import countryLanguage from '@ladjs/country-language'
 import fs from 'fs'
 import path from 'path'
@@ -384,9 +384,9 @@ export function cleanupAxiosError(err: AxiosError) {
   return { name: err.name, message: err.message, url: err.config?.url, status: err.response?.status, responseType: err.config?.responseType, data: err.response?.data }
 }
 
-async function downloadListByUrl(url: string): Promise<string> {
+async function downloadListByUrl(url: string, downloader: Downloader): Promise<string> {
   const fileName = url.split('/').slice(-1)[0]
-  const { data: contentStream } = await axios.get(url, defaultStreamRequestOptions)
+  const { data: contentStream } = await axios.get(url, downloader.streamRequestOptions)
   const filePath = path.join(await getTmpDirectory(), fileName)
   const writeStream = fs.createWriteStream(filePath)
   await new Promise((resolve, reject) => {
@@ -398,7 +398,7 @@ async function downloadListByUrl(url: string): Promise<string> {
   return filePath
 }
 
-export async function extractArticleList(articleList: string): Promise<string[]> {
+export async function extractArticleList(articleList: string, downloader: Downloader): Promise<string[]> {
   const list = await Promise.all(
     articleList
       .split(',')
@@ -414,7 +414,7 @@ export async function extractArticleList(articleList: string): Promise<string[]>
           }
           if (url && url.href) {
             try {
-              item = await downloadListByUrl(url.href)
+              item = await downloadListByUrl(url.href, downloader)
             } catch (e) {
               throw new Error(`Failed to read articleList from URL: ${url.href}`)
             }

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -3,7 +3,6 @@ import deepmerge from 'deepmerge'
 import * as logger from '../Logger.js'
 import Downloader from '../Downloader.js'
 import Timer from './Timer.js'
-import axios from 'axios'
 import RedisStore from '../RedisStore.js'
 import MediaWiki from '../MediaWiki.js'
 import { REDIRECT_PAGE_SIGNATURE } from './const.js'
@@ -261,15 +260,16 @@ export function mwRetToArticleDetail(obj: QueryMwRet): KVS<ArticleDetail> {
 /**
  * Check for API availability at the given URL.
  *
+ * @param downloader Downloader class handling web requests
  * @param url The URL to check.
  * @param loginCookie A string representing a cookie for login, if necessary.
  * @param allowedMimeTypes An array of allowed mime types for the response. If this is set, the check is only considered a
  * success if the response has a mime type in this array. Set to null to disable this filter.
  * @returns Promise resolving to true if the API is available.
  */
-export async function checkApiAvailability(url: string, loginCookie = '', allowedMimeTypes = null): Promise<boolean> {
+export async function checkApiAvailability(downloader: Downloader, url: string, allowedMimeTypes = null): Promise<boolean> {
   try {
-    const resp = await axios.get(decodeURI(url), { maxRedirects: 0, headers: { cookie: loginCookie } })
+    const resp = await downloader.request({ url: decodeURI(url), method: 'GET', maxRedirects: 0, ...downloader.basicRequestOptions })
 
     const isRedirectPage = typeof resp.data === 'string' && resp.data.startsWith(REDIRECT_PAGE_SIGNATURE)
 

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -6,6 +6,7 @@ import Timer from './Timer.js'
 import RedisStore from '../RedisStore.js'
 import MediaWiki from '../MediaWiki.js'
 import { REDIRECT_PAGE_SIGNATURE } from './const.js'
+import { cleanupAxiosError } from './misc.js'
 
 export async function getArticlesByIds(articleIds: string[], downloader: Downloader, log = true): Promise<void> {
   let from = 0
@@ -292,6 +293,7 @@ export async function checkApiAvailability(downloader: Downloader, url: string, 
 
     return !isRedirectPage && isSuccess && validMimeType
   } catch (err) {
+    logger.info(cleanupAxiosError(err))
     return false
   }
 }

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -281,15 +281,15 @@ export async function saveArticles(zimCreator: ZimCreator, downloader: Downloade
   let articlesRenderer
   if (forceRender) {
     // All articles and main page will use the same renderer if 'forceRender' is specified
-    const renderer = await rendererBuilder.createRenderer({
+    const renderer = await rendererBuilder.createRenderer(downloader, {
       renderType: 'specific',
       renderName: forceRender,
     })
     mainPageRenderer = renderer
     articlesRenderer = renderer
   } else {
-    mainPageRenderer = await rendererBuilder.createRenderer({ renderType: 'desktop' })
-    articlesRenderer = await rendererBuilder.createRenderer({
+    mainPageRenderer = await rendererBuilder.createRenderer(downloader, { renderType: 'desktop' })
+    articlesRenderer = await rendererBuilder.createRenderer(downloader, {
       renderType: hasWikimediaMobileApi ? 'mobile' : 'auto',
     })
   }

--- a/test/unit/downloader.test.ts
+++ b/test/unit/downloader.test.ts
@@ -289,11 +289,16 @@ describe('Downloader class', () => {
       MediaWiki.base = 'https://en.wikipedia.org'
       MediaWiki.getCategories = true
 
-      s3 = new S3(`${s3UrlObj.protocol}//${s3UrlObj.host}/`, {
-        bucketName: s3UrlObj.query.bucketName,
-        keyId: s3UrlObj.query.keyId,
-        secretAccessKey: s3UrlObj.query.secretAccessKey,
-      })
+      s3 = new S3(
+        `${s3UrlObj.protocol}//${s3UrlObj.host}/`,
+        {
+          bucketName: s3UrlObj.query.bucketName,
+          keyId: s3UrlObj.query.keyId,
+          secretAccessKey: s3UrlObj.query.secretAccessKey,
+        },
+        1000 * 60,
+        false,
+      )
       downloader = new Downloader({
         uaString: `${config.userAgent} (contact@kiwix.org)`,
         speed: 1,

--- a/test/unit/downloader.test.ts
+++ b/test/unit/downloader.test.ts
@@ -34,10 +34,10 @@ describe('Downloader class', () => {
 
     await MediaWiki.getMwMetaData(downloader)
     await MediaWiki.hasCoordinates(downloader)
-    await MediaWiki.hasWikimediaDesktopApi()
-    await MediaWiki.hasWikimediaMobileApi()
-    await MediaWiki.hasRestApi()
-    await MediaWiki.hasVisualEditorApi()
+    await MediaWiki.hasWikimediaDesktopApi(downloader)
+    await MediaWiki.hasWikimediaMobileApi(downloader)
+    await MediaWiki.hasRestApi(downloader)
+    await MediaWiki.hasVisualEditorApi(downloader)
   })
 
   test('Test Action API version 2 response in comparison with version 1', async () => {

--- a/test/unit/mwApi.test.ts
+++ b/test/unit/mwApi.test.ts
@@ -18,9 +18,9 @@ afterAll(stopRedis)
 const initMW = async (downloader: Downloader) => {
   await MediaWiki.getMwMetaData(downloader)
   await MediaWiki.hasCoordinates(downloader)
-  await MediaWiki.hasWikimediaDesktopApi()
-  await MediaWiki.hasRestApi()
-  await MediaWiki.hasVisualEditorApi()
+  await MediaWiki.hasWikimediaDesktopApi(downloader)
+  await MediaWiki.hasRestApi(downloader)
+  await MediaWiki.hasVisualEditorApi(downloader)
 
   await MediaWiki.getNamespaces([], downloader)
 }

--- a/test/unit/mwApiCapabilities.test.ts
+++ b/test/unit/mwApiCapabilities.test.ts
@@ -1,5 +1,7 @@
+import Downloader from '../../src/Downloader.js'
 import MediaWiki from '../../src/MediaWiki.js'
 import { jest } from '@jest/globals'
+import { config } from '../../src/config.js'
 
 jest.setTimeout(30000)
 
@@ -14,75 +16,82 @@ describe('Checking Mediawiki capabilities', () => {
 
   test('test capabilities of en.wikipedia.org', async () => {
     MediaWiki.base = 'https://en.wikipedia.org'
-    expect(await MediaWiki.hasWikimediaDesktopApi()).toBe(true)
-    expect(await MediaWiki.hasWikimediaMobileApi()).toBe(true)
-    expect(await MediaWiki.hasRestApi()).toBe(true)
-    expect(await MediaWiki.hasVisualEditorApi()).toBe(true)
+    const downloader = new Downloader({ uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' })
+    expect(await MediaWiki.hasWikimediaDesktopApi(downloader)).toBe(true)
+    expect(await MediaWiki.hasWikimediaMobileApi(downloader)).toBe(true)
+    expect(await MediaWiki.hasRestApi(downloader)).toBe(true)
+    expect(await MediaWiki.hasVisualEditorApi(downloader)).toBe(true)
   })
 
   test('test capabilities of wiki.openstreetmap.org', async () => {
     MediaWiki.base = 'https://wiki.openstreetmap.org'
+    const downloader = new Downloader({ uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' })
 
-    expect(await MediaWiki.hasWikimediaDesktopApi()).toBe(false)
-    expect(await MediaWiki.hasWikimediaMobileApi()).toBe(false)
-    expect(await MediaWiki.hasRestApi()).toBe(true)
-    expect(await MediaWiki.hasVisualEditorApi()).toBe(true)
+    expect(await MediaWiki.hasWikimediaDesktopApi(downloader)).toBe(false)
+    expect(await MediaWiki.hasWikimediaMobileApi(downloader)).toBe(false)
+    expect(await MediaWiki.hasRestApi(downloader)).toBe(true)
+    expect(await MediaWiki.hasVisualEditorApi(downloader)).toBe(true)
   })
 
   test('test capabilities of fo.wikisource.org', async () => {
     MediaWiki.base = 'https://fo.wikisource.org'
+    const downloader = new Downloader({ uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' })
 
-    expect(await MediaWiki.hasWikimediaDesktopApi()).toBe(true)
-    expect(await MediaWiki.hasWikimediaMobileApi()).toBe(false)
-    expect(await MediaWiki.hasRestApi()).toBe(true)
-    expect(await MediaWiki.hasVisualEditorApi()).toBe(true)
+    expect(await MediaWiki.hasWikimediaDesktopApi(downloader)).toBe(true)
+    expect(await MediaWiki.hasWikimediaMobileApi(downloader)).toBe(false)
+    expect(await MediaWiki.hasRestApi(downloader)).toBe(true)
+    expect(await MediaWiki.hasVisualEditorApi(downloader)).toBe(true)
   })
 
   test('test capabilities of minecraft.wiki with correct VisualEditor receipt', async () => {
     MediaWiki.base = 'https://minecraft.wiki'
     MediaWiki.wikiPath = '/'
     MediaWiki.actionApiPath = 'api.php'
+    const downloader = new Downloader({ uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' })
 
-    expect(await MediaWiki.hasWikimediaDesktopApi()).toBe(false)
-    expect(await MediaWiki.hasWikimediaMobileApi()).toBe(false)
-    expect(await MediaWiki.hasRestApi()).toBe(false)
-    expect(await MediaWiki.hasVisualEditorApi()).toBe(true)
+    expect(await MediaWiki.hasWikimediaDesktopApi(downloader)).toBe(false)
+    expect(await MediaWiki.hasWikimediaMobileApi(downloader)).toBe(false)
+    expect(await MediaWiki.hasRestApi(downloader)).toBe(false)
+    expect(await MediaWiki.hasVisualEditorApi(downloader)).toBe(true)
   })
 
   test('test capabilities of pokemon.fandom.com with correct VisualEditor receipt', async () => {
     MediaWiki.base = 'https://pokemon.fandom.com/'
     MediaWiki.wikiPath = '/'
     MediaWiki.actionApiPath = 'api.php'
+    const downloader = new Downloader({ uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' })
 
-    expect(await MediaWiki.hasWikimediaDesktopApi()).toBe(false)
-    expect(await MediaWiki.hasWikimediaMobileApi()).toBe(false)
-    expect(await MediaWiki.hasRestApi()).toBe(false)
-    expect(await MediaWiki.hasVisualEditorApi()).toBe(true)
+    expect(await MediaWiki.hasWikimediaDesktopApi(downloader)).toBe(false)
+    expect(await MediaWiki.hasWikimediaMobileApi(downloader)).toBe(false)
+    expect(await MediaWiki.hasRestApi(downloader)).toBe(false)
+    expect(await MediaWiki.hasVisualEditorApi(downloader)).toBe(true)
   })
 
   test('test capabilities of pokemon.fandom.com with default receipt', async () => {
     MediaWiki.base = 'https://pokemon.fandom.com/'
+    const downloader = new Downloader({ uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' })
 
-    expect(await MediaWiki.hasWikimediaDesktopApi()).toBe(false)
-    expect(await MediaWiki.hasWikimediaMobileApi()).toBe(false)
-    expect(await MediaWiki.hasRestApi()).toBe(false)
-    expect(await MediaWiki.hasVisualEditorApi()).toBe(false)
+    expect(await MediaWiki.hasWikimediaDesktopApi(downloader)).toBe(false)
+    expect(await MediaWiki.hasWikimediaMobileApi(downloader)).toBe(false)
+    expect(await MediaWiki.hasRestApi(downloader)).toBe(false)
+    expect(await MediaWiki.hasVisualEditorApi(downloader)).toBe(false)
   })
 
   test('test capabilities of pokemon.fandom.com with RestApi receipt', async () => {
     MediaWiki.base = 'https://pokemon.fandom.com/'
     MediaWiki.wikiPath = '/'
     MediaWiki.restApiPath = 'rest.php'
+    const downloader = new Downloader({ uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' })
 
-    expect(await MediaWiki.hasWikimediaDesktopApi()).toBe(false)
-    expect(await MediaWiki.hasWikimediaMobileApi()).toBe(false)
-    expect(await MediaWiki.hasVisualEditorApi()).toBe(false)
+    expect(await MediaWiki.hasWikimediaDesktopApi(downloader)).toBe(false)
+    expect(await MediaWiki.hasWikimediaMobileApi(downloader)).toBe(false)
+    expect(await MediaWiki.hasVisualEditorApi(downloader)).toBe(false)
 
     /* TODO:
       Title MediaWiki:Sidebar does not exist for Mediawiki Rest Api in pokemon.fandom.com for some reason. This will lead to incorrect capability check
       See: https://pokemon.fandom.com/rest.php/v1/page/MediaWiki%3ASidebar/html
     */
     MediaWiki.apiCheckArticleId = 'Volcarona'
-    expect(await MediaWiki.hasRestApi()).toBe(true)
+    expect(await MediaWiki.hasRestApi(downloader)).toBe(true)
   })
 })

--- a/test/unit/renderers/renderer.builder.test.ts
+++ b/test/unit/renderers/renderer.builder.test.ts
@@ -5,19 +5,26 @@ import { RendererBuilderOptions } from '../../../src/renderers/abstract.renderer
 import { WikimediaDesktopRenderer } from '../../../src/renderers/wikimedia-desktop.renderer.js'
 import { VisualEditorRenderer } from '../../../src/renderers/visual-editor.renderer.js'
 import { RestApiRenderer } from '../../../src/renderers/rest-api.renderer.js'
+import MediaWiki from '../../../src/MediaWiki.js'
+import Downloader from '../../../src/Downloader.js'
+import { config } from '../../../src/config.js'
 
 jest.setTimeout(10000)
 
 describe('RendererBuilder', () => {
   let rendererBuilder: RendererBuilder
+  let downloader: Downloader
+
   beforeEach(() => {
     rendererBuilder = new RendererBuilder()
+    MediaWiki.base = 'https://en.wikipedia.org'
+    downloader = new Downloader({ uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' })
   })
 
   it('should create a WikimediaDesktopRenderer for desktop mode', async () => {
     const { MediaWiki } = await setupScrapeClasses() // en wikipedia
 
-    const renderer = await rendererBuilder.createRenderer({
+    const renderer = await rendererBuilder.createRenderer(downloader, {
       MediaWiki,
       renderType: 'desktop',
     } as RendererBuilderOptions)
@@ -27,7 +34,7 @@ describe('RendererBuilder', () => {
   it('should create a WikimediaDesktopRenderer for auto mode for en wikipedia', async () => {
     const { MediaWiki } = await setupScrapeClasses() // en wikipedia
 
-    const renderer = await rendererBuilder.createRenderer({
+    const renderer = await rendererBuilder.createRenderer(downloader, {
       MediaWiki,
       renderType: 'auto',
     } as RendererBuilderOptions)
@@ -38,7 +45,7 @@ describe('RendererBuilder', () => {
     const { MediaWiki } = await setupScrapeClasses() // en wikipedia
 
     expect(async () => {
-      await rendererBuilder.createRenderer({
+      await rendererBuilder.createRenderer(downloader, {
         MediaWiki,
         renderType: 'unknownMode' as any,
       } as RendererBuilderOptions)
@@ -57,7 +64,7 @@ describe('RendererBuilder', () => {
       renderName: 'VisualEditor',
     }
 
-    const renderer = await rendererBuilder.createRenderer(rendererBuilderOptions as RendererBuilderOptions)
+    const renderer = await rendererBuilder.createRenderer(downloader, rendererBuilderOptions as RendererBuilderOptions)
 
     expect(renderer).toBeInstanceOf(VisualEditorRenderer)
   })
@@ -74,7 +81,7 @@ describe('RendererBuilder', () => {
       renderName: 'WikimediaDesktop',
     }
 
-    const renderer = await rendererBuilder.createRenderer(rendererBuilderOptions as RendererBuilderOptions)
+    const renderer = await rendererBuilder.createRenderer(downloader, rendererBuilderOptions as RendererBuilderOptions)
 
     expect(renderer).toBeInstanceOf(WikimediaDesktopRenderer)
   })
@@ -91,7 +98,7 @@ describe('RendererBuilder', () => {
       renderName: 'RestApi',
     }
 
-    const renderer = await rendererBuilder.createRenderer(rendererBuilderOptions as RendererBuilderOptions)
+    const renderer = await rendererBuilder.createRenderer(downloader, rendererBuilderOptions as RendererBuilderOptions)
 
     expect(renderer).toBeInstanceOf(RestApiRenderer)
   })
@@ -99,10 +106,10 @@ describe('RendererBuilder', () => {
   it('should throw an error for unknown RendererAPI in specific mode', async () => {
     const { downloader, MediaWiki } = await setupScrapeClasses() // en wikipedia
     await MediaWiki.hasCoordinates(downloader)
-    await MediaWiki.hasWikimediaDesktopApi()
-    await MediaWiki.hasWikimediaMobileApi()
-    await MediaWiki.hasRestApi()
-    await MediaWiki.hasVisualEditorApi()
+    await MediaWiki.hasWikimediaDesktopApi(downloader)
+    await MediaWiki.hasWikimediaMobileApi(downloader)
+    await MediaWiki.hasRestApi(downloader)
+    await MediaWiki.hasVisualEditorApi(downloader)
 
     const rendererBuilderOptions = {
       MediaWiki,
@@ -110,7 +117,7 @@ describe('RendererBuilder', () => {
       renderName: 'UnknownAPI', // Using an invalid RendererAPI for the test
     }
 
-    expect(async () => rendererBuilder.createRenderer(rendererBuilderOptions as RendererBuilderOptions)).rejects.toThrow(
+    expect(async () => rendererBuilder.createRenderer(downloader, rendererBuilderOptions as RendererBuilderOptions)).rejects.toThrow(
       `Unknown renderName for specific mode: ${rendererBuilderOptions.renderName}`,
     )
   })

--- a/test/unit/s3.test.ts
+++ b/test/unit/s3.test.ts
@@ -10,11 +10,16 @@ describeIf('S3', () => {
   test('S3 checks', async () => {
     const s3UrlObj = urlParser.parse(`${process.env.S3_URL}`, true)
 
-    const s3 = new S3(`${s3UrlObj.protocol}//${s3UrlObj.host}/`, {
-      bucketName: s3UrlObj.query.bucketName,
-      keyId: s3UrlObj.query.keyId,
-      secretAccessKey: s3UrlObj.query.secretAccessKey,
-    })
+    const s3 = new S3(
+      `${s3UrlObj.protocol}//${s3UrlObj.host}/`,
+      {
+        bucketName: s3UrlObj.query.bucketName,
+        keyId: s3UrlObj.query.keyId,
+        secretAccessKey: s3UrlObj.query.secretAccessKey,
+      },
+      1000 * 60,
+      false,
+    )
 
     const credentialExists = await s3.initialise()
     // Credentials on S3 exists
@@ -48,11 +53,16 @@ describeIf('S3', () => {
 
     expect(
       () =>
-        new S3(`${wrongS3UrlObj.protocol}//${wrongS3UrlObj.host}/`, {
-          bucketName: wrongS3UrlObj.query.bucketName,
-          keyId: wrongS3UrlObj.query.keyId,
-          secretAccessKey: wrongS3UrlObj.query.secretAccessKey,
-        }),
+        new S3(
+          `${wrongS3UrlObj.protocol}//${wrongS3UrlObj.host}/`,
+          {
+            bucketName: wrongS3UrlObj.query.bucketName,
+            keyId: wrongS3UrlObj.query.keyId,
+            secretAccessKey: wrongS3UrlObj.query.secretAccessKey,
+          },
+          1000 * 60,
+          false,
+        ),
     ).toThrow('Unknown S3 region set')
   })
 })

--- a/test/unit/saveArticles.test.ts
+++ b/test/unit/saveArticles.test.ts
@@ -41,10 +41,10 @@ describe('saveArticles', () => {
     test(`Article html processing using ${renderer} renderer`, async () => {
       const { MediaWiki, downloader, dump } = await setupScrapeClasses() // en wikipedia
       await MediaWiki.hasCoordinates(downloader)
-      await MediaWiki.hasWikimediaDesktopApi()
-      await MediaWiki.hasWikimediaMobileApi()
-      await MediaWiki.hasRestApi()
-      await MediaWiki.hasVisualEditorApi()
+      await MediaWiki.hasWikimediaDesktopApi(downloader)
+      await MediaWiki.hasWikimediaMobileApi(downloader)
+      await MediaWiki.hasRestApi(downloader)
+      await MediaWiki.hasVisualEditorApi(downloader)
 
       const _articlesDetail = await downloader.getArticleDetailsIds(['London'])
       const articlesDetail = mwRetToArticleDetail(_articlesDetail)

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -313,19 +313,31 @@ describe('Utils', () => {
     })
 
     test('URL as parameter', async () => {
-      jest.spyOn(axios, 'get').mockResolvedValue({
+      jest.spyOn(downloader, 'request').mockResolvedValue({
         data: fs.createReadStream(filePath),
+        status: 200,
+        statusText: 'OK',
+        headers: null,
+        config: null,
       })
       const result: string[] = await extractArticleList('http://test.com/strings', downloader)
       expect(result).toEqual(argumentsList)
     })
 
     test("Comma separated URL's as parameter", async () => {
-      jest.spyOn(axios, 'get').mockResolvedValueOnce({
+      jest.spyOn(downloader, 'request').mockResolvedValueOnce({
         data: fs.createReadStream(filePath),
+        status: 200,
+        statusText: 'OK',
+        headers: null,
+        config: null,
       })
-      jest.spyOn(axios, 'get').mockResolvedValueOnce({
+      jest.spyOn(downloader, 'request').mockResolvedValueOnce({
         data: fs.createReadStream(anotherFilePath),
+        status: 200,
+        statusText: 'OK',
+        headers: null,
+        config: null,
       })
       const result: string[] = await extractArticleList('http://test.com/strings,http://test.com/another-strings', downloader)
       expect(result.sort()).toEqual(argumentsList.concat(anotherArgumentsList))
@@ -337,7 +349,7 @@ describe('Utils', () => {
     })
 
     test('Error if trying to get articleList from wrong URL ', async () => {
-      jest.spyOn(axios, 'get').mockRejectedValue({})
+      jest.spyOn(downloader, 'request').mockRejectedValue({})
       await expect(extractArticleList('http://valid-wrong-url.com/', downloader)).rejects.toThrow('Failed to read articleList from URL: http://valid-wrong-url.com/')
     })
   })

--- a/test/util.ts
+++ b/test/util.ts
@@ -41,10 +41,10 @@ export async function setupScrapeClasses({ mwUrl = 'https://en.wikipedia.org', f
 
   await MediaWiki.getMwMetaData(downloader)
   await MediaWiki.hasCoordinates(downloader)
-  await MediaWiki.hasWikimediaDesktopApi()
-  await MediaWiki.hasWikimediaMobileApi()
-  await MediaWiki.hasRestApi()
-  await MediaWiki.hasVisualEditorApi()
+  await MediaWiki.hasWikimediaDesktopApi(downloader)
+  await MediaWiki.hasWikimediaMobileApi(downloader)
+  await MediaWiki.hasRestApi(downloader)
+  await MediaWiki.hasVisualEditorApi(downloader)
 
   const dump = new Dump(format, {} as any, MediaWiki.metaData)
 


### PR DESCRIPTION
Fix #2137 
Fix #2139 
Fix #2141

Changes:
- destroy S3 socket when we do not need the response because it is outdated
- align S3 settings with Axios ones (keep-alive, no max sockets, insecure https, timeouts)
- always use a pre-defined AxiosRequestConfig from downloader for all axios calls (even those outside the downloader)
- mutualise settings of AxiosRequestConfig in a `basicRequestOptions` (keep-alive, timeouts, insecure HTTPs, login cookie)
- perform all axios calls through the downloader so that proper things are setup / collected:
  - collect cookies from responses
  - set cookie on subsequent requests (live value from last response with a `Set-Cookie` response header)
  - add a signal for connection timeout (must be unique to each request)
  - set `Referer` header on all requests (useful only for WMF maps so far, but might help for others as well and not expected to do any harm, best place to handle exceptions anyway)
- directly source mwoffliner version from package.json to set this as User-Agent
  -`HEAD` was used so far, and it both wrong and it looks like Cloudflare is blocking User-Agent containing `HEAD` string
  - it now uses a "tricky" prebuild npm hook to generate a `version.ts` file with proper TS content inside ; while not really lean / obvious, it is the only solution I found which avoids to have to embed package.json in build output and mess with directory layout (package.json is too high in the folder hierarchy)
- log error response from API checks when log level is `info`

Edit: to be merged to main only once https://github.com/openzim/mwoffliner/pull/2148 is merged