### PR TITLE
Set a default loglevel 'log' when verbose is not set

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,7 @@
 Unreleased:
 
+* CHANGED: Set default log level to `log` to sufficiently verbose logs by default (@benoit #2121)
+
 1.14.1:
 * FIX: Ensure AWS SDK has access to object size when issuing an upload (@benoit #2117)
 * FIX: Change log level of S3 missing keys message (@benoit #2144)

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -103,7 +103,7 @@ async function execute(argv: any) {
 
   let { articleList, articleListToIgnore } = argv
 
-  if (verbose) logger.setVerboseLevel(verbose)
+  logger.setVerboseLevel(verbose ? verbose : 'log') // Default log level is 'log'
 
   logger.log(`Starting mwoffliner v${packageJSON.version}...`)
 


### PR DESCRIPTION
Fix #2121