### PR TITLE
Ignore pages without a single revision / revid

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,5 @@
 Unreleased:
+* FIX: Ignore pages without a single revision / revid (#2091)
 
 * CHANGED: Set default log level to `log` to sufficiently verbose logs by default (@benoit #2121)
 


### PR DESCRIPTION
Fix #2091 

Code is a bit verbose but it allows to extend the conditions about articles we want to ignore without having to touch anything else, will probably save us one or two bugs in the future.

I also took this opportunity to make a clearer difference between `articleDetails` and `_articleDetails` variables (was very confusing).