### PR TITLE
Fix the filename computation of article list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ env:
   S3_URL: ${{ secrets.S3_URL }}
   ZIMCHECK_PATH: $( find .. -name zimcheck )
   ZIMDUMP_PATH: $( find .. -name zimdump )
+  KEEP_ZIMS: 1
 
 jobs:
   ci-test:
@@ -53,6 +54,15 @@ jobs:
       - name: Running scheduled all tests (no coverage)
         if: ${{ github.event_name == 'schedule' }}
         run: npm run test-without-coverage
+
+      - name: Uploading ZIM artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          path: mwo-test-*/*.zim
+          # keep scheduled (daily artifacts for 7 days, others only 1 day)
+          retention-days: ${{ github.event_name == 'schedule' && 7 || 1 }}
+          compression-level: 0
 
       - name: Mailgun Action
         if: ${{ failure() && github.event_name == 'schedule' }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mwoffliner",
-  "version": "1.14.1-dev0",
+  "version": "1.14.3-dev0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mwoffliner",
-      "version": "1.14.1-dev0",
+      "version": "1.14.3-dev0",
       "license": "GPL-3.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.374.0",

--- a/src/Dump.ts
+++ b/src/Dump.ts
@@ -118,7 +118,7 @@ export class Dump {
           .basename(this.opts.articleList)
           .toLowerCase()
           .replace(/\.\w{3}$/, '')
-          .replace(/[\,\s]/g, '_')
+          .replace(/[^a-z0-9-]+/g, '-')
         if (filenamePostfix.length > 50) {
           filenamePostfix = filenamePostfix.slice(0, 50)
         }

--- a/test/e2e/apiPathParamsSanitizing.e2e.test.ts
+++ b/test/e2e/apiPathParamsSanitizing.e2e.test.ts
@@ -17,7 +17,7 @@ const parameters = {
   mwWikiPath: sanitizeWikiPath('/wiki'),
 }
 
-await testAllRenders(parameters, async (outFiles) => {
+await testAllRenders('api-path-params', parameters, async (outFiles) => {
   describe(`e2e test for api url params for en.wikipedia.org for ${outFiles[0]?.renderer} renderer`, () => {
     test('Mediawiki actionApiPath option sanitized', () => {
       expect(outFiles[0].mwMetaData.actionApiPath).toBe('/w/api.php')
@@ -45,7 +45,9 @@ await testAllRenders(parameters, async (outFiles) => {
     })
 
     afterAll(() => {
-      rimraf.sync(`./${outFiles[0].testId}`)
+      if (!process.env.KEEP_ZIMS) {
+        rimraf.sync(`./${outFiles[0].testId}`)
+      }
     })
   })
 })

--- a/test/e2e/articleLists.test.ts
+++ b/test/e2e/articleLists.test.ts
@@ -19,7 +19,7 @@ const parameters = {
   format: ['nopic'],
 }
 
-await testAllRenders(parameters, async (outFiles) => {
+await testAllRenders('article-lists', parameters, async (outFiles) => {
   describe('articleList', () => {
     const listMinusIgnore = 2
 
@@ -50,7 +50,9 @@ await testAllRenders(parameters, async (outFiles) => {
       expect(redisScan.stdout).toEqual('')
     })
     afterAll(() => {
-      rimraf.sync(`./${outFiles[0].testId}`)
+      if (!process.env.KEEP_ZIMS) {
+        rimraf.sync(`./${outFiles[0].testId}`)
+      }
     })
   })
 })

--- a/test/e2e/bm.e2e.test.ts
+++ b/test/e2e/bm.e2e.test.ts
@@ -15,7 +15,7 @@ const parameters = {
   format: ['nopic'],
 }
 
-await testAllRenders(parameters, async (outFiles) => {
+await testAllRenders('bm-wikipedia', parameters, async (outFiles) => {
   test(`test zim integrity for ${outFiles[0]?.renderer} renderer`, async () => {
     await expect(zimcheck(outFiles[0].outFile)).resolves.not.toThrowError()
   })
@@ -29,8 +29,8 @@ await testAllRenders(parameters, async (outFiles) => {
       if (dump.nopic) {
         // nopic has enough files (this is just an estimate and can change
         // with time, as new Mediwiki versions are released).
-        expect(dump.status.files.success).toBeGreaterThan(12)
-        expect(dump.status.files.success).toBeLessThan(22)
+        expect(dump.status.files.success).toBeGreaterThan(6)
+        expect(dump.status.files.success).toBeLessThan(14)
         // nopic has enough redirects
         expect(dump.status.redirects.written).toBeGreaterThan(170)
         // nopic has enough articles
@@ -40,11 +40,13 @@ await testAllRenders(parameters, async (outFiles) => {
   })
 
   afterAll(() => {
-    rimraf.sync(`./${outFiles[0].testId}`)
+    if (!process.env.KEEP_ZIMS) {
+      rimraf.sync(`./${outFiles[0].testId}`)
+    }
   })
 })
 
-await testAllRenders({ ...parameters, addNamespaces: 1 }, async (outFiles) => {
+await testAllRenders('bm-wikipedia-with-ns-1', { ...parameters, addNamespaces: 1 }, async (outFiles) => {
   test(`Articles with "Discussion" namespace for ${outFiles[0]?.renderer} renderer for bm.wikipedia.org`, async () => {
     await execa('redis-cli flushall', { shell: true })
 
@@ -55,6 +57,8 @@ await testAllRenders({ ...parameters, addNamespaces: 1 }, async (outFiles) => {
     expect(discussionArticlesList.length).toBeGreaterThan(30)
   })
   afterAll(() => {
-    rimraf.sync(`./${outFiles[0].testId}`)
+    if (!process.env.KEEP_ZIMS) {
+      rimraf.sync(`./${outFiles[0].testId}`)
+    }
   })
 })

--- a/test/e2e/downloadImage.e2e.test.ts
+++ b/test/e2e/downloadImage.e2e.test.ts
@@ -18,7 +18,7 @@ const parameters = {
   optimisationCacheUrl: process.env.S3_URL,
 }
 
-await testAllRenders(parameters, async (outFiles) => {
+await testAllRenders('download-image', parameters, async (outFiles) => {
   describeIf('Check image downloading from S3 using optimisationCacheUrl parameter', () => {
     test(`right scrapping from fr.wikipedia.org with optimisationCacheUrl parameter for ${outFiles[0]?.renderer} renderer`, async () => {
       await expect(zimcheck(outFiles[0].outFile)).resolves.not.toThrowError()
@@ -28,7 +28,9 @@ await testAllRenders(parameters, async (outFiles) => {
       expect(redisScan.stdout).toEqual('')
     })
     afterAll(() => {
-      rimraf.sync(`./${outFiles[0].testId}`)
+      if (!process.env.KEEP_ZIMS) {
+        rimraf.sync(`./${outFiles[0].testId}`)
+      }
     })
   })
 })

--- a/test/e2e/en.e2e.test.ts
+++ b/test/e2e/en.e2e.test.ts
@@ -26,7 +26,7 @@ const parameters = {
   adminEmail: 'test@kiwix.org',
 }
 
-await testAllRenders(parameters, async (outFiles) => {
+await testAllRenders('en-wikipedia', parameters, async (outFiles) => {
   const articleFromDump = await zimdump(`show --url A/${parameters.articleList} ${outFiles[0].outFile}`)
   describe('e2e test for en.wikipedia.org', () => {
     const articleDoc = domino.createDocument(articleFromDump)
@@ -47,7 +47,9 @@ await testAllRenders(parameters, async (outFiles) => {
     })
 
     afterAll(() => {
-      rimraf.sync(`./${outFiles[0].testId}`)
+      if (!process.env.KEEP_ZIMS) {
+        rimraf.sync(`./${outFiles[0].testId}`)
+      }
     })
   })
 })

--- a/test/e2e/en10.e2e.test.ts
+++ b/test/e2e/en10.e2e.test.ts
@@ -14,7 +14,7 @@ const parameters = {
   format: ['nopic', 'nopdf'],
 }
 
-await testAllRenders(parameters, async (outFiles) => {
+await testAllRenders('en10-wikipedia', parameters, async (outFiles) => {
   describe('en10', () => {
     test(`Simple articleList for ${outFiles[0]?.renderer} renderer`, async () => {
       // Created 2 outputs
@@ -24,8 +24,8 @@ await testAllRenders(parameters, async (outFiles) => {
         if (dump.nopic) {
           // nopic has enough files (this is just an estimate and can change
           // with time, as new Mediwiki versions are released).
-          expect(dump.status.files.success).toBeGreaterThan(50)
-          expect(dump.status.files.success).toBeLessThan(60)
+          expect(dump.status.files.success).toBeGreaterThanOrEqual(48)
+          expect(dump.status.files.success).toBeLessThan(59)
           // nopic has enough redirects
           expect(dump.status.redirects.written).toBeGreaterThan(500)
           // nopic has 10 articles
@@ -63,7 +63,9 @@ await testAllRenders(parameters, async (outFiles) => {
     })
 
     afterAll(() => {
-      rimraf.sync(`./${outFiles[0].testId}`)
+      if (!process.env.KEEP_ZIMS) {
+        rimraf.sync(`./${outFiles[0].testId}`)
+      }
     })
   })
 })

--- a/test/e2e/formatParams.test.ts
+++ b/test/e2e/formatParams.test.ts
@@ -14,7 +14,7 @@ const parameters = {
   redis: process.env.REDIS,
 }
 
-await testAllRenders({ ...parameters, format: 'nopic', articleList: 'BMW' }, async (outFiles) => {
+await testAllRenders('format-params-nopic', { ...parameters, format: 'nopic', articleList: 'BMW' }, async (outFiles) => {
   describe('format:nopic', () => {
     test(`Test en.wikipedia.org using format:nopic for ${outFiles[0]?.renderer} renderer`, async () => {
       await execa('redis-cli flushall', { shell: true })
@@ -24,12 +24,14 @@ await testAllRenders({ ...parameters, format: 'nopic', articleList: 'BMW' }, asy
       const imgElements = Array.from(articleDoc.querySelectorAll('img'))
 
       expect(imgElements).toHaveLength(0)
-      rimraf.sync(`./${outFiles[0].testId}`)
+      if (!process.env.KEEP_ZIMS) {
+        rimraf.sync(`./${outFiles[0].testId}`)
+      }
     })
   })
 })
 
-await testAllRenders({ ...parameters, format: 'nodet', articleList: 'BMW' }, async (outFiles) => {
+await testAllRenders('format-params-nodet', { ...parameters, format: 'nodet', articleList: 'BMW' }, async (outFiles) => {
   describe('format:nodet', () => {
     test(`Test en.wikipedia.org using format:nodet for ${outFiles[0]?.renderer} renderer`, async () => {
       await execa('redis-cli flushall', { shell: true })
@@ -40,12 +42,14 @@ await testAllRenders({ ...parameters, format: 'nodet', articleList: 'BMW' }, asy
 
       expect(sectionsElements).toHaveLength(1)
       expect(sectionsElements[0].getAttribute('data-mw-section-id')).toEqual('0')
-      rimraf.sync(`./${outFiles[0].testId}`)
+      if (!process.env.KEEP_ZIMS) {
+        rimraf.sync(`./${outFiles[0].testId}`)
+      }
     })
   })
 })
 
-await testAllRenders({ ...parameters, format: 'novid', articleList: 'Animation' }, async (outFiles) => {
+await testAllRenders('format-params-novid-1', { ...parameters, format: 'novid', articleList: 'Animation' }, async (outFiles) => {
   describe('format:novid to check no video tags', () => {
     test(`Test en.wikipedia.org using format:novid for ${outFiles[0]?.renderer} renderer (no video)`, async () => {
       await execa('redis-cli flushall', { shell: true })
@@ -55,12 +59,14 @@ await testAllRenders({ ...parameters, format: 'novid', articleList: 'Animation' 
       const audioElements = Array.from(articleDoc.querySelectorAll('audio'))
 
       expect(audioElements).toHaveLength(0)
-      rimraf.sync(`./${outFiles[0].testId}`)
+      if (!process.env.KEEP_ZIMS) {
+        rimraf.sync(`./${outFiles[0].testId}`)
+      }
     })
   })
 })
 
-await testAllRenders({ ...parameters, format: 'novid', articleList: 'English_alphabet' }, async (outFiles) => {
+await testAllRenders('format-params-novid-2', { ...parameters, format: 'novid', articleList: 'English_alphabet' }, async (outFiles) => {
   describe('format:novid to check no audio tags', () => {
     test(`Test en.wikipedia.org using format:novid for ${outFiles[0]?.renderer} renderer (no audio)`, async () => {
       await execa('redis-cli flushall', { shell: true })
@@ -70,7 +76,9 @@ await testAllRenders({ ...parameters, format: 'novid', articleList: 'English_alp
       const videoElements = Array.from(articleDoc.querySelectorAll('video'))
 
       expect(videoElements).toHaveLength(0)
-      rimraf.sync(`./${outFiles[0].testId}`)
+      if (!process.env.KEEP_ZIMS) {
+        rimraf.sync(`./${outFiles[0].testId}`)
+      }
     })
   })
 })
@@ -85,7 +93,9 @@ await testRenders({ ...parameters, format: 'nopdf', articleList: 'PDF' }, async 
       const articleDoc = domino.createDocument(articleFromDump)
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const anchorElements = Array.from(articleDoc.querySelectorAll('a'))
-      rimraf.sync(`./${outFiles[0].testId}`)
+      if (!process.env.KEEP_ZIMS) {
+        rimraf.sync(`./${outFiles[0].testId}`)
+      }
     })
   })
 })

--- a/test/e2e/multimediaContent.test.ts
+++ b/test/e2e/multimediaContent.test.ts
@@ -16,6 +16,7 @@ const parameters = {
 }
 
 await testRenders(
+  'multimedia-content',
   parameters,
   async (outFiles) => {
     describe('Multimedia', () => {
@@ -42,7 +43,9 @@ await testRenders(
             )
           })
           afterAll(() => {
-            rimraf.sync(`./${outFiles[0].testId}`)
+            if (!process.env.KEEP_ZIMS) {
+              rimraf.sync(`./${outFiles[0].testId}`)
+            }
           })
           break
         case 'VisualEditor':
@@ -67,7 +70,9 @@ await testRenders(
             )
           })
           afterAll(() => {
-            rimraf.sync(`./${outFiles[0].testId}`)
+            if (!process.env.KEEP_ZIMS) {
+              rimraf.sync(`./${outFiles[0].testId}`)
+            }
           })
           break
       }
@@ -77,6 +82,7 @@ await testRenders(
 )
 
 await testRenders(
+  'multimedia-content',
   { ...parameters, format: ['nopic', 'novid', 'nopdf', 'nodet'] },
   async (outFiles) => {
     describe('Multimedia for different formats', () => {
@@ -135,7 +141,9 @@ await testRenders(
             }
           })
           afterAll(() => {
-            rimraf.sync(`./${outFiles[0].testId}`)
+            if (!process.env.KEEP_ZIMS) {
+              rimraf.sync(`./${outFiles[0].testId}`)
+            }
           })
           break
         case 'VisualEditor':
@@ -191,7 +199,9 @@ await testRenders(
             }
           })
           afterAll(() => {
-            rimraf.sync(`./${outFiles[0].testId}`)
+            if (!process.env.KEEP_ZIMS) {
+              rimraf.sync(`./${outFiles[0].testId}`)
+            }
           })
           break
       }

--- a/test/e2e/openstreetmap.e2e.test.ts
+++ b/test/e2e/openstreetmap.e2e.test.ts
@@ -27,6 +27,7 @@ const parameters = {
 }
 
 await testRenders(
+  'openstreetmap',
   parameters,
   async (outFiles) => {
     const articleFromDump = await zimdump(`show --url A/${parameters.articleList} ${outFiles[0].outFile}`)
@@ -49,7 +50,9 @@ await testRenders(
       })
 
       afterAll(() => {
-        rimraf.sync(`./${outFiles[0].testId}`)
+        if (!process.env.KEEP_ZIMS) {
+          rimraf.sync(`./${outFiles[0].testId}`)
+        }
       })
     })
   },

--- a/test/e2e/treatMedia.e2e.test.ts
+++ b/test/e2e/treatMedia.e2e.test.ts
@@ -14,7 +14,7 @@ const parameters = {
   redis: process.env.REDIS,
 }
 
-await testAllRenders(parameters, async (outFiles) => {
+await testAllRenders('treat-media', parameters, async (outFiles) => {
   test('media file from hidden element should not be downloaded', async () => {
     await execa('redis-cli flushall', { shell: true })
 
@@ -24,6 +24,8 @@ await testAllRenders(parameters, async (outFiles) => {
   })
 
   afterAll(() => {
-    rimraf.sync(`./${outFiles[0].testId}`)
+    if (!process.env.KEEP_ZIMS) {
+      rimraf.sync(`./${outFiles[0].testId}`)
+    }
   })
 })

--- a/test/e2e/vikidia.e2e.test.ts
+++ b/test/e2e/vikidia.e2e.test.ts
@@ -34,7 +34,9 @@ await testRenders(
     })
 
     afterAll(() => {
-      rimraf.sync(`./${outFiles[0].testId}`)
+      if (!process.env.KEEP_ZIMS) {
+        rimraf.sync(`./${outFiles[0].testId}`)
+      }
     })
   },
   // en.vikidia.org supports only VisualEditor among other renders

--- a/test/e2e/wikisource.e2e.test.ts
+++ b/test/e2e/wikisource.e2e.test.ts
@@ -15,6 +15,7 @@ const parameters = {
 }
 
 await testRenders(
+  'wikisource',
   parameters,
   async (outFiles) => {
     describe('wikisource', () => {
@@ -29,7 +30,7 @@ await testRenders(
               if (dump.nopic) {
                 console.log(dump.status.files.fail)
                 // nopic has enough files
-                expect(dump.status.files.success).toBeGreaterThanOrEqual(13)
+                expect(dump.status.files.success).toBeGreaterThanOrEqual(7)
                 // nopic has enough redirects
                 expect(dump.status.redirects.written).toBeGreaterThanOrEqual(16)
                 // nopic has enough articles
@@ -39,7 +40,9 @@ await testRenders(
           })
 
           afterAll(() => {
-            rimraf.sync(`./${outFiles[0].testId}`)
+            if (!process.env.KEEP_ZIMS) {
+              rimraf.sync(`./${outFiles[0].testId}`)
+            }
           })
           break
         case 'VisualEditor':
@@ -51,7 +54,7 @@ await testRenders(
             for (const dump of outFiles) {
               if (dump.nopic) {
                 // nopic has enough files
-                expect(dump.status.files.success).toBeGreaterThanOrEqual(13)
+                expect(dump.status.files.success).toBeGreaterThanOrEqual(7)
                 // nopic has enough redirects
                 expect(dump.status.redirects.written).toBeGreaterThanOrEqual(16)
                 // nopic has enough articles
@@ -59,7 +62,9 @@ await testRenders(
               }
             }
           })
-          rimraf.sync(`./${outFiles[0].testId}`)
+          if (!process.env.KEEP_ZIMS) {
+            rimraf.sync(`./${outFiles[0].testId}`)
+          }
           break
       }
     })

--- a/test/e2e/zimMetadata.e2e.test.ts
+++ b/test/e2e/zimMetadata.e2e.test.ts
@@ -19,7 +19,7 @@ const parameters = {
   publisher: 'Example of the publisher',
 }
 
-await testAllRenders(parameters, async (outFiles) => {
+await testAllRenders('zim-metadata', parameters, async (outFiles) => {
   describe('zimMetadata', () => {
     test(`check all zim metadata using zimdump for ${outFiles[0]?.renderer} renderer`, async () => {
       await execa('redis-cli flushall', { shell: true })
@@ -46,7 +46,9 @@ await testAllRenders(parameters, async (outFiles) => {
     })
 
     afterAll(() => {
-      rimraf.sync(`./${outFiles[0].testId}`)
+      if (!process.env.KEEP_ZIMS) {
+        rimraf.sync(`./${outFiles[0].testId}`)
+      }
     })
   })
 })

--- a/test/testRenders.ts
+++ b/test/testRenders.ts
@@ -52,12 +52,12 @@ async function getOutFiles(renderName: string, testId: string, parameters: Param
   return outFiles
 }
 
-export async function testRenders(parameters: Parameters, callback, renderersList: Array<string>) {
+export async function testRenders(testName: string, parameters: Parameters, callback, renderersList: Array<string>) {
   await checkZimTools()
   for (const renderer of renderersList) {
     try {
       const now = new Date()
-      const testId = `mwo-test-${+now}`
+      const testId = `mwo-test-${testName}-${renderer}-${+now}`
       const outFiles = await getOutFiles(renderer, testId, parameters)
       outFiles[0].testId = testId
       outFiles[0].renderer = renderer
@@ -69,6 +69,6 @@ export async function testRenders(parameters: Parameters, callback, renderersLis
   }
 }
 
-export async function testAllRenders(parameters: Parameters, callback) {
-  return testRenders(parameters, callback, RENDERERS_LIST)
+export async function testAllRenders(testName: string, parameters: Parameters, callback) {
+  return testRenders(testName, parameters, callback, RENDERERS_LIST)
 }

--- a/test/unit/dump.test.ts
+++ b/test/unit/dump.test.ts
@@ -1,29 +1,49 @@
 import { startRedis, stopRedis } from './bootstrap.js'
 import { Dump } from '../../src/Dump.js'
 
-describe('Dump formats', () => {
+describe('Dump filename radical', () => {
   beforeAll(startRedis)
   afterAll(stopRedis)
 
-  const formatTests = {
-    '': '',
-    ':extra_alias_tag': '_extra_alias_tag',
-    'nopic:nopic_alias': '_nopic_alias',
-    'nopic,nopdf': '_nopic',
-    'nopic,nopdf:pdf_alias': '_pdf_alias',
-    'nopic,:extra_alias': '_extra_alias',
-    'nopic:': '',
-    'nopic,novid:': '',
-    'nopic,nodet': '_nopic_nodet',
-    'nodet,nopic': '_nopic_nodet',
-  }
+  describe('Based on format', () => {
+    const formatTests = {
+      '': '',
+      ':extra_alias_tag': '_extra_alias_tag',
+      'nopic:nopic_alias': '_nopic_alias',
+      'nopic,nopdf': '_nopic',
+      'nopic,nopdf:pdf_alias': '_pdf_alias',
+      'nopic,:extra_alias': '_extra_alias',
+      'nopic:': '',
+      'nopic,novid:': '',
+      'nopic,nodet': '_nopic_nodet',
+      'nodet,nopic': '_nopic_nodet',
+    }
 
-  for (const [format, expectedFormatTags] of Object.entries(formatTests)) {
-    test(`tag [${expectedFormatTags}] is correct`, async () => {
-      const dump = new Dump(format, {} as any, { creator: '', webUrl: 'https://en.wikipedia.org', langIso2: '' } as any)
-      const outFormat = dump.computeFilenameRadical(true, false, true)
+    for (const [format, expectedFormatTags] of Object.entries(formatTests)) {
+      test(`tag [${expectedFormatTags}] is correct`, async () => {
+        const dump = new Dump(format, {} as any, { creator: '', webUrl: 'https://en.wikipedia.org', langIso2: '' } as any)
+        const outFormat = dump.computeFilenameRadical(true, false, true)
 
-      expect(outFormat).toEqual(`_${expectedFormatTags}`)
-    })
-  }
+        expect(outFormat).toEqual(`_${expectedFormatTags}`)
+      })
+    }
+  })
+
+  describe('Based on article list', () => {
+    const radicalTests = {
+      Brian_May: 'brian-may',
+      'Bob:Morane': 'bob-morane',
+      'Brian,Bob,Morane': 'brian-bob-morane',
+      'https://myhost.acme.com/mylist.tsv': 'mylist',
+      'https://myhost.acme.com/mylist1.tsv,https://myhost.acme.com/mylist2.tsv': 'mylist2',
+    }
+
+    for (const [articleList, expectedRadicalSuffix] of Object.entries(radicalTests)) {
+      test(`radical for article list [${articleList}] is correct`, async () => {
+        const dump = new Dump('', { articleList } as any, { creator: '', webUrl: 'https://en.wikipedia.org', langIso2: 'en' } as any)
+        const outFormat = dump.computeFilenameRadical(false, false, true)
+        expect(outFormat).toEqual(`_en_${expectedRadicalSuffix}`)
+      })
+    }
+  })
 })


### PR DESCRIPTION
When the computation of ZIM filename is based on article list, and when the article list contains real article titles (instead of file / URL), the resulting ZIM name does not necessarily respect our convention:

- we used the underscore _ as separator between words while we should aim for dash since underscores are reserved for name parts in the convention (https://wiki.openzim.org/wiki/Content_team/ZIM_Naming_Convention)
- we kept too many special chars, only lowercase alphanum is allowed

Note that this is a temporary fix, mid-term solution is probably https://github.com/openzim/mwoffliner/issues/2197 but there is just too much to analyze in this issue, this simple fix is enough for the short term