### PR TITLE
Implement use of ActionParse API to retrieve article HTML

### DIFF
--- a/docs/functional_architecture.md
+++ b/docs/functional_architecture.md
@@ -1,0 +1,62 @@
+# Functional Architecture
+
+This document describes a high-level overview of how mwoffliner scraper works.
+
+At a high level, mwoffliner is divided into following sequence of actions.
+
+- retrieve list of articles to include and their metadata
+- for every article:
+  - retrieve its parsed HTML (Wikitext transformed into HTML) and JS/CSS dependencie
+  - adapt / render it for proper operation within the ZIM file (includes detection of media dependencies)
+  - save rendered article HTML into the ZIM
+- for every file dependency (JS/CSS/media)
+  - if its an image, download it either from S3 cache (images only) or from online and recompress when possible
+  - otherwise download it from online
+  - save them into the ZIM file
+
+The scraper supports flavours, which are variants of the ZIM (e.g. without images, with images but without videos, ...).
+
+The process above is repeated for every flavour requested.
+
+## Retrieving article HTML and rendering
+
+In order to retrieve article HTML and render it, multiple solutions have been identified.
+
+As of today, 5 renderers (way to download article + render it to ZIM compatible HTML) are implemented:
+
+- WikimediaDesktop
+- WikimediaMobile
+- RestApi
+- VisualEditor
+- ActionParse
+
+WikimediaDesktop and WikimediaMobile are only available on Wikimedia Mediawikis.
+
+Availability of RestApi and VisualEditor is subject to Mediawiki admin decision to support it or not. RestApi is available by default but might be blocked by admin. VisualEditor is an extension which might be installed or not.
+
+ActionParse is available since 1.16.0 (2010) and is anyway a requirement for other APIs.
+
+Only ActionParse (most recent renderer) implements a thorough skin support (see below about skin).
+
+All renderers but ActionParse needs two HTTP queries: one to retrieve the article HTML and one to retrieve its metadata (to a 'simplified' ActionParse URL in fact).
+
+Renderer is automatically selected based on its availability and mwoffliner own preference. ActionParse is the preferred renderer since 1.15.0 due to its general availability and support of skins.
+
+### Skins
+
+In Mediwikis, rendering of Wikitext into HTML works around a concept of skin. A skin is a mix of HTML template and CSS+JS dependencies. It defines both the visual appareance of the rendered Wikitext but also everything "around it".
+
+Since most wikis have adapted their content to their skin (and vice versa), it is mostly mandatory to use the skin inside the ZIM, both for proper rendering and for a visual appareance similar to online website (users don't mind about technical details, they want the wiki to be the same inside the ZIM than online).
+
+Skin detection is automated in mwoffliner for now (see https://github.com/openzim/mwoffliner/issues/2213).
+
+For now, only `vector` (legacy) and `vector-2022` are supported, and only with ActionParse renderer. Only `vector-2022` is the truely responsive skin, providing ultimate rendering on mostly all screen sizes.
+
+
+### JS / CSS dependencies
+
+ActionParse API is returning the list of JS and CSS dependencies for a given article, by inspecting what Wikitext is using.
+
+The special `startup` JS module is missing from results because always used anyway.
+
+There are still some known hiccups around this (see https://github.com/openzim/mwoffliner/issues/2212 and https://github.com/openzim/mwoffliner/issues/2215 for instance), and probably more to come, this is a complex area of Mediawiki.

--- a/res/templates/pageVector2022.html
+++ b/res/templates/pageVector2022.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html class='client-js'>
+  <head>
+    <meta charset="UTF-8"/>
+    <title></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/> __ARTICLE_CANONICAL_LINK__ __ARTICLE_CSS_LIST__
+    __CSS_LINKS__ __JS_SCRIPTS__
+    <style>.vector-body{font-size: 1rem; line-height: 1.6;}@media screen{@media (max-width:calc(639px)){table.infobox{width:100%!important;display:table}}}</style>
+  </head>
+  <body class="skin--responsive skin-vector skin-vector-search-vue mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable skin-vector-2022 action-view uls-dialog-sticky-hide" cz-shortcut-listen="true">
+    <div class="vector-header-container"></div>
+    <div class="mw-page-container">
+      <div class="mw-page-container-inner">
+        <div class="vector-sitenotice-container"></div>
+        <div class="vector-column-start"></div>
+        <div class="mw-content-container">
+          <main id="content" class="mw-body">
+            <header class="mw-body-header vector-page-titlebar">
+              <h1 id="firstHeading" class="firstHeading mw-first-heading">
+                <span id="openzim-page-title" class="mw-page-title-main"></span>
+              </h1>
+            </header>
+            <div class="vector-page-toolbar"></div>
+            <div class="vector-column-end"></div>
+            <a id="top"></a>
+            <div id="bodyContent" class="vector-body ve-init-mw-desktopArticleTarget-targetContainer" aria-labelledby="firstHeading" data-mw-ve-target-container="">
+              <div class="vector-body-before-content"></div>
+              <div id="contentSub"></div>
+              <h1 id="titleHeading" style="background-color: white; margin: 0;"></h1>
+              <div id="mw-content-text" class="mw-body-content"></div>
+            </div>
+          </main>
+        </div>
+      </div>
+    </div>    
+    __ARTICLE_CONFIGVARS_LIST__
+    __ARTICLE_JS_LIST__
+  </body>
+</html>

--- a/res/templates/pageVector2022.html
+++ b/res/templates/pageVector2022.html
@@ -4,8 +4,7 @@
     <meta charset="UTF-8"/>
     <title></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/> __ARTICLE_CANONICAL_LINK__ __ARTICLE_CSS_LIST__
-    __CSS_LINKS__ __JS_SCRIPTS__
-    <style>.vector-body{font-size: 1rem; line-height: 1.6;}@media screen{@media (max-width:calc(639px)){table.infobox{width:100%!important;display:table}}}</style>
+    <style>.vector-body{font-size: 1rem; line-height: 1.6;}@media screen{@media (max-width:calc(639px)){table.infobox{width:100%!important;display:table}}}.noviewer{display: none}</style>
   </head>
   <body class="skin--responsive skin-vector skin-vector-search-vue mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable skin-vector-2022 action-view uls-dialog-sticky-hide" cz-shortcut-listen="true">
     <div class="vector-header-container"></div>

--- a/res/templates/pageVectorLegacy.html
+++ b/res/templates/pageVectorLegacy.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html class="client-js">
+  <head>
+    <meta charset="UTF-8" />
+    <title></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    __ARTICLE_CANONICAL_LINK__ __ARTICLE_CSS_LIST__ __CSS_LINKS__ __JS_SCRIPTS__
+    <style>.mw-body{margin-left: auto;}</style>
+  </head>
+
+  <body
+    class="mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable skin-vector action-view minerva--history-page-action-enabled skin-vector-legacy"
+    cz-shortcut-listen="true"
+  >
+    <div id="mw-page-base" class="noprint"></div>
+    <div id="mw-head-base" class="noprint"></div>
+    <div id="content" class="mw-body" role="main">
+      <a id="top"></a>
+      <div class="mw-indicators mw-body-content"></div>
+      <h1 id="firstHeading" class="firstHeading" lang="en"><span id="openzim-page-title"></span></h1>
+      <div id="bodyContent" class="mw-body-content">
+        <div id="contentSub"></div>
+        <div id="contentSub2"></div>
+        <div id="mw-content-text" lang="en" dir="ltr" class="mw-content-ltr"></div>
+        <div class="printfooter"></div>
+        <div id="catlinks" class="catlinks" data-mw="interface"></div>
+      </div>
+    </div>
+    <div id="mw-navigation"></div>
+    <footer id="footer" class="mw-footer" role="contentinfo"></footer>
+
+    __ARTICLE_CONFIGVARS_LIST__ __ARTICLE_JS_LIST__
+  </body>
+</html>

--- a/res/templates/pageVectorLegacy.html
+++ b/res/templates/pageVectorLegacy.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <title></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    __ARTICLE_CANONICAL_LINK__ __ARTICLE_CSS_LIST__ __CSS_LINKS__ __JS_SCRIPTS__
+    __ARTICLE_CANONICAL_LINK__ __ARTICLE_CSS_LIST__
     <style>.mw-body{margin-left: auto;}</style>
   </head>
 

--- a/src/DOMUtils.ts
+++ b/src/DOMUtils.ts
@@ -1,5 +1,8 @@
 const DOMUtils = {
   deleteNode(node: DominoElement) {
+    if (!node) {
+      return
+    }
     if (node.parentNode) {
       node.parentNode.removeChild(node)
     } else {

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -177,6 +177,8 @@ class Downloader {
         return MediaWiki.wikimediaMobileUrlDirector
       case 'RestApiRenderer':
         return MediaWiki.restApiUrlDirector
+      case 'ActionParseRenderer':
+        return MediaWiki.actionParseUrlDirector
       /* istanbul ignore next */
       default:
         throw new Error(`Unknown renderer ${renderer.constructor.name}`)

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -748,7 +748,6 @@ class Downloader {
     // the script below extracts the config with a regex executed on the page header returned from the api
     const scriptTags = domino.createDocument(`${headhtml}</body></html>`).getElementsByTagName('script')
     const regex = /mw\.config\.set\(\{.*?\}\);/gm
-    // eslint-disable-next-line @typescript-eslint/prefer-for-of
     for (let i = 0; i < scriptTags.length; i += 1) {
       if (scriptTags[i].text.includes('mw.config.set')) {
         jsConfigVars = regex.exec(scriptTags[i].text)[0] || ''

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -12,6 +12,7 @@ import WikimediaDesktopURLDirector from './util/builders/url/desktop.director.js
 import WikimediaMobileURLDirector from './util/builders/url/mobile.director.js'
 import VisualEditorURLDirector from './util/builders/url/visual-editor.director.js'
 import RestApiURLDirector from './util/builders/url/rest-api.director.js'
+import ActionParseURLDirector from './util/builders/url/action-parse.director.js'
 import { checkApiAvailability } from './util/mw-api.js'
 import { BLACKLISTED_NS } from './util/const.js'
 
@@ -43,6 +44,7 @@ class MediaWiki {
   public apiCheckArticleId: string
   public queryOpts: QueryOpts
   public urlDirector: BaseURLDirector
+  public skin = 'vector' // Default fallback
 
   #wikiPath: string
   #actionApiPath: string
@@ -56,6 +58,7 @@ class MediaWiki {
   public wikimediaMobileUrlDirector: WikimediaMobileURLDirector
   public visualEditorUrlDirector: VisualEditorURLDirector
   public restApiUrlDirector: RestApiURLDirector
+  public actionParseUrlDirector: ActionParseURLDirector
 
   public visualEditorApiUrl: URL
   public actionApiUrl: URL
@@ -72,6 +75,7 @@ class MediaWiki {
   #hasWikimediaMobileApi: boolean | null
   #hasVisualEditorApi: boolean | null
   #hasRestApi: boolean | null
+  #hasActionParseApi: boolean | null
   #hasCoordinates: boolean | null
 
   set username(value: string) {
@@ -164,6 +168,7 @@ class MediaWiki {
     this.#hasWikimediaMobileApi = null
     this.#hasVisualEditorApi = null
     this.#hasRestApi = null
+    this.#hasActionParseApi = null
     this.#hasCoordinates = null
   }
 
@@ -213,6 +218,23 @@ class MediaWiki {
       return this.#hasRestApi
     }
     return this.#hasRestApi
+  }
+
+  public async hasActionParseApi(downloader: Downloader): Promise<boolean> {
+    if (this.#hasActionParseApi === null) {
+      for (const skin of ['vector-2022', 'vector']) {
+        this.actionParseUrlDirector = new ActionParseURLDirector(this.actionApiUrl.href, skin)
+        const checkUrl = this.actionParseUrlDirector.buildArticleURL(this.apiCheckArticleId)
+        this.#hasActionParseApi = await checkApiAvailability(downloader, checkUrl)
+        logger.log(`Checked for ActionParseApi with skin ${skin} at ${checkUrl} -- result is: ${this.#hasActionParseApi}`)
+        if (this.#hasActionParseApi) {
+          this.skin = skin
+          break
+        }
+      }
+      return this.#hasActionParseApi
+    }
+    return this.#hasActionParseApi
   }
 
   public async hasCoordinates(downloader: Downloader): Promise<boolean> {

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -182,7 +182,6 @@ class MediaWiki {
       const checkUrl = this.wikimediaDesktopUrlDirector.buildArticleURL(this.apiCheckArticleId)
       this.#hasWikimediaDesktopApi = await checkApiAvailability(downloader, checkUrl)
       logger.log('Checked for WikimediaDesktopApi at', checkUrl, '-- result is: ', this.#hasWikimediaDesktopApi)
-      return this.#hasWikimediaDesktopApi
     }
     return this.#hasWikimediaDesktopApi
   }
@@ -193,7 +192,6 @@ class MediaWiki {
       const checkUrl = this.wikimediaMobileUrlDirector.buildArticleURL(this.apiCheckArticleId)
       this.#hasWikimediaMobileApi = await checkApiAvailability(downloader, checkUrl)
       logger.log('Checked for WikimediaMobileApi at', checkUrl, '-- result is: ', this.#hasWikimediaMobileApi)
-      return this.#hasWikimediaMobileApi
     }
     return this.#hasWikimediaMobileApi
   }
@@ -204,7 +202,6 @@ class MediaWiki {
       const checkUrl = this.visualEditorUrlDirector.buildArticleURL(this.apiCheckArticleId)
       this.#hasVisualEditorApi = await checkApiAvailability(downloader, checkUrl, this.visualEditorUrlDirector.validMimeTypes)
       logger.log('Checked for VisualEditorApi at', checkUrl, '-- result is: ', this.#hasVisualEditorApi)
-      return this.#hasVisualEditorApi
     }
     return this.#hasVisualEditorApi
   }
@@ -215,7 +212,6 @@ class MediaWiki {
       const checkUrl = this.restApiUrlDirector.buildArticleURL(this.apiCheckArticleId)
       this.#hasRestApi = await checkApiAvailability(downloader, checkUrl)
       logger.log('Checked for RestApi at', checkUrl, '-- result is: ', this.#hasRestApi)
-      return this.#hasRestApi
     }
     return this.#hasRestApi
   }
@@ -232,7 +228,6 @@ class MediaWiki {
           break
         }
       }
-      return this.#hasActionParseApi
     }
     return this.#hasActionParseApi
   }

--- a/src/Templates.ts
+++ b/src/Templates.ts
@@ -29,6 +29,14 @@ const htmlWikimediaDesktopTemplateCode = () => {
   return readTemplate(config.output.templates.pageWikimediaDesktop)
 }
 
+const htmlVectorLegacyTemplateCode = () => {
+  return readTemplate(config.output.templates.pageVectorLegacy)
+}
+
+const htmlVector2022TemplateCode = () => {
+  return readTemplate(config.output.templates.pageVector2022)
+}
+
 const articleListHomeTemplate = readTemplate(config.output.templates.articleListHomeTemplate)
 
 export {
@@ -38,6 +46,8 @@ export {
   subSectionTemplate,
   htmlWikimediaMobileTemplateCode,
   htmlWikimediaDesktopTemplateCode,
+  htmlVectorLegacyTemplateCode,
+  htmlVector2022TemplateCode,
   articleListHomeTemplate,
   categoriesTemplate,
   subCategoriesTemplate,

--- a/src/config.ts
+++ b/src/config.ts
@@ -94,6 +94,14 @@ const config = {
         'ext.gadget.VisibilityToggles',
         'ext.gadget.defaultVisibilityToggles',
       ],
+      css_simplified: [
+        // infobox styles needed at least on hu.wikipedia.org
+        'ext.gadget.infobox,wikiMenuStyles',
+      ],
+      js_simplified: [
+        // base JS scripts always needed / never returned on API calls
+        'startup',
+      ],
     },
 
     // Output directories for storing mw related js and css resources
@@ -110,6 +118,8 @@ const config = {
        */
       pageWikimediaDesktop: './templates/pageWikimediaDesktop.html',
       pageWikimediaMobile: './templates/pageWikimediaMobile.html',
+      pageVectorLegacy: './templates/pageVectorLegacy.html',
+      pageVector2022: './templates/pageVector2022.html',
 
       categories: './templates/categories.html',
 

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -214,6 +214,7 @@ async function execute(argv: any) {
   const hasWikimediaMobileApi = await MediaWiki.hasWikimediaMobileApi(downloader)
   await MediaWiki.hasRestApi(downloader)
   await MediaWiki.hasVisualEditorApi(downloader)
+  await MediaWiki.hasActionParseApi(downloader)
 
   RedisStore.setOptions(argv.redis || config.defaults.redisPath)
   await RedisStore.connect()

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -37,7 +37,7 @@ export const parameterDescriptions = {
   addNamespaces: 'Force additional namespace (comma separated numbers)',
   osTmpDir: 'Override default operating system temporary directory path environment variable',
   optimisationCacheUrl: 'Object Storage URL (including credentials and bucket name) to cache optimised media files',
-  forceRender: 'Force the usage of a specific API end-point/render, automatically chosen otherwise. Accepted values: [ VisualEditor, WikimediaDesktop. WikimediaMobile, RestApi ]',
+  forceRender: 'Force the usage of a specific API end-point/render, automatically chosen otherwise. Accepted values: [ VisualEditor, WikimediaDesktop. WikimediaMobile, RestApi, ActionParse ]',
   insecure: 'Skip HTTPS server authenticity verification step',
 }
 

--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -501,9 +501,13 @@ export abstract class Renderer {
     htmlTemplateDoc.getElementById('mw-content-text').innerHTML = parsoidDoc.getElementsByTagName('body')[0].innerHTML
 
     /* Title */
-    htmlTemplateDoc.getElementsByTagName('title')[0].innerHTML = htmlTemplateDoc.getElementById('title_0')
-      ? htmlTemplateDoc.getElementById('title_0').textContent
-      : articleId.replace(/_/g, ' ')
+    const articleTitle = htmlTemplateDoc.getElementById('title_0') ? htmlTemplateDoc.getElementById('title_0').textContent : articleId.replace(/_/g, ' ')
+    htmlTemplateDoc.getElementsByTagName('title')[0].innerHTML = articleTitle
+    // Set inline page title when missing
+    const inlineTitle = htmlTemplateDoc.getElementById('openzim-page-title')
+    if (inlineTitle && !inlineTitle.innerHTML) {
+      inlineTitle.innerHTML = articleTitle
+    }
     DOMUtils.deleteNode(htmlTemplateDoc.getElementById('titleHeading'))
 
     /* Subpage */

--- a/src/renderers/abstractDesktop.render.ts
+++ b/src/renderers/abstractDesktop.render.ts
@@ -65,21 +65,22 @@ export abstract class DesktopRenderer extends Renderer {
       )
     }, '')
 
+    const articleConfigVarsList = jsConfigVars === '' ? '' : genHeaderScript(config, 'jsConfigVars', articleId, config.output.dirs.mediawiki)
+    const articleJsList =
+      jsDependenciesList.length === 0 ? '' : jsDependenciesList.map((oneJsDep: string) => genHeaderScript(config, oneJsDep, articleId, config.output.dirs.mediawiki)).join('\n')
+    const articleCssList =
+      styleDependenciesList.length === 0
+        ? ''
+        : styleDependenciesList.map((oneCssDep: string) => genHeaderCSSLink(config, oneCssDep, articleId, config.output.dirs.mediawiki)).join('\n')
+
     const htmlTemplateString = htmlWikimediaDesktopTemplateCode()
       .replace('__CSS_LINKS__', cssLinks)
       .replace('__JS_SCRIPTS__', jsScripts)
       .replace('__ARTICLE_CANONICAL_LINK__', genCanonicalLink(config, MediaWiki.webUrl.href, articleId))
-      .replace('__ARTICLE_CONFIGVARS_LIST__', jsConfigVars !== '' ? genHeaderScript(config, 'jsConfigVars', articleId, config.output.dirs.mediawiki) : '')
-      .replace(
-        '__ARTICLE_JS_LIST__',
-        jsDependenciesList.length !== 0 ? jsDependenciesList.map((oneJsDep) => genHeaderScript(config, oneJsDep, articleId, config.output.dirs.mediawiki)).join('\n') : '',
-      )
-      .replace(
-        '__ARTICLE_CSS_LIST__',
-        styleDependenciesList.length !== 0 ? styleDependenciesList.map((oneCssDep) => genHeaderCSSLink(config, oneCssDep, articleId, config.output.dirs.mediawiki)).join('\n') : '',
-      )
+      .replace('__ARTICLE_CONFIGVARS_LIST__', articleConfigVarsList)
+      .replace('__ARTICLE_JS_LIST__', articleJsList)
+      .replace('__ARTICLE_CSS_LIST__', articleCssList)
 
-    const htmlTemplateDoc = domino.createDocument(htmlTemplateString)
-    return htmlTemplateDoc
+    return domino.createDocument(htmlTemplateString)
   }
 }

--- a/src/renderers/abstractDesktop.render.ts
+++ b/src/renderers/abstractDesktop.render.ts
@@ -19,9 +19,8 @@ export abstract class DesktopRenderer extends Renderer {
     const moduleDependencies = this.filterWikimediaDesktopModules(await downloader.getModuleDependencies(articleDetail.title))
 
     const data = await downloader.getJSON<any>(articleUrl)
-    /* istanbul ignore if */
     if (data.error) {
-      throw data.error
+      throw new Error(data.error)
     }
 
     return { data, moduleDependencies }

--- a/src/renderers/abstractMobile.render.ts
+++ b/src/renderers/abstractMobile.render.ts
@@ -41,23 +41,21 @@ export abstract class MobileRenderer extends Renderer {
   public templateMobileArticle(moduleDependencies: any, articleId: string): Document {
     const { jsDependenciesList, styleDependenciesList } = moduleDependencies
 
+    const articleJsList =
+      jsDependenciesList.length === 0 ? '' : jsDependenciesList.map((oneJsDep: string) => genHeaderScript(config, oneJsDep, articleId, config.output.dirs.mediawiki)).join('\n')
+    const articleCssList =
+      styleDependenciesList.length === 0
+        ? ''
+        : styleDependenciesList.map((oneCssDep: string) => genHeaderCSSLink(config, oneCssDep, articleId, config.output.dirs.mediawiki)).join('\n')
+
     const htmlTemplateString = htmlWikimediaMobileTemplateCode()
       .replace('__ARTICLE_CANONICAL_LINK__', genCanonicalLink(config, MediaWiki.webUrl.href, articleId))
       .replace('__ARTICLE_CONFIGVARS_LIST__', '')
       .replace('__JS_SCRIPTS__', this.genWikimediaMobileOverrideScript(config.output.wikimediaMobileJsResources[0]))
       .replace('__CSS_LINKS__', this.genWikimediaMobileOverrideCSSLink(config.output.wikimediaMobileCssResources[0]))
-      .replace(
-        '__ARTICLE_JS_LIST__',
-        jsDependenciesList.length !== 0 ? jsDependenciesList.map((oneJsDep: string) => genHeaderScript(config, oneJsDep, articleId, config.output.dirs.mediawiki)).join('\n') : '',
-      )
-      .replace(
-        '__ARTICLE_CSS_LIST__',
-        styleDependenciesList.length !== 0
-          ? styleDependenciesList.map((oneCssDep: string) => genHeaderCSSLink(config, oneCssDep, articleId, config.output.dirs.mediawiki)).join('\n')
-          : '',
-      )
+      .replace('__ARTICLE_JS_LIST__', articleJsList)
+      .replace('__ARTICLE_CSS_LIST__', articleCssList)
 
-    const htmlTemplateDoc = domino.createDocument(htmlTemplateString)
-    return htmlTemplateDoc
+    return domino.createDocument(htmlTemplateString)
   }
 }

--- a/src/renderers/action-parse.renderer.ts
+++ b/src/renderers/action-parse.renderer.ts
@@ -1,0 +1,107 @@
+import domino from 'domino'
+import { DownloadOpts, DownloadRes, Renderer } from './abstract.renderer.js'
+import { RenderOpts, RenderOutput } from './abstract.renderer.js'
+import { config } from '../config.js'
+import { genCanonicalLink, genHeaderScript, genHeaderCSSLink, getStaticFiles } from '../util/misc.js'
+import MediaWiki from '../MediaWiki.js'
+import { htmlVectorLegacyTemplateCode, htmlVector2022TemplateCode } from '../Templates.js'
+import Downloader from '../Downloader.js'
+
+// Represent 'https://{wikimedia-wiki}/w/api.php?action=parse&format=json&prop=modules|jsconfigvars|text&parsoid=1&page={article_title}&skin=vector-2022'
+export class ActionParseRenderer extends Renderer {
+  public staticFilesList: string[] = []
+  constructor() {
+    super()
+    if (this.staticFilesList.length === 0) {
+      this.staticFilesList = getStaticFiles(config.output.jsResourcesCommon, config.output.cssResourcesCommon)
+    }
+  }
+
+  public templateDesktopArticle(moduleDependencies: any, articleId: string): Document {
+    const { jsConfigVars, jsDependenciesList, styleDependenciesList } = moduleDependencies as {
+      jsConfigVars
+      jsDependenciesList: string[]
+      styleDependenciesList: string[]
+    }
+
+    const htmlTemplateCode = MediaWiki.skin === 'vector' ? htmlVectorLegacyTemplateCode : MediaWiki.skin === 'vector-2022' ? htmlVector2022TemplateCode : null
+
+    if (!htmlTemplateCode) {
+      throw new Error(`Skin ${MediaWiki.skin} is not supported by ActionParse renderer`)
+    }
+    const htmlTemplateString = htmlTemplateCode()
+      .replace('__CSS_LINKS__', '') // Unused with ActionParse
+      .replace('__JS_SCRIPTS__', '') // Unused with ActionParse
+      .replace('__ARTICLE_CANONICAL_LINK__', genCanonicalLink(config, MediaWiki.webUrl.href, articleId))
+      .replace('__ARTICLE_CONFIGVARS_LIST__', jsConfigVars !== '' ? genHeaderScript(config, 'jsConfigVars', articleId, config.output.dirs.mediawiki) : '')
+      .replace(
+        '__ARTICLE_JS_LIST__',
+        jsDependenciesList.length !== 0 ? jsDependenciesList.map((oneJsDep) => genHeaderScript(config, oneJsDep, articleId, config.output.dirs.mediawiki)).join('\n') : '',
+      )
+      .replace(
+        '__ARTICLE_CSS_LIST__',
+        styleDependenciesList.length !== 0 ? styleDependenciesList.map((oneCssDep) => genHeaderCSSLink(config, oneCssDep, articleId, config.output.dirs.mediawiki)).join('\n') : '',
+      )
+
+    const htmlTemplateDoc = domino.createDocument(htmlTemplateString)
+    return htmlTemplateDoc
+  }
+
+  public async download(downloadOpts: DownloadOpts): Promise<DownloadRes> {
+    const { downloader, articleUrl } = downloadOpts
+
+    const data = await downloader.getJSON<any>(articleUrl)
+    if (data.error) {
+      throw new Error(data.error)
+    }
+
+    const moduleDependencies = {
+      jsConfigVars: Downloader.extractJsConfigVars(data.parse.headhtml['*']),
+      jsDependenciesList: config.output.mw.js_simplified.concat(data.parse.modules),
+      styleDependenciesList: config.output.mw.css_simplified.concat(data.parse.modulestyles),
+    }
+
+    return { data: data.parse.text['*'], moduleDependencies }
+  }
+
+  public async render(renderOpts: RenderOpts): Promise<any> {
+    const result: RenderOutput = []
+    const { data, articleId, moduleDependencies, dump } = renderOpts
+
+    if (!data) {
+      throw new Error('Cannot render missing data into an article')
+    }
+
+    const articleDetail = await renderOpts.articleDetailXId.get(articleId)
+
+    const htmlDocument = domino.createDocument(data)
+
+    // Remove edit links + brackets
+    const editLinks = htmlDocument.querySelectorAll('.mw-editsection')
+    editLinks.forEach((elem: DominoElement) => {
+      elem.remove()
+    })
+
+    const { finalHTML, mediaDependencies, videoDependencies, imageDependencies, subtitles } = await super.processHtml(
+      htmlDocument.documentElement.outerHTML,
+      dump,
+      articleId,
+      articleDetail,
+      moduleDependencies,
+      this.templateDesktopArticle.bind(this),
+    )
+
+    result.push({
+      articleId,
+      displayTitle: articleId.replace(/_/g, ' '),
+      html: finalHTML,
+      mediaDependencies,
+      videoDependencies,
+      imageDependencies,
+      moduleDependencies,
+      staticFiles: this.staticFilesList,
+      subtitles,
+    })
+    return result
+  }
+}

--- a/src/renderers/action-parse.renderer.ts
+++ b/src/renderers/action-parse.renderer.ts
@@ -29,22 +29,22 @@ export class ActionParseRenderer extends Renderer {
     if (!htmlTemplateCode) {
       throw new Error(`Skin ${MediaWiki.skin} is not supported by ActionParse renderer`)
     }
-    const htmlTemplateString = htmlTemplateCode()
-      .replace('__CSS_LINKS__', '') // Unused with ActionParse
-      .replace('__JS_SCRIPTS__', '') // Unused with ActionParse
-      .replace('__ARTICLE_CANONICAL_LINK__', genCanonicalLink(config, MediaWiki.webUrl.href, articleId))
-      .replace('__ARTICLE_CONFIGVARS_LIST__', jsConfigVars !== '' ? genHeaderScript(config, 'jsConfigVars', articleId, config.output.dirs.mediawiki) : '')
-      .replace(
-        '__ARTICLE_JS_LIST__',
-        jsDependenciesList.length !== 0 ? jsDependenciesList.map((oneJsDep) => genHeaderScript(config, oneJsDep, articleId, config.output.dirs.mediawiki)).join('\n') : '',
-      )
-      .replace(
-        '__ARTICLE_CSS_LIST__',
-        styleDependenciesList.length !== 0 ? styleDependenciesList.map((oneCssDep) => genHeaderCSSLink(config, oneCssDep, articleId, config.output.dirs.mediawiki)).join('\n') : '',
-      )
 
-    const htmlTemplateDoc = domino.createDocument(htmlTemplateString)
-    return htmlTemplateDoc
+    const articleConfigVarsList = jsConfigVars === '' ? '' : genHeaderScript(config, 'jsConfigVars', articleId, config.output.dirs.mediawiki)
+    const articleJsList =
+      jsDependenciesList.length === 0 ? '' : jsDependenciesList.map((oneJsDep: string) => genHeaderScript(config, oneJsDep, articleId, config.output.dirs.mediawiki)).join('\n')
+    const articleCssList =
+      styleDependenciesList.length === 0
+        ? ''
+        : styleDependenciesList.map((oneCssDep: string) => genHeaderCSSLink(config, oneCssDep, articleId, config.output.dirs.mediawiki)).join('\n')
+
+    const htmlTemplateString = htmlTemplateCode()
+      .replace('__ARTICLE_CANONICAL_LINK__', genCanonicalLink(config, MediaWiki.webUrl.href, articleId))
+      .replace('__ARTICLE_CONFIGVARS_LIST__', articleConfigVarsList)
+      .replace('__ARTICLE_JS_LIST__', articleJsList)
+      .replace('__ARTICLE_CSS_LIST__', articleCssList)
+
+    return domino.createDocument(htmlTemplateString)
   }
 
   public async download(downloadOpts: DownloadOpts): Promise<DownloadRes> {

--- a/src/renderers/renderer.builder.ts
+++ b/src/renderers/renderer.builder.ts
@@ -6,16 +6,18 @@ import { WikimediaMobileRenderer } from './wikimedia-mobile.renderer.js'
 import { RestApiRenderer } from './rest-api.renderer.js'
 import * as logger from './../Logger.js'
 import Downloader from 'src/Downloader.js'
+import { ActionParseRenderer } from './action-parse.renderer.js'
 
 export class RendererBuilder {
   public async createRenderer(downloader: Downloader, options: RendererBuilderOptions): Promise<Renderer> {
     const { renderType, renderName } = options
 
-    const [hasVisualEditorApi, hasWikimediaDesktopApi, hasWikimediaMobileApi, hasRestApi] = await Promise.all([
+    const [hasVisualEditorApi, hasWikimediaDesktopApi, hasWikimediaMobileApi, hasRestApi, hasActionParseApi] = await Promise.all([
       MediaWiki.hasVisualEditorApi(downloader),
       MediaWiki.hasWikimediaDesktopApi(downloader),
       MediaWiki.hasWikimediaMobileApi(downloader),
       MediaWiki.hasRestApi(downloader),
+      MediaWiki.hasActionParseApi(downloader),
     ])
 
     switch (renderType) {
@@ -27,6 +29,8 @@ export class RendererBuilder {
           return new VisualEditorRenderer()
         } else if (hasRestApi) {
           return new RestApiRenderer()
+        } else if (hasActionParseApi) {
+          return new ActionParseRenderer()
         } else {
           logger.error('No available desktop renderer.')
           process.exit(1)
@@ -49,6 +53,8 @@ export class RendererBuilder {
           return new RestApiRenderer()
         } else if (hasWikimediaMobileApi) {
           return new WikimediaMobileRenderer()
+        } else if (hasActionParseApi) {
+          return new ActionParseRenderer()
         } else {
           logger.error('No render available at all.')
           process.exit(1)
@@ -56,15 +62,28 @@ export class RendererBuilder {
         break // prettier-ignore
       case 'specific':
         // renderName argument is required for 'specific' mode
-        return this.handleSpecificRender(renderName, hasVisualEditorApi, hasWikimediaDesktopApi, hasWikimediaMobileApi, hasRestApi)
+        return this.handleSpecificRender(renderName, hasVisualEditorApi, hasWikimediaDesktopApi, hasWikimediaMobileApi, hasRestApi, hasActionParseApi)
       default:
         throw new Error(`Unknown render: ${renderType}`)
     }
   }
 
-  private handleSpecificRender(renderName: string, hasVisualEditorApi: boolean, hasWikimediaDesktopApi: boolean, hasWikimediaMobileApi: boolean, hasRestApi: boolean) {
+  private handleSpecificRender(
+    renderName: string,
+    hasVisualEditorApi: boolean,
+    hasWikimediaDesktopApi: boolean,
+    hasWikimediaMobileApi: boolean,
+    hasRestApi: boolean,
+    hasActionParseApi: boolean,
+  ) {
     // renderName argument is required for 'specific' mode
     switch (renderName) {
+      case 'ActionParse':
+        if (hasActionParseApi) {
+          return new ActionParseRenderer()
+        }
+        logger.error('Cannot create an instance of ActionParse renderer.')
+        process.exit(1)
       case 'WikimediaDesktop':
         if (hasWikimediaDesktopApi) {
           return new WikimediaDesktopRenderer()

--- a/src/renderers/renderer.builder.ts
+++ b/src/renderers/renderer.builder.ts
@@ -84,6 +84,7 @@ export class RendererBuilder {
         }
         logger.error('Cannot create an instance of ActionParse renderer.')
         process.exit(1)
+        break // prettier-ignore
       case 'WikimediaDesktop':
         if (hasWikimediaDesktopApi) {
           return new WikimediaDesktopRenderer()

--- a/src/renderers/wikimedia-mobile.renderer.ts
+++ b/src/renderers/wikimedia-mobile.renderer.ts
@@ -35,10 +35,6 @@ export class WikimediaMobileRenderer extends MobileRenderer {
     const moduleDependencies = super.filterWikimediaMobileModules(await downloader.getModuleDependencies(articleDetail.title))
 
     const data = await downloader.getJSON<any>(articleUrl)
-    /* istanbul ignore if */
-    if (data.error) {
-      throw data.error
-    }
 
     return { data, moduleDependencies }
   }

--- a/src/util/builders/url/action-parse.director.ts
+++ b/src/util/builders/url/action-parse.director.ts
@@ -1,0 +1,21 @@
+import urlBuilder from './url.builder.js'
+
+/**
+ * Interface to build URLs based on MediaWiki ActionParse
+ */
+export default class ActionParseURLDirector {
+  baseDomain: string
+  skin: string
+
+  constructor(baseDomain: string, skin: string) {
+    this.baseDomain = baseDomain
+    this.skin = skin
+  }
+
+  buildArticleURL(articleId: string) {
+    return urlBuilder
+      .setDomain(this.baseDomain)
+      .setQueryParams({ action: 'parse', format: 'json', prop: 'modules|jsconfigvars|headhtml|text', parsoid: '1', page: articleId, useskin: this.skin })
+      .build()
+  }
+}

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -19,7 +19,7 @@ export const RULE_TO_REDIRECT = /window\.top !== window\.self/
 export const WEBP_HANDLER_URL = 'https://gist.githubusercontent.com/rgaudin/60bb9cc6f187add506584258028b8ee1/raw/9d575b8e25d67eed2a9c9a91d3e053a0062d2fc7/web-handler.js'
 export const MAX_FILE_DOWNLOAD_RETRIES = 5
 export const BLACKLISTED_NS = ['Story'] // 'Story' Wikipedia namespace is content, but not indgestable by Parsoid https://github.com/openzim/mwoffliner/issues/1853
-export const RENDERERS_LIST = ['WikimediaDesktop', 'VisualEditor', 'WikimediaMobile', 'RestApi']
+export const RENDERERS_LIST = ['WikimediaDesktop', 'VisualEditor', 'WikimediaMobile', 'RestApi', 'ActionParse']
 export const WIKIMEDIA_REST_API_PATH = '/api/rest_v1/'
 
 /*

--- a/src/util/dump.ts
+++ b/src/util/dump.ts
@@ -125,7 +125,7 @@ export async function downloadAndSaveModule(zimCreator: Creator, downloader: Dow
   }
 
   if (!module.includes('javascript/mobile') && !module.includes('css/mobile')) {
-    moduleApiUrl = encodeURI(`${MediaWiki.modulePath}debug=true&lang=en&modules=${module}&only=${apiParameterOnly}&skin=vector&version=&*`)
+    moduleApiUrl = encodeURI(`${MediaWiki.modulePath}debug=true&lang=en&modules=${module}&only=${apiParameterOnly}&skin=${MediaWiki.skin}&version=&*`)
   } else {
     moduleApiUrl = encodeURI(`https:${module}`)
   }

--- a/src/util/dump.ts
+++ b/src/util/dump.ts
@@ -149,7 +149,7 @@ export async function downloadAndSaveModule(zimCreator: Creator, downloader: Dow
   // Zimcheck complains about empty files, and it is too late to decide to not create this file
   // since it has been referenced in all articles HTML, hence creating broken links if we do not
   // include this file in the ZIM, so let's create a minimal file content
-  text = text || '/* Empty file */'
+  text = text || `/* ${module} is an empty file */`
 
   try {
     let articleId

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -57,7 +57,7 @@ export async function downloadFiles(fileStore: RKVS<FileDetail>, retryStore: RKV
           }
         }
       }
-      if ((dump.status.files.success + dump.status.files.fail) % 10 === 0) {
+      if ((dump.status.files.success + dump.status.files.fail) % (10 * downloader.speed) === 0) {
         const percentProgress = (((dump.status.files.success + dump.status.files.fail) / filesTotal) * 100).toFixed(1)
         if (percentProgress !== prevPercentProgress) {
           prevPercentProgress = percentProgress

--- a/test/e2e/en.e2e.test.ts
+++ b/test/e2e/en.e2e.test.ts
@@ -35,7 +35,7 @@ await testAllRenders('en-wikipedia', parameters, async (outFiles) => {
     })
 
     test(`test article header for ${outFiles[0]?.renderer} renderer`, async () => {
-      expect(articleDoc.querySelector('h1.article-header, h1.pcs-edit-section-title')).toBeTruthy()
+      expect(articleDoc.querySelector('h1.firstHeading > span#openzim-page-title, h1.article-header, h1.pcs-edit-section-title')).toBeTruthy()
     })
     test(`test article image integrity for ${outFiles[0]?.renderer} renderer`, async () => {
       const allFiles = await zimdump(`list ${outFiles[0].outFile}`)

--- a/test/e2e/openstreetmap.e2e.test.ts
+++ b/test/e2e/openstreetmap.e2e.test.ts
@@ -38,7 +38,7 @@ await testRenders(
       })
 
       test(`test article header for ${outFiles[0]?.renderer} renderer`, async () => {
-        expect(articleDoc.querySelector('h1.article-header, h1.pcs-edit-section-title')).toBeTruthy()
+        expect(articleDoc.querySelector('h1.firstHeading > span#openzim-page-title, h1.article-header, h1.pcs-edit-section-title')).toBeTruthy()
       })
       test(`test article image integrity for ${outFiles[0]?.renderer} renderer`, async () => {
         const allFiles = await zimdump(`list ${outFiles[0].outFile}`)

--- a/test/unit/downloader.test.ts
+++ b/test/unit/downloader.test.ts
@@ -17,6 +17,7 @@ import { WikimediaDesktopRenderer } from '../../src/renderers/wikimedia-desktop.
 import { WikimediaMobileRenderer } from '../../src/renderers/wikimedia-mobile.renderer.js'
 import { VisualEditorRenderer } from '../../src/renderers/visual-editor.renderer.js'
 import { RestApiRenderer } from '../../src/renderers/rest-api.renderer.js'
+import { ActionParseRenderer } from '../../src/renderers/action-parse.renderer.js'
 import { RENDERERS_LIST } from '../../src/util/const.js'
 
 jest.setTimeout(200000)
@@ -226,6 +227,9 @@ describe('Downloader class', () => {
           break
         case 'RestApi':
           rendererInstance = new RestApiRenderer()
+          break
+        case 'ActionParse':
+          rendererInstance = new ActionParseRenderer()
           break
         default:
           throw new Error(`Unknown renderer: ${renderer}`)

--- a/test/unit/saveArticles.test.ts
+++ b/test/unit/saveArticles.test.ts
@@ -129,7 +129,7 @@ describe('saveArticles', () => {
       articleDetailXId.setMany(articlesDetail)
       const result = await downloader.getArticle(articleId, articleDetailXId, rendererInstance, articleUrl, dump, articleDetail, dump.isMainPage(articleId))
       const articleDoc = domino.createDocument(result[0].html)
-      expect(articleDoc.querySelector('h1.firstHeading > span#openzim-page-title, h1.article-header, h1.pcs-edit-section-title')).toBeFalsy()
+      expect(articleDoc.querySelector('h1.article-header')).toBeFalsy()
     })
 
     test(`--customFlavour using ${renderer} renderer`, async () => {

--- a/test/unit/treatments/article.treatment.test.ts
+++ b/test/unit/treatments/article.treatment.test.ts
@@ -10,6 +10,7 @@ import { WikimediaDesktopRenderer } from '../../../src/renderers/wikimedia-deskt
 import { WikimediaMobileRenderer } from '../../../src/renderers/wikimedia-mobile.renderer.js'
 import { VisualEditorRenderer } from '../../../src/renderers/visual-editor.renderer.js'
 import { RestApiRenderer } from '../../../src/renderers/rest-api.renderer.js'
+import { ActionParseRenderer } from '../../../src/renderers/action-parse.renderer.js'
 import { RENDERERS_LIST } from '../../../src/util/const.js'
 
 jest.setTimeout(10000)
@@ -32,6 +33,9 @@ describe('ArticleTreatment', () => {
         break
       case 'RestApi':
         rendererInstance = new RestApiRenderer()
+        break
+      case 'ActionParse':
+        rendererInstance = new ActionParseRenderer()
         break
       default:
         throw new Error(`Unknown renderer: ${renderer}`)

--- a/test/unit/util/metaData.test.ts
+++ b/test/unit/util/metaData.test.ts
@@ -13,6 +13,5 @@ describe('Test metadata utilities', () => {
     test('multiletter graphemes', async () => {
       expect('विकी मेड मेडिकल इनसाइक्लोपीडिया हिंदी में'.split(byGrapheme).length).toBe(24)
     })
-
   })
 })


### PR DESCRIPTION
⚠️ ~~to be merged only once https://github.com/openzim/mwoffliner/pull/2205 is merged, hence the unusual base branch~~ ⚠️ 
⚠️ to be merged only once https://github.com/openzim/mwoffliner/pull/2228 is merged, hence the unusual base branch ⚠️ 

Fix #2127
Fix #2220 

Superseeds #1899 (which itself superseeds #1846)

Changes:
- introduce a new `ActionParse` renderer, based on `action=parse` results
  - this API can return both modules + parsoid HTML in one call
  - jsConfigVars are still extracted from HTML head for now, looks good on small wikivoyage test
- add support for two skins in this renderer: `vector` (legacy) and `vector-2022`
  - custom HTML template needs to be used so that CSS rules can apply, one per skin
    - also contains some minor CSS tweaks
    - also contains additional placeholder for page title (not returned in parsoid HTML of action=parse API) : see `#openzim-page-title` span
  - contrary to what we said when preparing this PR, CSS specific to the skin is retrieved from online because it can be tweaked at site level + we need anyway to pass skin for all style modules because the skin can also tweak the "regular" style modules
    - module retrieval now always pass a skin, by default `vector` for backward compatibility (this is what we used so far) and otherwise the one used in ActionParse
- automatically detect the skin used by Mediawiki while checking action=parse API availability
- do not fail when deleting a missing DOM node (required due to the skin module - or at least way simpler)
- introduce very limited set of JS + CSS base modules (contrary to what is used in other renderers)
  - this is what looks necessary on few tests done so far
  - it was impossible to modify existing list without taking significant risks of breaking too many things

https://github.com/openzim/mwoffliner/issues/2214 is not yet implemented and a blocker for the release, but I kept this out of this PR since ZIM are already very good without it.

What is left for later because not blocking:
- https://github.com/openzim/mwoffliner/issues/2208
- https://github.com/openzim/mwoffliner/issues/2209
- https://github.com/openzim/mwoffliner/issues/2210
- https://github.com/openzim/mwoffliner/issues/2211
- https://github.com/openzim/mwoffliner/issues/2212
- https://github.com/openzim/mwoffliner/issues/2213
- https://github.com/openzim/mwoffliner/issues/2215