### PR TITLE
Refactor modules download

### DIFF
--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -11,6 +11,7 @@ import { Dump } from '../Dump.js'
 import { rewriteUrlsOfDoc } from '../util/rewriteUrls.js'
 import { footerTemplate } from '../Templates.js'
 import { getFullUrl, getMediaBase, getRelativeFilePath, interpolateTranslationString, encodeArticleIdForZimHtmlUrl, getStaticFiles } from '../util/misc.js'
+import Downloader from 'src/Downloader.js'
 
 type renderType = 'auto' | 'desktop' | 'mobile' | 'specific'
 type renderName = 'VisualEditor' | 'WikimediaDesktop' | 'WikimediaMobile' | 'RestApi'
@@ -31,9 +32,20 @@ interface RendererBuilderOptionsSpecific extends RendererBuilderOptionsBase {
 
 export type RendererBuilderOptions = RendererBuilderOptionsCommon | RendererBuilderOptionsSpecific
 
+export interface DownloadOpts {
+  downloader: Downloader
+  articleUrl: string
+  articleDetail: ArticleDetail
+}
+
+export interface DownloadRes {
+  data?: any
+  moduleDependencies: any
+}
+
 export interface RenderOpts {
   data?: any
-  _moduleDependencies: any
+  moduleDependencies: any
   articleId?: string
   articleDetailXId?: RKVS<ArticleDetail>
   articleDetail?: ArticleDetail
@@ -763,5 +775,6 @@ export abstract class Renderer {
     return doc.documentElement.outerHTML
   }
 
+  abstract download(downloadOpts: DownloadOpts): Promise<DownloadRes>
   abstract render(renderOpts: RenderOpts): Promise<any>
 }

--- a/src/renderers/abstractDesktop.render.ts
+++ b/src/renderers/abstractDesktop.render.ts
@@ -1,5 +1,5 @@
 import * as domino from 'domino'
-import { Renderer } from './abstract.renderer.js'
+import { DownloadOpts, DownloadRes, Renderer } from './abstract.renderer.js'
 import { getStaticFiles } from '../util/misc.js'
 import { config } from '../config.js'
 import MediaWiki from '../MediaWiki.js'
@@ -12,6 +12,20 @@ export abstract class DesktopRenderer extends Renderer {
   constructor() {
     super()
     this.staticFilesListDesktop = this.staticFilesListCommon.concat(getStaticFiles(config.output.jsResources, config.output.cssResources))
+  }
+
+  public async download(downloadOpts: DownloadOpts): Promise<DownloadRes> {
+    const { downloader, articleUrl, articleDetail } = downloadOpts
+
+    const moduleDependencies = this.filterWikimediaDesktopModules(await downloader.getModuleDependencies(articleDetail.title))
+
+    const data = await downloader.getJSON<any>(articleUrl)
+    /* istanbul ignore if */
+    if (data.error) {
+      throw data.error
+    }
+
+    return { data, moduleDependencies }
   }
 
   public filterWikimediaDesktopModules(_moduleDependencies) {

--- a/src/renderers/rest-api.renderer.ts
+++ b/src/renderers/rest-api.renderer.ts
@@ -34,15 +34,14 @@ export class RestApiRenderer extends DesktopRenderer {
 
   public async render(renderOpts: RenderOpts): Promise<any> {
     const result: RenderOutput = []
-    const { data, articleId, articleDetailXId, _moduleDependencies, isMainPage, dump } = renderOpts
+    const { data, articleId, articleDetailXId, moduleDependencies, isMainPage, dump } = renderOpts
 
+    /* istanbul ignore if */
     if (!data) {
       throw new Error(`Cannot render [${data}] into an article`)
     }
 
     const articleDetail = await renderOpts.articleDetailXId.get(articleId)
-
-    const moduleDependenciesFiltered = super.filterWikimediaDesktopModules(_moduleDependencies)
 
     // Paginate when there are more than 200 subCategories
     const numberOfPagesToSplitInto = Math.max(Math.ceil((articleDetail.subCategories || []).length / 200), 1)
@@ -58,7 +57,7 @@ export class RestApiRenderer extends DesktopRenderer {
         dump,
         articleId,
         articleDetail,
-        moduleDependenciesFiltered,
+        moduleDependencies,
         super.templateDesktopArticle.bind(this),
       )
 
@@ -69,7 +68,7 @@ export class RestApiRenderer extends DesktopRenderer {
         mediaDependencies,
         videoDependencies,
         imageDependencies,
-        moduleDependencies: moduleDependenciesFiltered,
+        moduleDependencies,
         staticFiles: this.staticFilesListDesktop,
         subtitles,
       })

--- a/src/renderers/visual-editor.renderer.ts
+++ b/src/renderers/visual-editor.renderer.ts
@@ -15,6 +15,7 @@ export class VisualEditorRenderer extends DesktopRenderer {
   private async retrieveHtml(renderOpts: RenderOpts): Promise<any> {
     const { data, articleId, articleDetail, isMainPage } = renderOpts
 
+    /* istanbul ignore if */
     if (!data) {
       throw new Error(`Cannot render [${data}] into an article`)
     }
@@ -50,16 +51,15 @@ export class VisualEditorRenderer extends DesktopRenderer {
   public async render(renderOpts: RenderOpts): Promise<any> {
     try {
       const result: RenderOutput = []
-      const { articleId, articleDetail, _moduleDependencies, dump } = renderOpts
+      const { articleId, articleDetail, moduleDependencies, dump } = renderOpts
       const { html, displayTitle } = await this.retrieveHtml(renderOpts)
       if (html) {
-        const moduleDependenciesFiltered = super.filterWikimediaDesktopModules(_moduleDependencies)
         const { finalHTML, mediaDependencies, videoDependencies, imageDependencies, subtitles } = await super.processHtml(
           html,
           dump,
           articleId,
           articleDetail,
-          moduleDependenciesFiltered,
+          moduleDependencies,
           super.templateDesktopArticle.bind(this),
         )
         result.push({
@@ -69,7 +69,7 @@ export class VisualEditorRenderer extends DesktopRenderer {
           mediaDependencies,
           videoDependencies,
           imageDependencies,
-          moduleDependencies: moduleDependenciesFiltered,
+          moduleDependencies,
           staticFiles: this.staticFilesListDesktop,
           subtitles,
         })

--- a/test/unit/downloader.test.ts
+++ b/test/unit/downloader.test.ts
@@ -163,10 +163,7 @@ describe('Downloader class', () => {
         timestamp: '2023-08-20T14:54:01Z',
         coordinates: '51.50722222;-0.1275',
       }
-      const _moduleDependencies = await downloader.getModuleDependencies(articleDetail.title)
       const LondonArticle = await downloader.getArticle(
-        downloader.webp,
-        _moduleDependencies,
         articleId,
         RedisStore.articleDetailXId,
         wikimediaMobileRenderer,
@@ -180,7 +177,6 @@ describe('Downloader class', () => {
 
     test('Categories with many subCategories are paginated for WikimediaDesktop render', async () => {
       const articleId = 'Category:Container_categories'
-      const _moduleDependencies = await downloader.getModuleDependencies(articleId)
       const wikimediaDesktopRenderer = new WikimediaDesktopRenderer()
       const articleDetail = {
         title: articleId,
@@ -191,8 +187,6 @@ describe('Downloader class', () => {
       // Enforce desktop url here as this test desktop API-specific
       const articleUrl = `https://en.wikipedia.org/api/rest_v1/page/html/${articleId}`
       const PaginatedArticle = await downloader.getArticle(
-        downloader.webp,
-        _moduleDependencies,
         articleId,
         RedisStore.articleDetailXId,
         wikimediaDesktopRenderer,
@@ -211,19 +205,8 @@ describe('Downloader class', () => {
         title: articleId,
         missing: '',
       }
-      const _moduleDependencies = await downloader.getModuleDependencies(articleDetail.title)
       await expect(
-        downloader.getArticle(
-          downloader.webp,
-          _moduleDependencies,
-          'NeverExistingArticle',
-          RedisStore.articleDetailXId,
-          wikimediaMobileRenderer,
-          articleUrl,
-          dump,
-          articleDetail,
-          dump.isMainPage(articleId),
-        ),
+        downloader.getArticle('NeverExistingArticle', RedisStore.articleDetailXId, wikimediaMobileRenderer, articleUrl, dump, articleDetail, dump.isMainPage(articleId)),
       ).rejects.toThrowError(new Error('Request failed with status code 404'))
     })
   })
@@ -260,19 +243,8 @@ describe('Downloader class', () => {
           title: articleId,
           missing: '',
         }
-        const _moduleDependencies = await downloader.getModuleDependencies(articleDetail.title)
         await expect(
-          downloader.getArticle(
-            downloader.webp,
-            _moduleDependencies,
-            'NeverExistingArticle',
-            RedisStore.articleDetailXId,
-            rendererInstance,
-            articleUrl,
-            dump,
-            articleDetail,
-            dump.isMainPage(articleId),
-          ),
+          downloader.getArticle('NeverExistingArticle', RedisStore.articleDetailXId, rendererInstance, articleUrl, dump, articleDetail, dump.isMainPage(articleId)),
         ).rejects.toThrowError(new Error('Request failed with status code 404'))
       })
     }

--- a/test/unit/renderers/article.renderer.test.ts
+++ b/test/unit/renderers/article.renderer.test.ts
@@ -38,11 +38,11 @@ describe('ArticleRenderer', () => {
     it('should return visualeditor content if the main page flag is true', async () => {
       const { downloader, dump } = await setupScrapeClasses()
       const { data, articleId, articleDetail } = prepareFixtures({ visualeditor: { content: 'Lorem ipsum dolor sit amet' } })
-      const _moduleDependencies = await downloader.getModuleDependencies(articleDetail.title)
+      const moduleDependencies = await downloader.getModuleDependencies(articleDetail.title)
       const result = await visualEditorRenderer.render({
         data,
         webp: downloader.webp,
-        _moduleDependencies,
+        moduleDependencies,
         articleId,
         articleDetail,
         isMainPage: true,
@@ -59,11 +59,11 @@ describe('ArticleRenderer', () => {
       const { downloader, dump } = await setupScrapeClasses()
       const content = '<body class="mw-body-content">consectetur adipiscing elit</body>'
       const { data, articleId, articleDetail } = prepareFixtures({ visualeditor: { content } })
-      const _moduleDependencies = await downloader.getModuleDependencies(articleDetail.title)
+      const moduleDependencies = await downloader.getModuleDependencies(articleDetail.title)
       const result = await visualEditorRenderer.render({
         data,
         webp: downloader.webp,
-        _moduleDependencies,
+        moduleDependencies,
         articleId,
         articleDetail: { title: 'consectetur adipiscing elit', timestamp: '2023-08-24T02:19:04Z' },
         isMainPage: false,
@@ -78,11 +78,11 @@ describe('ArticleRenderer', () => {
       const { downloader, dump } = await setupScrapeClasses()
       const htmlBody = '<body>sed do eiusmod tempor incididunt</body>'
       const { data, articleId, articleDetail } = prepareFixtures({ html: { body: htmlBody }, contentmodel: 'wikitext' })
-      const _moduleDependencies = await downloader.getModuleDependencies(articleDetail.title)
+      const moduleDependencies = await downloader.getModuleDependencies(articleDetail.title)
       const result = await visualEditorRenderer.render({
         data,
         webp: downloader.webp,
-        _moduleDependencies,
+        moduleDependencies,
         articleId,
         articleDetail,
         isMainPage: false,
@@ -99,11 +99,11 @@ describe('ArticleRenderer', () => {
       const { downloader, dump } = await setupScrapeClasses()
       const htmlBody = '<body>ut labore et dolore magna aliqua. Ut enim ad minim veniam</body>'
       const { data, articleId, articleDetail } = prepareFixtures({ html: { body: htmlBody } })
-      const _moduleDependencies = await downloader.getModuleDependencies(articleDetail.title)
+      const moduleDependencies = await downloader.getModuleDependencies(articleDetail.title)
       const result = await visualEditorRenderer.render({
         data,
         webp: downloader.webp,
-        _moduleDependencies,
+        moduleDependencies,
         articleId,
         articleDetail,
         isMainPage: false,
@@ -119,11 +119,11 @@ describe('ArticleRenderer', () => {
     it('should return empty string if there was an error during article retrievement', async () => {
       const { downloader, dump } = await setupScrapeClasses()
       const { data, articleId, articleDetail } = prepareFixtures({ error: 'Unexpected internal error' })
-      const _moduleDependencies = await downloader.getModuleDependencies(articleDetail.title)
+      const moduleDependencies = await downloader.getModuleDependencies(articleDetail.title)
       const result = await visualEditorRenderer.render({
         data,
         webp: downloader.webp,
-        _moduleDependencies,
+        moduleDependencies,
         articleId,
         articleDetail,
         isMainPage: false,

--- a/test/unit/saveArticles.test.ts
+++ b/test/unit/saveArticles.test.ts
@@ -12,6 +12,7 @@ import { VisualEditorRenderer } from '../../src/renderers/visual-editor.renderer
 import { WikimediaMobileRenderer } from '../../src/renderers/wikimedia-mobile.renderer.js'
 import { RestApiRenderer } from '../../src/renderers/rest-api.renderer.js'
 import { RENDERERS_LIST } from '../../src/util/const.js'
+import { RenderOpts } from 'src/renderers/abstract.renderer.js'
 
 jest.setTimeout(40000)
 
@@ -77,11 +78,8 @@ describe('saveArticles', () => {
       const articleId = 'non-existent-article'
       const articleUrl = downloader.getArticleUrl(articleId)
       const articleDetail = { title: 'Non-existent-article', missing: '' }
-      const _moduleDependencies = await downloader.getModuleDependencies(articleDetail.title)
 
-      await expect(
-        downloader.getArticle(downloader.webp, _moduleDependencies, articleId, articleDetailXId, rendererInstance, articleUrl, dump, articleDetail, dump.isMainPage(articleId)),
-      ).rejects.toThrowError('')
+      await expect(downloader.getArticle(articleId, articleDetailXId, rendererInstance, articleUrl, dump, articleDetail, dump.isMainPage(articleId))).rejects.toThrowError('')
 
       const articleDoc = domino.createDocument(addedArticles.shift().getContentProvider().feed().toString())
 
@@ -102,19 +100,8 @@ describe('saveArticles', () => {
       const articlesDetail = mwRetToArticleDetail(_articleDetailsRet)
       const { articleDetailXId } = RedisStore
       const articleDetail = { title: articleId, timestamp: '2023-09-10T17:36:04Z' }
-      const _moduleDependencies = await downloader.getModuleDependencies(articleDetail.title)
       articleDetailXId.setMany(articlesDetail)
-      const result = await downloader.getArticle(
-        downloader.webp,
-        _moduleDependencies,
-        articleId,
-        articleDetailXId,
-        rendererInstance,
-        articleUrl,
-        dump,
-        articleDetail,
-        dump.isMainPage(articleId),
-      )
+      const result = await downloader.getArticle(articleId, articleDetailXId, rendererInstance, articleUrl, dump, articleDetail, dump.isMainPage(articleId))
 
       const articleDoc = domino.createDocument(result[0].html)
 
@@ -133,19 +120,8 @@ describe('saveArticles', () => {
       const articlesDetail = mwRetToArticleDetail(_articleDetailsRet)
       const { articleDetailXId } = RedisStore
       const articleDetail = { title: articleId, timestamp: '2023-08-20T14:54:01Z' }
-      const _moduleDependencies = await downloader.getModuleDependencies(articleDetail.title)
       articleDetailXId.setMany(articlesDetail)
-      const result = await downloader.getArticle(
-        downloader.webp,
-        _moduleDependencies,
-        articleId,
-        articleDetailXId,
-        rendererInstance,
-        articleUrl,
-        dump,
-        articleDetail,
-        dump.isMainPage(articleId),
-      )
+      const result = await downloader.getArticle(articleId, articleDetailXId, rendererInstance, articleUrl, dump, articleDetail, dump.isMainPage(articleId))
       const articleDoc = domino.createDocument(result[0].html)
       expect(articleDoc.querySelector('h1.article-header')).toBeFalsy()
     })
@@ -225,19 +201,8 @@ describe('saveArticles', () => {
       const articlesDetail = mwRetToArticleDetail(_articleDetailsRet)
       const { articleDetailXId } = RedisStore
       const articleDetail = { title: articleId, timestamp: '2023-08-20T14:54:01Z' }
-      const _moduleDependencies = await downloader.getModuleDependencies(articleDetail.title)
       articleDetailXId.setMany(articlesDetail)
-      const result = await downloader.getArticle(
-        downloader.webp,
-        _moduleDependencies,
-        articleId,
-        articleDetailXId,
-        rendererInstance,
-        articleUrl,
-        dump,
-        articleDetail,
-        dump.isMainPage(articleId),
-      )
+      const result = await downloader.getArticle(articleId, articleDetailXId, rendererInstance, articleUrl, dump, articleDetail, dump.isMainPage(articleId))
 
       const articleDoc = domino.createDocument(result[0].html)
 
@@ -324,15 +289,13 @@ describe('saveArticles', () => {
       }
 
       const articleDetail = { title: articleId, missing: '' }
-      const _moduleDependencies = await downloader.getModuleDependencies(articleDetail.title)
+      const moduleDependencies = await downloader.getModuleDependencies(articleDetail.title)
 
       const visualEditorRenderer = new VisualEditorRenderer()
 
-      const renderOpts = {
+      const renderOpts: RenderOpts = {
         data: articleJsonObject,
-        RedisStore,
-        webp: downloader.webp,
-        _moduleDependencies,
+        moduleDependencies,
         articleId,
         articleDetailXId,
         articleDetail,

--- a/test/unit/treatments/article.treatment.test.ts
+++ b/test/unit/treatments/article.treatment.test.ts
@@ -52,7 +52,6 @@ describe('ArticleTreatment', () => {
       downloader.setUrlsDirectors(rendererInstance, rendererInstance)
       const articleUrl = downloader.getArticleUrl(articleId)
 
-      const _moduleDependencies = await downloader.getModuleDependencies(title)
       const articleDetail = {
         title,
         thumbnail: {
@@ -85,9 +84,7 @@ describe('ArticleTreatment', () => {
       expect(addedArticles).toHaveLength(1)
       expect(addedArticles[0].title).toEqual('London')
 
-      await expect(
-        downloader.getArticle(downloader.webp, _moduleDependencies, articleId, articleDetailXId, rendererInstance, articleUrl, dump, articleDetail, dump.isMainPage(articleId)),
-      ).rejects.toThrowError('')
+      await expect(downloader.getArticle(articleId, articleDetailXId, rendererInstance, articleUrl, dump, articleDetail, dump.isMainPage(articleId))).rejects.toThrowError('')
 
       const articleDoc = domino.createDocument(addedArticles.shift().getContentProvider().feed().toString())
 

--- a/test/unit/treatments/media.treatment.test.ts
+++ b/test/unit/treatments/media.treatment.test.ts
@@ -6,6 +6,9 @@ import { startRedis, stopRedis } from '../bootstrap.js'
 
 describe('MediaTreatment', () => {
   class TestableRenderer extends Renderer {
+    public download(): any {
+      return null
+    }
     public render(): any {
       return null
     }


### PR DESCRIPTION
~~⚠️ to be merged only once https://github.com/openzim/mwoffliner/pull/2204 is merged, hence the unusual base branch ⚠️~~

In preparation for the introduction of ActionParse API, this PR refactors the downloading of module dependencies.

Before that PR, downloading of module dependencies was handled above the renderer. In fact, this should be done differently based on the renderer used. It was visible even before the introduction of ActionParse API since we had to filter the list of modules afterwards at render stage, since this is a decision done by the renderer. This will be mandatory with ActionParse API since we will download both article content and article modules in a single HTTP call.

Changes:
- renderers now have a second abstract method: `download` which must download both article data (mostly parsoid HTML, but depending on the API there could be more and format is varying) and list of module dependencies (styles, scripts and jsConfigVars)
- this made it obvious that `webp` argument is in fact not needed in many interfaces
- simplify a bit the code of `Downloader.getModulesDependencies` (only semantics)
- extract logic to compute `jsConfigVars` from head HTML from`Downloader.getModulesDependencies` to static `Downloader.extractJsConfigVars`
  - we will need this logic in ActionParse renderer `download` method, because all other renderers continue to use the "default" `Downloader.getModulesDependencies` method, but not future ActionParse renderer
- new interfaces `DownloadOpts` and `DownloadRes` for type checking
- add an error when renderer passed is unknown (not supposed to happen because cleaned-up at CLI level but this could be a bug)
- remove `continuation` fallbacks, not needed