### PR TITLE
Fix regression on front articles

### DIFF
--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -485,6 +485,7 @@ async function execute(argv: any) {
             // We fake a title, by just removing the underscores
             String(redirectId).replace(/_/g, ' '),
             targetId,
+            { FRONT_ARTICLE: 1 },
           )
 
           dump.status.redirects.written += 1
@@ -597,7 +598,7 @@ async function execute(argv: any) {
 
     function createMainPageRedirect() {
       logger.log(`Create main page redirection from [index] to [${mainPage}]`)
-      zimCreator.addRedirection('index', '', mainPage)
+      zimCreator.addRedirection('index', '', mainPage, { FRONT_ARTICLE: 1 })
     }
 
     return mainPage ? createMainPageRedirect() : createMainPage()

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -241,7 +241,7 @@ async function saveArticle(
 
     await RedisStore.filesToDownloadXPath.setMany(filesToDownload)
 
-    const zimArticle = new StringItem(articleId, 'text/html', articleTitle, {}, finalHTML)
+    const zimArticle = new StringItem(articleId, 'text/html', articleTitle, { FRONT_ARTICLE: 1 }, finalHTML)
     await zimCreatorMutex.runExclusive(() => zimCreator.addItem(zimArticle))
 
     return null


### PR DESCRIPTION
Fix #2199 

Problem was simply a regression introduced in https://github.com/openzim/mwoffliner/pull/2194 where no article was marked as "front-article" anymore ...

I've fixed redirects (both articles and main page) to reproduce previous behavior.