### PR TITLE
Fix npm install and enhance CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   ci-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,16 @@ jobs:
         if: ${{ matrix.node-version == '22.x' }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  build_docker:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure we can build the Docker image
+        run: |
+          docker build -t local-mwoffliner .
+
+      - name: Ensure we can start the Docker image and display help
+        run: |
+          docker run --rm local-mwoffliner mwoffliner --help

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-push:
     name: Deploy Docker Dev Image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     environment: release
 
     steps:

--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,7 @@
 Unreleased:
 
+* FIX: Avoid reducing redirects directly to an Object to avoid memory issue (@benoit74 #2142)
+
 1.14.2:
 * FIX: Ignore pages without a single revision / revid (@benoit74 #2091)
 * CHANGED: Set default log level to `log` to sufficiently verbose logs by default (@benoit74 #2121)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ ENV REDIS=/dev/shm/redis.sock
 RUN printf '#!/bin/bash\n/usr/local/bin/mwoffliner --redis=$REDIS "$@"' > /usr/local/sbin/mwoffliner
 RUN chmod +x /usr/local/sbin/mwoffliner
 
-# Install dependences
+# Install dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     make g++ curl git && \
@@ -29,7 +29,9 @@ RUN apt-get update && \
 WORKDIR /tmp/mwoffliner
 COPY *.json ./
 COPY dev dev
-RUN mkdir src
+RUN mkdir src && \
+    # create fake cli.ts so that install can complete
+    printf '#!/usr/bin/env -S node' > src/cli.ts
 RUN npm i
 COPY src src
 COPY res res

--- a/src/util/categories.ts
+++ b/src/util/categories.ts
@@ -39,11 +39,8 @@ export async function getCategoriesForArticles(articleStore: RKVS<ArticleDetail>
         }
 
         const parentCategories = (detail.categories || []).reduce((acc, info) => {
-          const articleId = info.title
-          return {
-            ...acc,
-            [articleId]: info,
-          }
+          acc[info.title] = info
+          return acc
         }, {})
 
         await nextCategoriesBatch.setMany(parentCategories)

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -64,11 +64,10 @@ export async function getArticlesByIds(articleIds: string[], downloader: Downloa
         for (const [articleId, articleDetail] of Object.entries(mwArticleDetails)) {
           if (articleDetail.redirects && articleDetail.redirects.length) {
             await redirectsXId.setMany(
-              Object.fromEntries(
-                articleDetail.redirects.reduce((acc, redirect) => {
-                  return acc.set(redirect.title, { targetId: articleId, title: redirect.title })
-                }, new Map()),
-              ),
+              articleDetail.redirects.reduce((acc, redirect) => {
+                acc[redirect.title] = { targetId: articleId, title: redirect.title }
+                return acc
+              }, {}),
             )
           }
         }

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -64,13 +64,11 @@ export async function getArticlesByIds(articleIds: string[], downloader: Downloa
         for (const [articleId, articleDetail] of Object.entries(mwArticleDetails)) {
           if (articleDetail.redirects && articleDetail.redirects.length) {
             await redirectsXId.setMany(
-              articleDetail.redirects.reduce((acc, redirect) => {
-                const rId = redirect.title
-                return {
-                  ...acc,
-                  [rId]: { targetId: articleId, title: redirect.title },
-                }
-              }, {}),
+              Object.fromEntries(
+                articleDetail.redirects.reduce((acc, redirect) => {
+                  return acc.set(redirect.title, { targetId: articleId, title: redirect.title })
+                }, new Map()),
+              ),
             )
           }
         }


### PR DESCRIPTION
Currently, `main` branch is broken, CI is failing.

The problem has been introduced in https://github.com/openzim/mwoffliner/pull/2223 and concerns only the Docker image build.

The fact that we do not test Docker image at all is an issue, we should at least try to build and start the image, this is introduced in this PR (and aligned with Python scraper "standard")

The Docker build issue is that build cannot complete in "early" dependencies installation step because it misses the cli.ts script. This PR proposes to create a fake cli.ts so that installation of dependencies can complete properly.

This PR also updates CI images to `ubuntu-24.04` since `ubuntu-22.04` is going to be removed soon.