### PR TITLE
Clearer status around supported Node version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Run `mwoffliner --help` to get all the possible options.
 
 - *NIX Operating System (GNU/Linux, macOS, ...)
 - [Redis](https://redis.io/)
-- [NodeJS](https://nodejs.org/en/) version 16 or greater
+- [NodeJS](https://nodejs.org/en/) version 22 (we support only one single Node.JS version, other versions might work or not)
 - [Libzim](https://github.com/openzim/libzim) (On GNU/Linux & macOS we automatically download it)
 - Various build tools which are probably already installed on your
   machine (packages `libjpeg-dev`, `libglu1`, `autoconf`, `automake`, `gcc` on
@@ -50,8 +50,6 @@ Run `mwoffliner --help` to get all the possible options.
 ... and an online MediaWiki with its API available.
 
 ## Usage
-
-We support only one single Node.JS version (Node.JS 22 currently).
 
 To install MWoffliner globally:
 ```bash

--- a/README.md
+++ b/README.md
@@ -108,33 +108,6 @@ Complementary information about MWoffliner:
 * MediaWiki includes a parser for WikiText into HTML, and this
   parser creates the HTML pages displayed in your browser.
 
-### GNU/Linux - Debian based distributions
-
-Install NodeJS:
-Read https://nodejs.org/en/download/current/
-
-Install Redis:
-```bash
-sudo apt-get install redis-server
-```
-
-## Troubleshooting
-
-Older GNU/Linux distributions and/or versions of Node.js might be
-shipped with a deprecated version of `npm`. Older versions of `npm`
-have incompatbilities with certain versions of Node.js and might
-simply fail to install `mwoffliner` package.
-
-We recommend to use a recent version of `npm`. Recent versions can
-perfectly deal with older Node.js 10. Do install the packaged
-version of `npm` and then use it to install a newer version like:
-
-```bash
-sudo npm install --unsafe-perm -g npm
-```
-
-Don't forget to remove the packaged version of `npm` afterward.
-
 License
 -------
 

--- a/package.json
+++ b/package.json
@@ -55,9 +55,6 @@
   "engines": {
     "node": ">=22.0.0 <23.0.0"
   },
-  "engine-strict": {
-    "node": ">=22.0.0 <23.0.0"
-  },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.779.0",
     "@ladjs/country-language": "^1.0.3",


### PR DESCRIPTION
Fix #2227

- have only one version mentioned in README.md (sic)
- drop non-existent 'engine-strict' property of package.json
- add .npmrc with engine-strict rule to enforce by default the Node.JS version (applies only to developers, and even them can drop this file if they don't see fit ; users will only see a warning)

This seems to be the "best" we can do in a Node.JS context