### PR TITLE
Avoid reducing redirects directly to an Object to avoid memory issue

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,7 @@
 Unreleased:
 
+* FIX: Avoid reducing redirects directly to an Object to avoid memory issue (@benoit74 #2142)
+
 1.14.2:
 * FIX: Ignore pages without a single revision / revid (@benoit74 #2091)
 * CHANGED: Set default log level to `log` to sufficiently verbose logs by default (@benoit74 #2121)

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -64,13 +64,11 @@ export async function getArticlesByIds(articleIds: string[], downloader: Downloa
         for (const [articleId, articleDetail] of Object.entries(mwArticleDetails)) {
           if (articleDetail.redirects && articleDetail.redirects.length) {
             await redirectsXId.setMany(
-              articleDetail.redirects.reduce((acc, redirect) => {
-                const rId = redirect.title
-                return {
-                  ...acc,
-                  [rId]: { targetId: articleId, title: redirect.title },
-                }
-              }, {}),
+              Object.fromEntries(
+                articleDetail.redirects.reduce((acc, redirect) => {
+                  return acc.set(redirect.title, { targetId: articleId, title: redirect.title })
+                }, new Map()),
+              ),
             )
           }
         }


### PR DESCRIPTION
Fix #2142 

Reducing the list of redirects directly to an Object caused abnormal memory consumption. While the exact root cause is unknown, reducing first to a Map and then transforming into a Object removes the memory issue. Since Object keys are redirect titles which might be quite big and there might be many in some occasion, we might have memory fragmentation issues or something else.