### PR TITLE
Also rewrite Mediawiki CSS modules

### DIFF
--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -448,7 +448,7 @@ async function execute(argv: any) {
         return pmap(
           moduleList,
           (oneModule) => {
-            return downloadAndSaveModule(zimCreator, downloader, dump, oneModule, type as any)
+            return downloadAndSaveModule(zimCreator, downloader, oneModule, type as any)
           },
           { concurrency: downloader.speed },
         )

--- a/test/unit/util/dump.test.ts
+++ b/test/unit/util/dump.test.ts
@@ -1,0 +1,35 @@
+import { startRedis, stopRedis } from '../bootstrap.js'
+import Downloader from '../../../src/Downloader.js'
+import MediaWiki from '../../../src/MediaWiki.js'
+import { config } from '../../../src/config.js'
+import { downloadModule } from '../../../src/util/dump.js'
+import RedisStore from '../../../src/RedisStore.js'
+
+describe('Download CSS or JS Module', () => {
+  beforeAll(startRedis)
+  afterAll(stopRedis)
+
+  let downloader: Downloader
+
+  beforeEach(() => {
+    const { filesToDownloadXPath } = RedisStore
+    filesToDownloadXPath.flush()
+    MediaWiki.base = 'https://en.wikipedia.org'
+    downloader = new Downloader({ uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' })
+  })
+
+  test('download skins.vector.styles CSS', async () => {
+    const { text: content, moduleApiUrl } = await downloadModule(downloader, 'skins.vector.styles', 'css')
+
+    // URL expected to be used to retrieve CSS module
+    expect(moduleApiUrl).toBe('https://en.wikipedia.org/w/load.php?debug=true&lang=en&modules=skins.vector.styles&only=styles&skin=vector&version=&*')
+
+    // Check if CSS module still contain this background image
+    expect(content).toContain(`background-image: url(link.ernal-small-ltr-progressive.svg`)
+
+    // One SVG (among others) expected to be used inside the CSS
+    expect(Object.keys(downloader.cssDependenceUrls)).toContain(
+      'https://en.wikipedia.org/w/skins/Vector/resources/skins.vector.styles/images/link-external-small-ltr-progressive.svg?fb64d',
+    )
+  })
+})


### PR DESCRIPTION
Fix #2214 

Before this commit, only CSS fetched from main page was rewritten.

With this commit, we also rewrite CSS modules retrieved from the Mediawiki for any article.

Changes:
- extract method responsible to rewrite CSS
- also call this method when downloading/saving CSS modules 

Nota: I'm not sure what the id at the end of SVG url used in test is used for. This is maybe used for caches refresh and might be regularly rotated ... if so, then we will have to harden this test, not a big deal but no hurry to do it if this ID stays the same "forever". Anyway, skin might change at some point and not use same SVG at any point in time.