### PR TITLE
Check early for availability APIs + add check for module API

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -4,6 +4,7 @@ Unreleased:
 * FIX: Ignore pages without a single revision / revid - continued (@benoit74 #2234)
 * FIX: Set proper mimetype for ZIM illustration(s) metadata (@benoit74 #1974)
 * FIX: Avoid reducing redirects directly to an Object to avoid memory issue (@benoit74 #2142)
+* NEW: Check early for availability of load.php module API (@benoit74 #2246)
 
 1.14.2:
 * FIX: Ignore pages without a single revision / revid (@benoit74 #2091)

--- a/Changelog
+++ b/Changelog
@@ -4,7 +4,7 @@ Unreleased:
 * FIX: Ignore pages without a single revision / revid - continued (@benoit74 #2234)
 * FIX: Set proper mimetype for ZIM illustration(s) metadata (@benoit74 #1974)
 * FIX: Avoid reducing redirects directly to an Object to avoid memory issue (@benoit74 #2142)
-* NEW: Check early for availability of load.php module API (@benoit74 #2246)
+* NEW: Check early for availability APIs + add check for module API (@benoit74 #2246 / #2248)
 
 1.14.2:
 * FIX: Ignore pages without a single revision / revid (@benoit74 #2091)

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -246,7 +246,7 @@ class Downloader {
     }
   }
 
-  public setUrlsDirectors(mainPageRenderer, articlesRenderer): void {
+  public setUrlsDirectors(mainPageRenderer: Renderer, articlesRenderer: Renderer): void {
     if (!this.articleUrlDirector) {
       this.articleUrlDirector = this.getUrlDirector(articlesRenderer)
     }

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -77,6 +77,7 @@ class MediaWiki {
   #hasRestApi: boolean | null
   #hasActionParseApi: boolean | null
   #hasCoordinates: boolean | null
+  #hasModuleApi: boolean | null
 
   set username(value: string) {
     this.#username = value
@@ -170,6 +171,7 @@ class MediaWiki {
     this.#hasRestApi = null
     this.#hasActionParseApi = null
     this.#hasCoordinates = null
+    this.#hasModuleApi = null
   }
 
   private constructor() {
@@ -251,6 +253,16 @@ class MediaWiki {
       return (this.#hasCoordinates = true)
     }
     return this.#hasCoordinates
+  }
+
+  public async hasModuleApi(): Promise<boolean> {
+    if (this.#hasModuleApi === null) {
+      // startup JS module is supposed to be available on all Mediawikis
+      const checkUrl = `${this.modulePath}lang=en&modules=startup&only=scripts`
+      this.#hasModuleApi = await checkApiAvailability(checkUrl)
+      logger.log('Checked for Module API at', checkUrl, '-- result is: ', this.#hasRestApi)
+    }
+    return this.#hasModuleApi
   }
 
   private setWikimediaDesktopApiUrl() {

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -39,6 +39,7 @@ import {
   extractArticleList,
   getTmpDirectory,
   validateMetadata,
+  downloadModule,
 } from './util/index.js'
 import S3 from './S3.js'
 import RedisStore from './RedisStore.js'
@@ -195,6 +196,16 @@ async function execute(argv: any) {
     'Illustration_48x48@1': await getIllustrationMetadata(),
   }
   validateMetadata(metaDataRequiredKeys)
+
+  // Try to download startup module which is supposed to be available on all wikis
+  // in order to ensure as early as possible that load.php URL is properly configured
+  // and available
+  try {
+    await downloadModule('startup', 'js')
+  } catch (err) {
+    logger.error('Impossible to reach module API load.php')
+    throw err
+  }
 
   // Sanitizing main page
   let mainPage = articleList ? '' : mwMetaData.mainPage

--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -13,7 +13,7 @@ import { footerTemplate } from '../Templates.js'
 import { getFullUrl, getMediaBase, getRelativeFilePath, interpolateTranslationString, encodeArticleIdForZimHtmlUrl, getStaticFiles } from '../util/misc.js'
 
 type renderType = 'auto' | 'desktop' | 'mobile' | 'specific'
-type renderName = 'VisualEditor' | 'WikimediaDesktop' | 'WikimediaMobile' | 'RestApi'
+export type renderName = 'VisualEditor' | 'WikimediaDesktop' | 'WikimediaMobile' | 'RestApi' | 'ActionParse'
 
 interface RendererBuilderOptionsBase {
   renderType: renderType

--- a/src/renderers/renderer.builder.ts
+++ b/src/renderers/renderer.builder.ts
@@ -11,13 +11,19 @@ export class RendererBuilder {
   public async createRenderer(options: RendererBuilderOptions): Promise<Renderer> {
     const { renderType, renderName } = options
 
-    const [hasVisualEditorApi, hasWikimediaDesktopApi, hasWikimediaMobileApi, hasRestApi, hasActionParseApi] = await Promise.all([
+    const [hasVisualEditorApi, hasWikimediaDesktopApi, hasWikimediaMobileApi, hasRestApi, hasActionParseApi, hasModuleApi] = await Promise.all([
       MediaWiki.hasVisualEditorApi(),
       MediaWiki.hasWikimediaDesktopApi(),
       MediaWiki.hasWikimediaMobileApi(),
       MediaWiki.hasRestApi(),
       MediaWiki.hasActionParseApi(),
+      MediaWiki.hasModuleApi(),
     ])
+
+    if (!hasModuleApi) {
+      logger.error('Module API not available while mandatory')
+      process.exit(1)
+    }
 
     switch (renderType) {
       case 'desktop':

--- a/src/renderers/rendering.context.ts
+++ b/src/renderers/rendering.context.ts
@@ -1,0 +1,43 @@
+import Downloader from '../Downloader.js'
+import { Renderer, renderName } from './abstract.renderer.js'
+import { RendererBuilder } from './renderer.builder.js'
+import * as logger from '../Logger.js'
+
+class RenderingContext {
+  private static instance: RenderingContext
+
+  public mainPageRenderer: Renderer
+  public articlesRenderer: Renderer
+
+  public static getInstance(): RenderingContext {
+    if (!RenderingContext.instance) {
+      RenderingContext.instance = new RenderingContext()
+    }
+    return RenderingContext.instance
+  }
+
+  public async createRenderers(forceRender: renderName | null, hasWikimediaMobileApi: boolean) {
+    const rendererBuilder = new RendererBuilder()
+
+    if (forceRender) {
+      // All articles and main page will use the same renderer if 'forceRender' is specified
+      const renderer = await rendererBuilder.createRenderer({
+        renderType: 'specific',
+        renderName: forceRender,
+      })
+      this.mainPageRenderer = renderer
+      this.articlesRenderer = renderer
+    } else {
+      this.mainPageRenderer = await rendererBuilder.createRenderer({ renderType: 'desktop' })
+      this.articlesRenderer = await rendererBuilder.createRenderer({
+        renderType: hasWikimediaMobileApi ? 'mobile' : 'auto',
+      })
+    }
+    logger.log(`Using ${this.mainPageRenderer.constructor.name} for main page renderer`)
+    logger.log(`Using ${this.articlesRenderer.constructor.name} for articles renderer`)
+    Downloader.setUrlsDirectors(this.mainPageRenderer, this.articlesRenderer)
+  }
+}
+
+const instance = RenderingContext.getInstance()
+export default instance as RenderingContext

--- a/test/unit/treatments/article.treatment.test.ts
+++ b/test/unit/treatments/article.treatment.test.ts
@@ -6,13 +6,10 @@ import { setupScrapeClasses } from '../../util.js'
 import { startRedis, stopRedis } from '../bootstrap.js'
 import { saveArticles } from '../../../src/util/saveArticles.js'
 import { jest } from '@jest/globals'
-import { WikimediaDesktopRenderer } from '../../../src/renderers/wikimedia-desktop.renderer.js'
-import { WikimediaMobileRenderer } from '../../../src/renderers/wikimedia-mobile.renderer.js'
-import { VisualEditorRenderer } from '../../../src/renderers/visual-editor.renderer.js'
-import { RestApiRenderer } from '../../../src/renderers/rest-api.renderer.js'
-import { ActionParseRenderer } from '../../../src/renderers/action-parse.renderer.js'
 import { RENDERERS_LIST } from '../../../src/util/const.js'
 import Downloader from '../../../src/Downloader.js'
+import RenderingContext from '../../../src/renderers/rendering.context.js'
+import { renderName } from 'src/renderers/abstract.renderer.js'
 
 jest.setTimeout(10000)
 
@@ -21,29 +18,9 @@ describe('ArticleTreatment', () => {
   afterAll(stopRedis)
 
   for (const renderer of RENDERERS_LIST) {
-    let rendererInstance
-    switch (renderer) {
-      case 'VisualEditor':
-        rendererInstance = new VisualEditorRenderer()
-        break
-      case 'WikimediaDesktop':
-        rendererInstance = new WikimediaDesktopRenderer()
-        break
-      case 'WikimediaMobile':
-        rendererInstance = new WikimediaMobileRenderer()
-        break
-      case 'RestApi':
-        rendererInstance = new RestApiRenderer()
-        break
-      case 'ActionParse':
-        rendererInstance = new ActionParseRenderer()
-        break
-      default:
-        throw new Error(`Unknown renderer: ${renderer}`)
-    }
-
     test(`Article html processing for ${renderer} render`, async () => {
       const { dump } = await setupScrapeClasses() // en wikipedia
+      await RenderingContext.createRenderers(renderer as renderName, true)
       const title = 'London'
       const _articlesDetail = await Downloader.getArticleDetailsIds([title])
       const articlesDetail = mwRetToArticleDetail(_articlesDetail)
@@ -54,7 +31,6 @@ describe('ArticleTreatment', () => {
       const addedArticles: StringItem[] = []
 
       const articleId = 'non-existent-article'
-      Downloader.setUrlsDirectors(rendererInstance, rendererInstance)
       const articleUrl = Downloader.getArticleUrl(articleId)
 
       const articleDetail = {
@@ -80,15 +56,15 @@ describe('ArticleTreatment', () => {
           },
         } as any,
         dump,
-        true,
-        renderer,
       )
 
       // Successfully scrapped existent articles
       expect(addedArticles).toHaveLength(1)
       expect(addedArticles[0].title).toEqual('London')
 
-      await expect(Downloader.getArticle(articleId, articleDetailXId, rendererInstance, articleUrl, dump, articleDetail, dump.isMainPage(articleId))).rejects.toThrowError('')
+      await expect(
+        Downloader.getArticle(articleId, articleDetailXId, RenderingContext.articlesRenderer, articleUrl, dump, articleDetail, dump.isMainPage(articleId)),
+      ).rejects.toThrowError('')
 
       const articleDoc = domino.createDocument(addedArticles.shift().getContentProvider().feed().toString())
 

--- a/test/unit/urlRewriting.test.ts
+++ b/test/unit/urlRewriting.test.ts
@@ -9,6 +9,7 @@ import { StringItem } from '@openzim/libzim'
 import { mwRetToArticleDetail } from '../../src/util/index.js'
 import { jest } from '@jest/globals'
 import Downloader from '../../src/Downloader.js'
+import RenderingContext from '../../src/renderers/rendering.context.js'
 
 jest.setTimeout(20000)
 
@@ -142,6 +143,8 @@ describe('Styles', () => {
     await RedisStore.redirectsXId.flush()
     const { dump } = await setupScrapeClasses() // en wikipedia
 
+    await RenderingContext.createRenderers(null, true)
+
     await getArticleIds('', ['London', 'British_Museum', 'Natural_History_Museum,_London', 'Farnborough/Aldershot_built-up_area'])
 
     let LondonArticle: StringItem
@@ -156,7 +159,6 @@ describe('Styles', () => {
         },
       } as any,
       dump,
-      true,
     )
 
     const html = LondonArticle.getContentProvider().feed().toString()

--- a/test/util.ts
+++ b/test/util.ts
@@ -33,10 +33,6 @@ export function makeLink($doc: Document, href: string, rel: string, title: strin
 export async function setupScrapeClasses({ mwUrl = 'https://en.wikipedia.org', format = '' } = {}) {
   MediaWiki.base = mwUrl
 
-  const renderer = {}
-
-  Object.defineProperty(renderer.constructor, 'name', { value: 'WikimediaDesktopRenderer' })
-
   Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: false, optimisationCacheUrl: '' }
 
   await MediaWiki.getMwMetaData()
@@ -45,12 +41,12 @@ export async function setupScrapeClasses({ mwUrl = 'https://en.wikipedia.org', f
   await MediaWiki.hasWikimediaMobileApi()
   await MediaWiki.hasRestApi()
   await MediaWiki.hasVisualEditorApi()
+  await MediaWiki.hasModuleApi()
 
   const dump = new Dump(format, {} as any, MediaWiki.metaData)
 
   return {
     dump,
-    renderer,
   }
 }
 


### PR DESCRIPTION
Fix #2246 

Changes:
- create renderers early in scraper logic so that we fail early should we not be able to create them because of missing API
  - before this change, renderers are created when we try to get and save articles, which is quite late since we've already spent time downloading articles list (potentially from namespaces, which could take some time)
- store these renderers in a singleton
- add a check for module API which is needed by all renderers