### PR TITLE
Fix CI by choosing another article with coordinates among first NS pages

### DIFF
--- a/test/unit/mwApi.test.ts
+++ b/test/unit/mwApi.test.ts
@@ -68,25 +68,23 @@ describe('mwApi', () => {
 
   test('MWApi NS', async () => {
     await getArticlesByNS(0, undefined, 5) // Get 5 continues/pages of NSes
-    const interestingAIds = ['"...And_Ladies_of_the_Club"', '"M"_Circle']
+    const interestingAIds = ['"...And_Ladies_of_the_Club"', '"Khan_gizi"_spring']
     const articles = await RedisStore.articleDetailXId.getMany(interestingAIds)
-    const Ladies = articles['"...And_Ladies_of_the_Club"']
-    const Circle = articles['"M"_Circle']
+    const ArticleWithRevisionsAndCategory = articles['"...And_Ladies_of_the_Club"']
+    const ArticleWithCoordinates = articles['"Khan_gizi"_spring']
 
-    // Article ""...And_Ladies_of_the_Club"" has been scraped
-    expect(Ladies).toBeDefined()
+    // Articles have been retrieved
+    expect(ArticleWithRevisionsAndCategory).not.toBeNull()
+    expect(ArticleWithCoordinates).not.toBeNull()
 
-    // Article ""M"_Circle" has been scraped
-    expect(Circle).toBeDefined()
+    // article has categories
+    expect(ArticleWithRevisionsAndCategory?.categories?.length).toBeGreaterThan(0)
 
-    // Ladies article has categories
-    expect(Ladies?.categories?.length).toBeGreaterThan(0)
+    // article has revision
+    expect(ArticleWithRevisionsAndCategory).toHaveProperty('revisionId')
 
-    // Ladies article has revision
-    expect(Ladies).toHaveProperty('revisionId')
-
-    // Circle article has coordinates'
-    expect(Circle).toHaveProperty('coordinates')
+    // article has coordinates'
+    expect(ArticleWithCoordinates).toHaveProperty('coordinates')
 
     // Got items in namespaces
     expect(Object.keys(MediaWiki.namespaces).length).toBeGreaterThan(0)


### PR DESCRIPTION
Fix #2262 

There was two problems:
- the `"M" Circle` page is now a redirect and hence not anymore among the first pages of NS query results (see https://en.wikipedia.org/w/index.php?title=%22M%22_Circle&action=history)
- the test supposed to check that page is among result was not properly written (is checked the variable is defined instead of not being null)

I fixed the variables names for clarity about the fact that we might need to change these values and what we are looking for, I fixed the test so that it fails at proper check should the page be gone, and I selected another random article among the results of first NS pages.