### PR TITLE
Fix logic catching 200 error + handle BadRevisionException errors and replace with placeholders

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -3,7 +3,7 @@ Unreleased:
 * UPDATE: Create Downloader singleton to stop passing object around (@arjitcodes #2154)
 * FIX: Ignore pages without a single revision / revid - continued (@benoit74 #2234)
 * FIX: Set proper mimetype for ZIM illustration(s) metadata (@benoit74 #1974)
-* CHANGED: Handle bad errors while downloading an article and replace with placeholder (@benoit74 #2185 #2239)
+* CHANGED: Handle bad errors while downloading an article and replace with placeholder (@benoit74 #2185 #2239 #2253)
 * FIX: Avoid reducing redirects directly to an Object to avoid memory issue (@benoit74 #2142)
 * NEW: Check early for availability APIs + add check for module API (@benoit74 #2246 / #2248)
 * CHANGED: Upgrade to node-libzim 3.3.0 (libzim 9.3.0) (@benoit74 #2247)

--- a/src/renderers/action-parse.renderer.ts
+++ b/src/renderers/action-parse.renderer.ts
@@ -6,7 +6,6 @@ import { genCanonicalLink, genHeaderScript, genHeaderCSSLink, getStaticFiles } f
 import MediaWiki from '../MediaWiki.js'
 import { htmlVectorLegacyTemplateCode, htmlVector2022TemplateCode } from '../Templates.js'
 import Downloader, { DownloaderClass } from '../Downloader.js'
-import { DownloadError } from '../Downloader.js'
 
 // Represent 'https://{wikimedia-wiki}/w/api.php?action=parse&format=json&prop=modules|jsconfigvars|text&parsoid=1&page={article_title}&skin=vector-2022'
 export class ActionParseRenderer extends Renderer {
@@ -52,9 +51,6 @@ export class ActionParseRenderer extends Renderer {
     const { articleUrl } = downloadOpts
 
     const data = await Downloader.getJSON<any>(articleUrl)
-    if (data.error) {
-      throw new DownloadError(`Error returned while calling API`, articleUrl, null, null, data)
-    }
 
     const moduleDependencies = {
       jsConfigVars: DownloaderClass.extractJsConfigVars(data.parse.headhtml['*']),

--- a/src/renderers/error.render.ts
+++ b/src/renderers/error.render.ts
@@ -107,6 +107,16 @@ const matchingRules: MatchingRule[] = [
     detailsMessageKey: 'ACTION_PARSE_DB_UNEXPECTED_ERROR',
     displayThirdLine: true,
   },
+  {
+    name: 'ActionParse API - JSON BadRevisionException error',
+    urlContains: ['api.php?action=parse&format=json'],
+    httpReturnCodes: [{ min: 200, max: 200 }],
+    contentTypes: ['application/json'],
+    rawResponseDataContains: null,
+    jsonResponseDataContains: [{ key: 'error.code', valueContains: ['internal_api_error_MediaWiki\\Revision\\BadRevisionException'] }],
+    detailsMessageKey: 'ACTION_PARSE_BAD_REVISION_ERROR',
+    displayThirdLine: true,
+  },
 ]
 
 function jsonMatch(jsonObject: any, keyPath: string, allowedValues: string[]) {
@@ -127,7 +137,7 @@ export function findFirstMatchingRule(err: DownloadErrorContext): MatchingRule |
       (!matchingRule.urlContains || matchingRule.urlContains.findIndex((urlContain) => err.urlCalled.includes(urlContain)) >= 0) &&
       (!matchingRule.httpReturnCodes ||
         matchingRule.httpReturnCodes.findIndex((httpReturnCode) => err.httpReturnCode >= httpReturnCode.min && err.httpReturnCode <= httpReturnCode.max) >= 0) &&
-      (!matchingRule.contentTypes || matchingRule.contentTypes.findIndex((contentType) => err.responseContentType.toLowerCase() == contentType.toLowerCase()) >= 0) &&
+      (!matchingRule.contentTypes || matchingRule.contentTypes.findIndex((contentType) => (err.responseContentType || "").toLowerCase().includes(contentType.toLowerCase())) >= 0) &&
       (!matchingRule.rawResponseDataContains ||
         matchingRule.rawResponseDataContains.findIndex((rawResponseDataContain) => typeof err.responseData == 'string' && err.responseData.includes(rawResponseDataContain)) >=
           0) &&

--- a/test/unit/misc.test.ts
+++ b/test/unit/misc.test.ts
@@ -96,6 +96,8 @@ describe('Misc utility', () => {
           'When the ZIM you are browsing was built, ${server} server ActionParse API raised an HTTP 503 error while giving details about this article HTML.',
         DOWNLOAD_ERRORS_LINE1_ACTION_PARSE_DB_UNEXPECTED_ERROR:
           'When the ZIM you are browsing was built, ${server} server ActionParse API raised an unexpected DB error while giving details about this article HTML.',
+        DOWNLOAD_ERRORS_LINE1_ACTION_PARSE_BAD_REVISION_ERROR:
+          'When the ZIM you are browsing was built, ${server} server ActionParse API raised an unexpected bad revision ID error while giving details about this article HTML.',
         DOWNLOAD_ERRORS_LINE2: 'The missing article was replaced by the placeholder page you are currently seeing.',
         DOWNLOAD_ERRORS_LINE3: "Let's hope the issue will be solved on ${server} server and our next version of this ZIM will contain this article.",
       })
@@ -122,6 +124,8 @@ describe('Misc utility', () => {
           'When the ZIM you are browsing was built, ${server} server ActionParse API raised an HTTP 503 error while giving details about this article HTML.',
         DOWNLOAD_ERRORS_LINE1_ACTION_PARSE_DB_UNEXPECTED_ERROR:
           'When the ZIM you are browsing was built, ${server} server ActionParse API raised an unexpected DB error while giving details about this article HTML.',
+        DOWNLOAD_ERRORS_LINE1_ACTION_PARSE_BAD_REVISION_ERROR:
+          'When the ZIM you are browsing was built, ${server} server ActionParse API raised an unexpected bad revision ID error while giving details about this article HTML.',
         DOWNLOAD_ERRORS_LINE2: 'The missing article was replaced by the placeholder page you are currently seeing.',
         DOWNLOAD_ERRORS_LINE3: "Let's hope the issue will be solved on ${server} server and our next version of this ZIM will contain this article.",
       })

--- a/test/unit/renderers/article.renderer.test.ts
+++ b/test/unit/renderers/article.renderer.test.ts
@@ -14,7 +14,7 @@ describe('ArticleRenderer', () => {
       return {
         data: json,
         articleId: '123',
-        articleDetail: { title: 'Eminem and D12', timestamp: '2023-08-24T02:19:04Z' },
+        articleDetail: { title: 'Brian May', timestamp: '2023-08-24T02:19:04Z' },
         isMainPage: false,
       }
     }

--- a/test/unit/saveArticles.test.ts
+++ b/test/unit/saveArticles.test.ts
@@ -5,11 +5,10 @@ import { startRedis, stopRedis } from './bootstrap.js'
 import { setupScrapeClasses } from '../util.js'
 import { saveArticles } from '../../src/util/saveArticles.js'
 import { StringItem } from '@openzim/libzim'
-import { mwRetToArticleDetail, DELETED_ARTICLE_ERROR } from '../../src/util/index.js'
+import { mwRetToArticleDetail } from '../../src/util/index.js'
 import { jest } from '@jest/globals'
-import { VisualEditorRenderer } from '../../src/renderers/visual-editor.renderer.js'
 import { RENDERERS_LIST } from '../../src/util/const.js'
-import { renderName, RenderOpts } from 'src/renderers/abstract.renderer.js'
+import { renderName } from 'src/renderers/abstract.renderer.js'
 import Downloader from '../../src/Downloader.js'
 import RenderingContext from '../../src/renderers/rendering.context.js'
 
@@ -244,35 +243,8 @@ describe('saveArticles', () => {
       expect(fewestChildren).toBeLessThanOrEqual(1)
     })
     */
-
-    test('Test deleted article rendering (Visual editor renderer)', async () => {
-      const { dump } = await setupScrapeClasses() // en wikipedia
-      const { articleDetailXId } = RedisStore
-      const articleId = 'deletedArticle'
-
-      const articleJsonObject = {
-        visualeditor: { oldid: 0 },
-      }
-
-      const articleDetail = { title: articleId, missing: '' }
-      const moduleDependencies = await Downloader.getModuleDependencies(articleDetail.title)
-
-      const visualEditorRenderer = new VisualEditorRenderer()
-
-      const renderOpts: RenderOpts = {
-        data: articleJsonObject,
-        moduleDependencies,
-        articleId,
-        articleDetailXId,
-        articleDetail,
-        isMainPage: dump.isMainPage(articleId),
-        dump,
-      }
-
-      expect(visualEditorRenderer.render(renderOpts)).rejects.toThrow(DELETED_ARTICLE_ERROR)
-    })
   })
-
+  
   test('Load inline js from HTML', async () => {
     await setupScrapeClasses() // en wikipedia
 

--- a/translation/en.json
+++ b/translation/en.json
@@ -11,6 +11,7 @@
     "DOWNLOAD_ERRORS_LINE1_ACTION_PARSE_504_UPSTREAM_TIMEOUT": "When the ZIM you are browsing was built, ${server} server ActionParse API timed-out while processing this article and returned an HTTP 504 error.",
 	"DOWNLOAD_ERRORS_LINE1_ACTION_PARSE_HTML_503_ERROR": "When the ZIM you are browsing was built, ${server} server ActionParse API raised an HTTP 503 error while giving details about this article HTML.",
   	"DOWNLOAD_ERRORS_LINE1_ACTION_PARSE_DB_UNEXPECTED_ERROR": "When the ZIM you are browsing was built, ${server} server ActionParse API raised an unexpected DB error while giving details about this article HTML.",
+    "DOWNLOAD_ERRORS_LINE1_ACTION_PARSE_BAD_REVISION_ERROR": "When the ZIM you are browsing was built, ${server} server ActionParse API raised an unexpected bad revision ID error while giving details about this article HTML.",
     "DOWNLOAD_ERRORS_LINE2": "The missing article was replaced by the placeholder page you are currently seeing.",
     "DOWNLOAD_ERRORS_LINE3": "Let's hope the issue will be solved on ${server} server and our next version of this ZIM will contain this article."
 }

--- a/translation/qqq.json
+++ b/translation/qqq.json
@@ -15,6 +15,7 @@
 	"DOWNLOAD_ERRORS_LINE1_ACTION_PARSE_504_UPSTREAM_TIMEOUT": "First details message showed on placeholder HTML when article failed to download and error is of given type",
 	"DOWNLOAD_ERRORS_LINE1_ACTION_PARSE_HTML_503_ERROR": "First details message showed on placeholder HTML when article failed to download and error is of given type",
 	"DOWNLOAD_ERRORS_LINE1_ACTION_PARSE_DB_UNEXPECTED_ERROR": "First details message showed on placeholder HTML when article failed to download and error is of given type",
+	"DOWNLOAD_ERRORS_LINE1_ACTION_PARSE_BAD_REVISION_ERROR": "First details message showed on placeholder HTML when article failed to download and error is of given type",
 	"DOWNLOAD_ERRORS_LINE2": "Second details message showed on placeholder HTML when article failed to download",
 	"DOWNLOAD_ERRORS_LINE3": "Third details message showed on placeholder HTML when article failed to download"
 }


### PR DESCRIPTION
Fix #2253 

Side-changes:
- properly raise a `DownloadError` when API (not matter which one) returned an error in its response
- fix backoff `retryIf` logic to consider that error might not be an AxiosError but a DownloadError now, and do not retry when return code is 200 but there is an error
- remove a test case which is a duplicate and messing with too much internals (and hence not working anymore)