### PR TITLE
Keep `typeof` HTML attribute and stop adding custom thumbiner HTML around figures

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -10,6 +10,7 @@ Unreleased:
 * FIX: CSS dependencies are not downloaded/pushed to the ZIM on all but first requested flavor (@benoit74 #2249)
 * FIX: Links to articles through index.php are not detected properly (@benoit74 #2260)
 * FIX: Properly sanitize mw* settings (@benoit74 #2269)
+* CHANGED: Keep `typeof` HTML attribute and stop adding custom thumbiner HTML around images when ActionParse renderer is used (@benoit74 #2254)
 
 1.14.2:
 * FIX: Ignore pages without a single revision / revid (@benoit74 #2091)

--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -240,6 +240,10 @@ export abstract class Renderer {
       return
     }
 
+    if (this.constructor.name === 'ActionParseRenderer') {
+      return
+    }
+
     const descriptions = imageNode.getElementsByTagName('figcaption')
     const description = descriptions.length > 0 ? descriptions[0] : undefined
     const imageWidth = parseInt(image.getAttribute('width'), 10)
@@ -360,7 +364,7 @@ export abstract class Renderer {
       imageDependencies = imageDependencies.concat(ret.imageDependencies)
     }
 
-    /* Improve image frames */
+    /* Treat image figures + special spans */
     const figures = parsoidDoc.getElementsByTagName('figure')
     const spans = parsoidDoc.querySelectorAll('span[typeof~=mw:Image/Frameless],span[typeof~=mw:File/Frameless]')
     const imageNodes = Array.prototype.slice.call(figures).concat(Array.prototype.slice.call(spans))
@@ -666,7 +670,9 @@ export abstract class Renderer {
     const allNodes: DominoElement[] = Array.from(parsoidDoc.getElementsByTagName('*'))
     for (const node of allNodes) {
       node.removeAttribute('data-parsoid')
-      node.removeAttribute('typeof')
+      if (this.constructor.name !== 'ActionParseRenderer') {
+        node.removeAttribute('typeof')
+      }
       node.removeAttribute('about')
       node.removeAttribute('data-mw')
 


### PR DESCRIPTION
Fix #2254

The `typeof` HTML attribute must be kept because it is used for some CSS rules.

![image](https://github.com/user-attachments/assets/2ecdca23-dfd7-4fd5-be8d-df0ada7e88c6)

Previous scraper logic was adding custom HTML around figures and spans. This does not seem to be necessary anymore with `ActionParse` API, and even leads to visual glitches.

Both changes are done only for `ActionParse` API since it seems they were needed with other renderers (or at least they "combined" well with ugly CSS which was injected)