### PR TITLE
Stop removing all images which should not be editable

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -11,6 +11,7 @@ Unreleased:
 * FIX: Links to articles through index.php are not detected properly (@benoit74 #2260)
 * FIX: Properly sanitize mw* settings (@benoit74 #2269)
 * CHANGED: Keep `typeof` HTML attribute and stop adding custom thumbiner HTML around images when ActionParse renderer is used (@benoit74 #2254)
+* FIX: Stop removing all images which should not be editable (@benoit74 #2255)
 
 1.14.2:
 * FIX: Ignore pages without a single revision / revid (@benoit74 #2091)

--- a/res/templates/pageVector2022.html
+++ b/res/templates/pageVector2022.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8"/>
     <title></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/> __ARTICLE_CANONICAL_LINK__ __ARTICLE_CSS_LIST__
-    <style>.vector-body{font-size: 1rem; line-height: 1.6;}@media screen{@media (max-width:calc(639px)){table.infobox{width:100%!important;display:table}}}.noviewer{display: none}</style>
+    <style>.vector-body{font-size: 1rem; line-height: 1.6;}@media screen{@media (max-width:calc(639px)){table.infobox{width:100%!important;display:table}}}</style>
   </head>
   <body class="skin--responsive skin-vector skin-vector-search-vue mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable skin-vector-2022 action-view uls-dialog-sticky-hide" cz-shortcut-listen="true">
     <div class="vector-header-container"></div>


### PR DESCRIPTION
Fix #2255 

The CSS rule removed by this PR was abusively introduced while trying to fix #2271 ; more explanations are in this issue, but basically this fix was really abusive and this PR hence removes it. Issue #2271 has been opened to track the issue and not forget about it, but it is probably not easily solvable / urgent / wishable to be fixed.

The `noviewer` attribute is added to every image for which we do not want the Mediawiki to let the user open the image viewer to see where the image comes from / edit it / download multiple res / ... This is typically used for the Commons image, but could be used in many other places. There is no point in hiding these images in general.