### PR TITLE
Use only minimal Vector (legacy and 2022) templates to avoid side-effects from CSS reserved spaces

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -12,6 +12,7 @@ Unreleased:
 * FIX: Properly sanitize mw* settings (@benoit74 #2269)
 * CHANGED: Keep `typeof` HTML attribute and stop adding custom thumbiner HTML around images when ActionParse renderer is used (@benoit74 #2254)
 * FIX: Stop removing all images which should not be editable (@benoit74 #2255)
+* FIX: Use only minimal Vector (legacy and 2022) templates to avoid side-effects from CSS reserved spaces (@benoit74 #2259)
 
 1.14.2:
 * FIX: Ignore pages without a single revision / revid (@benoit74 #2091)

--- a/res/templates/pageVector2022.html
+++ b/res/templates/pageVector2022.html
@@ -7,11 +7,8 @@
     <style>.vector-body{font-size: 1rem; line-height: 1.6;}@media screen{@media (max-width:calc(639px)){table.infobox{width:100%!important;display:table}}}</style>
   </head>
   <body class="skin--responsive skin-vector skin-vector-search-vue mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable skin-vector-2022 action-view uls-dialog-sticky-hide" cz-shortcut-listen="true">
-    <div class="vector-header-container"></div>
     <div class="mw-page-container">
       <div class="mw-page-container-inner">
-        <div class="vector-sitenotice-container"></div>
-        <div class="vector-column-start"></div>
         <div class="mw-content-container">
           <main id="content" class="mw-body">
             <header class="mw-body-header vector-page-titlebar">
@@ -19,13 +16,8 @@
                 <span id="openzim-page-title" class="mw-page-title-main"></span>
               </h1>
             </header>
-            <div class="vector-page-toolbar"></div>
-            <div class="vector-column-end"></div>
             <a id="top"></a>
             <div id="bodyContent" class="vector-body ve-init-mw-desktopArticleTarget-targetContainer" aria-labelledby="firstHeading" data-mw-ve-target-container="">
-              <div class="vector-body-before-content"></div>
-              <div id="contentSub"></div>
-              <h1 id="titleHeading" style="background-color: white; margin: 0;"></h1>
               <div id="mw-content-text" class="mw-body-content"></div>
             </div>
           </main>

--- a/res/templates/pageVectorLegacy.html
+++ b/res/templates/pageVectorLegacy.html
@@ -12,23 +12,13 @@
     class="mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable skin-vector action-view minerva--history-page-action-enabled skin-vector-legacy"
     cz-shortcut-listen="true"
   >
-    <div id="mw-page-base" class="noprint"></div>
-    <div id="mw-head-base" class="noprint"></div>
     <div id="content" class="mw-body" role="main">
       <a id="top"></a>
-      <div class="mw-indicators mw-body-content"></div>
       <h1 id="firstHeading" class="firstHeading" lang="en"><span id="openzim-page-title"></span></h1>
       <div id="bodyContent" class="mw-body-content">
-        <div id="contentSub"></div>
-        <div id="contentSub2"></div>
         <div id="mw-content-text" lang="en" dir="ltr" class="mw-content-ltr"></div>
-        <div class="printfooter"></div>
-        <div id="catlinks" class="catlinks" data-mw="interface"></div>
       </div>
     </div>
-    <div id="mw-navigation"></div>
-    <footer id="footer" class="mw-footer" role="contentinfo"></footer>
-
     __ARTICLE_CONFIGVARS_LIST__ __ARTICLE_JS_LIST__
   </body>
 </html>


### PR DESCRIPTION
Fix #2259 

When pushing vector (legacy and 2022) templates into the scraper, I wondered whether it might help or not to keep siblings of the HTML tree nodes we are really using to render the article content. 

I did not had any strong argument to push in any direction (keep them or remove them) at that time and hence considered it would be easier to keep them until something proves that we should remove them, rather than removing them and then having to reverse-engineer again the Mediawiki template (which is kinda a pain in the ass).

We are now at a point where issue #2259 proves that keeping these siblings have bad side-effects, since there is some CSS rules which kinda "reserve space" for them. Let's remove them then. Might be that we will need them somewhere in the future when we will add support for the content of these siblings, but then they will not be empty anymore and it will make much more sense.

Problem seems to be more visible on vector legacy template than on vector-2022, but I preferred to apply same approach on both templates for consistency.

Random rationalwiki page after the change:

![Screenshot 2025-04-28 at 11 29 10](https://github.com/user-attachments/assets/99ba1547-bb3c-4434-acb2-dae7bba2c87a)

![Screenshot 2025-04-28 at 11 29 20](https://github.com/user-attachments/assets/8583e8ab-9f80-44d7-bd32-4941c33f72a4)
