### PR TITLE
Fix issues when article is moved with redirect left behind

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -17,6 +17,7 @@ Unreleased:
 * CHANGED: Log ZIM location at the end of the scrape for conveniency (@benoit74 #2297)
 * FIX: ActionParse: enhance fixed style management + add external link icon in footer (@benoit74 #2276 #2283)
 * FIX: WikimediaMobile: fix wrong CSS/JS links when article has a slash in its title (@benoit74 #2293)
+* FIX: Fix issues when article is moved with redirect left behind (@benoit74 #2278)
 
 1.14.2:
 * FIX: Ignore pages without a single revision / revid (@benoit74 #2091)

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -276,12 +276,8 @@ class Downloader {
   }
 
   public setUrlsDirectors(mainPageRenderer: Renderer, articlesRenderer: Renderer): void {
-    if (!this.articleUrlDirector) {
-      this.articleUrlDirector = this.getUrlDirector(articlesRenderer)
-    }
-    if (!this.mainPageUrlDirector) {
-      this.mainPageUrlDirector = this.getUrlDirector(mainPageRenderer)
-    }
+    this.articleUrlDirector = this.getUrlDirector(articlesRenderer)
+    this.mainPageUrlDirector = this.getUrlDirector(mainPageRenderer)
   }
 
   public getArticleUrl(articleId: string): string {

--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -36,9 +36,15 @@ export interface DownloadOpts {
   articleDetail: ArticleDetail
 }
 
+export interface Redirect {
+  from: string
+  to: string
+}
+
 export interface DownloadRes {
   data?: any
   moduleDependencies: any
+  redirects: Redirect[]
 }
 
 export interface RenderOpts {

--- a/src/renderers/abstractDesktop.render.ts
+++ b/src/renderers/abstractDesktop.render.ts
@@ -24,7 +24,7 @@ export abstract class DesktopRenderer extends Renderer {
       throw new Error(data.error)
     }
 
-    return { data, moduleDependencies }
+    return { data, moduleDependencies, redirects: [] }
   }
 
   public filterWikimediaDesktopModules(_moduleDependencies) {

--- a/src/renderers/action-parse.renderer.ts
+++ b/src/renderers/action-parse.renderer.ts
@@ -63,7 +63,15 @@ export class ActionParseRenderer extends Renderer {
       styleDependenciesList: config.output.mw.css_simplified.concat(data.parse.modulestyles),
     }
 
-    return { data: data.parse.text['*'], moduleDependencies }
+    const normalizedRedirects = data.parse.redirects.map((redirect) => {
+      // The API returns the redirect title (!?), we fake the
+      // redirectId by putting the underscore.
+      redirect.from = String(redirect.from).replace(/ /g, '_')
+      redirect.to = String(redirect.to).replace(/ /g, '_')
+      return redirect
+    })
+
+    return { data: data.parse.text['*'], moduleDependencies, redirects: normalizedRedirects }
   }
 
   public async render(renderOpts: RenderOpts): Promise<any> {

--- a/src/renderers/wikimedia-mobile.renderer.ts
+++ b/src/renderers/wikimedia-mobile.renderer.ts
@@ -37,7 +37,7 @@ export class WikimediaMobileRenderer extends MobileRenderer {
 
     const data = await Downloader.getJSON<any>(articleUrl)
 
-    return { data, moduleDependencies }
+    return { data, moduleDependencies, redirects: [] }
   }
 
   public async render(renderOpts: RenderOpts): Promise<any> {

--- a/src/util/builders/url/action-parse.director.ts
+++ b/src/util/builders/url/action-parse.director.ts
@@ -15,7 +15,7 @@ export default class ActionParseURLDirector {
   buildArticleURL(articleId: string) {
     return urlBuilder
       .setDomain(this.baseDomain)
-      .setQueryParams({ action: 'parse', format: 'json', prop: 'modules|jsconfigvars|headhtml|text', parsoid: '1', page: articleId, useskin: this.skin })
+      .setQueryParams({ action: 'parse', format: 'json', prop: 'modules|jsconfigvars|headhtml|text', parsoid: '1', page: articleId, useskin: this.skin, redirects: '1' })
       .build()
   }
 }

--- a/test/unit/bootstrap.ts
+++ b/test/unit/bootstrap.ts
@@ -15,5 +15,5 @@ export const startRedis = async () => {
 
 export const stopRedis = async () => {
   console.info('Closing all redis connections')
-  RedisStore.close()
+  await RedisStore.close()
 }


### PR DESCRIPTION
Fix #2278 

Changes:
- change ActionParse query to follow redirects
- benefit from ActionParse redirects result to detect when a page has been moved since our listing of articles and include redirect from new location (where we will have nothing) to old location
- detect when page is moved during the listing as well, and recover properly (do not fetch new page and add a redirect from new location to old one)
- when writing redirects to the ZIM, ensure that we are not redirecting to self, not redirecting from a path for which we already have an article, and not redirecting to a path which is not an article
- fix issue (only impacting tests) where URL directors where not reinitialized now that Downloader is a singleton (we were first URLDirector init in any test, and hence using bad URLs throughout most tests)