### PR TITLE
ActionParse: Handle articles moved without redirects left behind

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -18,6 +18,7 @@ Unreleased:
 * FIX: ActionParse: enhance fixed style management + add external link icon in footer (@benoit74 #2276 #2283)
 * FIX: WikimediaMobile: fix wrong CSS/JS links when article has a slash in its title (@benoit74 #2293)
 * FIX: Fix issues when article is moved with redirect left behind (@benoit74 #2278)
+* FIX: ActionParse: Handle articles moved without redirects left behind (@benoit74 #2282)
 
 1.14.2:
 * FIX: Ignore pages without a single revision / revid (@benoit74 #2091)

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -398,6 +398,11 @@ class Downloader {
     }
   }
 
+  public async getLogEvents(letype: string, articleId: string): Promise<any> {
+    const logEventsData = await this.getJSON<any>(this.apiUrlDirector.buildLogEventsQuery(letype, articleId))
+    return logEventsData.query?.logevents
+  }
+
   public async getArticle(
     articleId: string,
     articleDetailXId: RKVS<ArticleDetail>,
@@ -411,6 +416,7 @@ class Downloader {
 
     try {
       const { data, moduleDependencies, redirects } = await articleRenderer.download({
+        articleId,
         articleUrl,
         articleDetail,
       })

--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -32,6 +32,7 @@ interface RendererBuilderOptionsSpecific extends RendererBuilderOptionsBase {
 export type RendererBuilderOptions = RendererBuilderOptionsCommon | RendererBuilderOptionsSpecific
 
 export interface DownloadOpts {
+  articleId: string
   articleUrl: string
   articleDetail: ArticleDetail
 }

--- a/src/util/builders/url/api.director.ts
+++ b/src/util/builders/url/api.director.ts
@@ -52,6 +52,10 @@ export default class ApiURLDirector {
     return urlBuilder.setDomain(this.baseDomain).setQueryParams({ action: 'visualeditor', mobileformat: 'html', format: 'json', paction: 'parse', formatversion: '2' }).build(true)
   }
 
+  buildLogEventsQuery(letype: string, articleId: string) {
+    return urlBuilder.setDomain(this.baseDomain).setQueryParams({ action: 'query', list: 'logevents', letype: letype, letitle: articleId, format: 'json' }).build()
+  }
+
   buildArticleApiURL(articleId: string) {
     return urlBuilder
       .setDomain(this.baseDomain)


### PR DESCRIPTION
Fix #2282 

To be merged after #2290

Changes: 
- When ActionParse API is used, it detects automatically when a page is deemed to be deleted, look in logevents for a move event without redirect left behind, and if it does it automatically fetch content from new article title (but stores it in the ZIM at old location, since we've assumed there will be something there in the other articles HTML rewriting)

Nota: at some point, we might want to add a redirect from new article title to old article title, but it was pretty complex to implement in current scraper architecture and deemed not really mandatory