### PR TITLE
Add prettier to CI, so that we fail early on formatting issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,13 @@ jobs:
       - name: Installing other dependencies
         run: |
           npm install
+          npm i -g prettier
           npm i -g eslint
           npm i -g codecov
           wget -qO- https://download.openzim.org/release/zim-tools/zim-tools_linux-x86_64.tar.gz | tar xvz
+
+      - name: Running Prettier
+        run: npm run format-check
 
       - name: Running ESLint
         run: npm run lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v9.26.0
+    hooks:
+      - id: eslint
+        types: [file]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ to participate to MWoffliner development or hack it.
 ## Setup
 
 To setup MWoffliner locally:
+
 ```bash
 git clone https://github.com/openzim/mwoffliner.git
 cd mwoffliner
@@ -13,6 +14,7 @@ npm ci
 ## Usage
 
 To run it (this is only an example):
+
 ```bash
 ./node_modules/.bin/ts-node-esm ./src/cli.ts --mwUrl=https://bm.wikipedia.org --adminEmail=XXX
 ```
@@ -26,9 +28,9 @@ npm start -- --mwUrl=https://bm.wikipedia.org --adminEmail=XXX
 ## Code
 
 We use TypeScript for development. You can find all `.ts` files in
-`src/**`.  The best way to develop is to run `npm run watch` in a
+`src/**`. The best way to develop is to run `npm run watch` in a
 terminal, and then execute MWOffliner via the pre-configured debugger
-in Visual Studio Code.  The compiled `.js` files are not committed to
+in Visual Studio Code. The compiled `.js` files are not committed to
 Git, but they are published to NPM.
 
 We follow a nearly exact `tslint:recommended` scheme -
@@ -38,54 +40,68 @@ It's best to use TSLint to check your code as you develop, this
 project is pre-configured for development with VSCode and the TSLint
 plugin.
 
+This repo also contains required pre-commit configuration, so that both
+eslint and prettier are ran before any commit, as required by the CI.
+Follow instructions at https://pre-commit.com/ to install it.
+
 ## Tests
 
 To run the automated tests with collecting coverage (both unit and e2e):
+
 ```bash
 npm test # or "npm run test"
 ```
 
 To run the automated tests with collecting coverage and verbose all debug message (both unit and e2e):
+
 ```bash
 npm run test-verbose
 ```
 
 To run the automated tests without collecting coverage (both unit and e2e). This command will be a bit faster:
+
 ```bash
 npm run test-without-coverage
 ```
 
 To run the unit tests with collecting coverage:
+
 ```bash
 npm run test:unit-coverage
 ```
 
 To run the unit tests without collecting coverage:
+
 ```bash
 npm run test:unit
 ```
 
 To run end-2-end tests with collecting coverage:
+
 ```bash
 npm run test:e2e-coverage
 ```
 
 To run end-2-end tests without collecting coverage:
+
 ```bash
 npm run test:e2e
 ```
 
 To run a specfic test with collecting coverage:
+
 ```bash
 npm run test:pattern test/e2e/wikisource.e2e.test.ts -- --coverage
 ```
 
 To run a specfic test without collecting coverage:
+
 ```bash
 npm run test:pattern test/e2e/wikisource.e2e.test.ts
 ```
 
 To run a tests by regex pattern. Example which runs all e2e tests:
+
 ```bash
 npm run test:pattern ^.*e2e.*\.test\.ts
 ```
@@ -93,6 +109,7 @@ npm run test:pattern ^.*e2e.*\.test\.ts
 For S3 tests to pass, create a '.env' file (at the root of your
 MWoffliner code directory) where you will configure S3 URL
 with credentials. Example:
+
 ```
 S3_URL=https://s3.region.amazonaws.com/?bucketName=S3_BUCKET_NAME&keyId=S3_KEY_ID&secretAccessKey=S3_ACCESS_KEY
 ```
@@ -109,38 +126,40 @@ Advices for debugging mwoffliner issues:
 
 1.  For pre-packaged Kiwix downloads, look at the scripts at
     https://github.com/kiwix/maintenance/tree/master/mwoffliner
-    *   If both, then you may need separate corrections for each.
+    - If both, then you may need separate corrections for each.
 2.  Create Parsoid output to understand what mwoffliner is working
     with, including checking whether the error is with the Parsoid
-    output itself.  For Wikimedia wikis you can easily generate and
+    output itself. For Wikimedia wikis you can easily generate and
     view the output in your browser using the Parsoid REST interface.
     Example URLs:
-    *   <del>Mobile (most pages):
-        https://en.wikivoyage.org/api/rest_v1/page/mobile-sections/Hot_springs</del>
-        > :warning: **DEPRECATED**: Mobile Content Service endpoints are now deprecated.
-    *   Desktop (main page):
-        https://es.wikipedia.org/api/rest_v1/page/html/Espa%C3%B1a
+    - <del>Mobile (most pages):
+      https://en.wikivoyage.org/api/rest_v1/page/mobile-sections/Hot_springs</del>
+      > :warning: **DEPRECATED**: Mobile Content Service endpoints are now deprecated.
+    - Desktop (main page):
+      https://es.wikipedia.org/api/rest_v1/page/html/Espa%C3%B1a
 3.  If the error is with the Parsoid output
-    *   Mark the issue in openzim/mwoffliner with the
-        "parsoid/mediawiki" tag.
-    *   It's good to reach out to Parsoid to open a corresponding bug
-        and reference it. Even so, keep the openzim/mwoffliner bug
-        open until the Parsoid bug is fixed.
-    *   Consider whether a workaround in mwoffliner is possible and
-        worthwhile.
+    - Mark the issue in openzim/mwoffliner with the
+      "parsoid/mediawiki" tag.
+    - It's good to reach out to Parsoid to open a corresponding bug
+      and reference it. Even so, keep the openzim/mwoffliner bug
+      open until the Parsoid bug is fixed.
+    - Consider whether a workaround in mwoffliner is possible and
+      worthwhile.
 4.  Make a small test case to use as you develop rather than
     processing a large wiki. In particular, the argument
-    `--articleList` are useful.  Run mwoffliner with `--help` for
+    `--articleList` are useful. Run mwoffliner with `--help` for
     details on those and other flags that may be useful.
 
 ## Releasing and Publishing
+
 To publish/release, it's best to use a clean clone of the project:
+
 1. Clone `git clone https://github.com/openzim/mwoffliner.git`
 2. Update `package.json`
 3. Commit `:package: Release version vX.X.X`
 4. Run `git tag vX.X.X`
 5. Run `git push origin vX.X.X`
-Whenever a tag is pushed, the CI automatically publishes to npmjs.com
+   Whenever a tag is pushed, the CI automatically publishes to npmjs.com
 
 ## Contributing Guidelines
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint": "eslint .",
     "lint-fix": "eslint --fix .",
     "format": "prettier --write './**/*.ts'",
+    "format-check": "prettier --check './**/*.ts'",
     "prebuild": "node -p \"'export const LIB_VERSION = \\'' + require('./package.json').version + '\\''\" > src/version.ts",
     "build": "./dev/build.sh",
     "watch": "./dev/watch.sh",


### PR DESCRIPTION
So far, the CI does not checks code formatting with prettier. 

This means that we regularly have commits which reformat something totally unrelated to the change simply because previous committer did not formatted files, and current author did.

This PR adds prettier (in check mode, to fail on error) to the CI.

This PR also adds required pre-commit configuration and instruction, so that users wishing to can check their code automatically before pushing it to the repo (prettier plugin is archived and supposedly broken but it still works fine ATM, waiting for the community to restart work on it should it break).

NOTA : pre-commit is a Python tool, coming mostly from the Python community, but it works very well on Node.JS projects and has mostly no requirements beside a Python runtime