### PR TITLE
Log ZIM location at the end of the scrape for conveniency

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -14,6 +14,7 @@ Unreleased:
 * FIX: Stop removing all images which should not be editable (@benoit74 #2255)
 * FIX: Use only minimal Vector (legacy and 2022) templates to avoid side-effects from CSS reserved spaces (@benoit74 #2259)
 * CHANGED: Replace urlparser deprecated API with WHATWG URL API (@benoit74 #2285)
+* CHANGED: Log ZIM location at the end of the scrape for conveniency (@benoit74 #2297)
 
 1.14.2:
 * FIX: Ignore pages without a single revision / revid (@benoit74 #2091)

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -369,7 +369,7 @@ async function execute(argv: any) {
 
   async function doDump(dump: Dump) {
     const outZim = path.resolve(dump.opts.outputDirectory, dump.computeFilenameRadical() + '.zim')
-    logger.log(`Writing zim to [${outZim}]`)
+    logger.log(`Writing ZIM to [${outZim}]`)
     dump.outFile = outZim
 
     const metadata = {
@@ -455,7 +455,7 @@ async function execute(argv: any) {
     logger.log('Writing Article Redirects')
     await writeArticleRedirects(dump, zimCreator)
 
-    logger.log('Finishing Zim Creation')
+    logger.log('Finishing ZIM Creation')
     await zimCreator.finishZimCreation()
 
     logger.log('Summary of scrape actions:', JSON.stringify(dump.status, null, '\t'))
@@ -489,17 +489,17 @@ async function execute(argv: any) {
       const faviconIsRemote = customZimFavicon.includes('http')
       let content
       if (faviconIsRemote) {
-        logger.log(`Downloading remote zim favicon from [${customZimFavicon}]`)
+        logger.log(`Downloading remote ZIM favicon from [${customZimFavicon}]`)
         content = await Downloader.request({ url: customZimFavicon, method: 'GET', ...Downloader.arrayBufferRequestOptions })
           .then((a) => a.data)
           .catch(() => {
-            throw new Error(`Failed to download custom zim favicon from [${customZimFavicon}]`)
+            throw new Error(`Failed to download custom ZIM favicon from [${customZimFavicon}]`)
           })
       } else {
         try {
           content = fs.readFileSync(customZimFavicon)
         } catch {
-          throw new Error(`Failed to read custom zim favicon from [${customZimFavicon}]`)
+          throw new Error(`Failed to read custom ZIM favicon from [${customZimFavicon}]`)
         }
       }
       try {

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -459,6 +459,7 @@ async function execute(argv: any) {
     await zimCreator.finishZimCreation()
 
     logger.log('Summary of scrape actions:', JSON.stringify(dump.status, null, '\t'))
+    logger.log(`ZIM is ready at [${outZim}]`)
   }
 
   /* ********************************* */

--- a/src/sanitize-argument.ts
+++ b/src/sanitize-argument.ts
@@ -116,7 +116,7 @@ export async function sanitize_all(argv: any) {
   // created a redis client and then closed it.
   sanitize_redis(argv)
 
-  // sanitizing custom zim favicon
+  // sanitizing custom ZIM favicon
   if (customZimFavicon) {
     await sanitize_customZimFavicon(customZimFavicon)
   }
@@ -208,7 +208,7 @@ export async function sanitize_customZimFavicon(customZimFavicon: any) {
   if (faviconIsRemote) {
     // make a download to check custom favicon link is valid
     await axios.get(customZimFavicon).catch(() => {
-      throw new Error(`Failed to download custom zim favicon from [${customZimFavicon}]`)
+      throw new Error(`Failed to download custom ZIM favicon from [${customZimFavicon}]`)
     })
   } else {
     fs.readFileSync(customZimFavicon)

--- a/test/e2e/apiPathParamsSanitizing.e2e.test.ts
+++ b/test/e2e/apiPathParamsSanitizing.e2e.test.ts
@@ -45,7 +45,7 @@ await testAllRenders('api-path-params', parameters, async (outFiles) => {
       expect(outFiles[0].mwMetaData.actionApiUrl).toBe('https://en.wikipedia.org/w/api.php')
     })
 
-    test(`test zim integrity for ${outFiles[0]?.renderer} renderer`, async () => {
+    test(`test ZIM integrity for ${outFiles[0]?.renderer} renderer`, async () => {
       await expect(zimcheck(outFiles[0].outFile)).resolves.not.toThrowError()
     })
 

--- a/test/e2e/bm.e2e.test.ts
+++ b/test/e2e/bm.e2e.test.ts
@@ -15,7 +15,7 @@ const parameters = {
 }
 
 await testAllRenders('bm-wikipedia', parameters, async (outFiles) => {
-  test(`test zim integrity for ${outFiles[0]?.renderer} renderer`, async () => {
+  test(`test ZIM integrity for ${outFiles[0]?.renderer} renderer`, async () => {
     await expect(zimcheck(outFiles[0].outFile)).resolves.not.toThrowError()
   })
 

--- a/test/e2e/en.e2e.test.ts
+++ b/test/e2e/en.e2e.test.ts
@@ -7,7 +7,7 @@ import { rimraf } from 'rimraf'
 
 jest.setTimeout(60000)
 
-// Check the integrity of img elements between zim file and article html taken from it
+// Check the integrity of img elements between ZIM file and article html taken from it
 const verifyImgElements = (imgFilesArr, imgElements) => {
   for (const img of imgElements) {
     for (const imgFile of imgFilesArr) {
@@ -30,7 +30,7 @@ await testAllRenders('en-wikipedia', parameters, async (outFiles) => {
   describe('e2e test for en.wikipedia.org', () => {
     const articleDoc = domino.createDocument(articleFromDump)
 
-    test(`test zim integrity for ${outFiles[0]?.renderer} renderer`, async () => {
+    test(`test ZIM integrity for ${outFiles[0]?.renderer} renderer`, async () => {
       await expect(zimcheck(outFiles[0].outFile)).resolves.not.toThrowError()
     })
 

--- a/test/e2e/openstreetmap.e2e.test.ts
+++ b/test/e2e/openstreetmap.e2e.test.ts
@@ -7,7 +7,7 @@ import { rimraf } from 'rimraf'
 
 jest.setTimeout(60000)
 
-// Check the integrity of img elements between zim file and article html taken from it
+// Check the integrity of img elements between ZIM file and article html taken from it
 const verifyImgElements = (imgFilesArr, imgElements) => {
   for (const img of imgElements) {
     for (const imgFile of imgFilesArr) {
@@ -33,7 +33,7 @@ await testRenders(
     describe('e2e test for wiki.openstreetmap.org', () => {
       const articleDoc = domino.createDocument(articleFromDump)
 
-      test(`test zim integrity for ${outFiles[0]?.renderer} renderer`, async () => {
+      test(`test ZIM integrity for ${outFiles[0]?.renderer} renderer`, async () => {
         await expect(zimcheck(outFiles[0].outFile)).resolves.not.toThrowError()
       })
 

--- a/test/e2e/vikidia.e2e.test.ts
+++ b/test/e2e/vikidia.e2e.test.ts
@@ -29,7 +29,7 @@ await testRenders(
       expect(outFiles).toHaveLength(1)
     })
 
-    test(`test zim integrity for ${outFiles[0]?.renderer} renderer`, async () => {
+    test(`test ZIM integrity for ${outFiles[0]?.renderer} renderer`, async () => {
       await expect(zimcheck(outFiles[0].outFile)).resolves.not.toThrowError()
     })
 

--- a/test/e2e/zimMetadata.e2e.test.ts
+++ b/test/e2e/zimMetadata.e2e.test.ts
@@ -21,7 +21,7 @@ const parameters = {
 
 await testAllRenders('zim-metadata', parameters, async (outFiles) => {
   describe('zimMetadata', () => {
-    test(`check all zim metadata using zimdump for ${outFiles[0]?.renderer} renderer`, async () => {
+    test(`check all ZIM metadata using zimdump for ${outFiles[0]?.renderer} renderer`, async () => {
       await execa('redis-cli flushall', { shell: true })
 
       expect(outFiles).toHaveLength(1)


### PR DESCRIPTION
This PR adds the ZIM location in the logs at the end of the scrape since it is very convenient / recommended in general.

This PR also fixes few typos on ZIM casing.