### PR TITLE
Fix `webpHandler.js` script handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,4 +14,5 @@ repos:
     rev: v9.26.0
     hooks:
       - id: eslint
+        args: [--config, eslint.config.js]
         types: [file]

--- a/Changelog
+++ b/Changelog
@@ -21,6 +21,7 @@ Unreleased:
 * FIX: ActionParse: Handle articles moved without redirects left behind (@benoit74 #2282)
 * FIX: Introduce the concept of soft/hard article download errors (@benoit74 #2302)
 * FIX: Stop creating links to titles which are known to be in error (@benoit74 #2303)
+* FIX: Fix webpHandler.js script handling (@benoit74 #2316)
 
 1.14.2:
 * FIX: Ignore pages without a single revision / revid (@benoit74 #2091)

--- a/res/webpHandler.js
+++ b/res/webpHandler.js
@@ -1,0 +1,165 @@
+function extend(obj, src) {
+  for (var key in src) {
+    if (src.hasOwnProperty(key)) obj[key] = src[key]
+  }
+  return obj
+}
+
+var WebPHandler = (function () {
+  var defaults
+
+  WebPHandler.name = 'WebPHandler'
+
+  defaults = {
+    // function to attach to img el before replacing src
+    on_error: null,
+    // whether to use an url: pngData cache of decoded images. disable if you have
+    // too many images on page
+    use_cache: true,
+    // function to call once WebPHandler is ready
+    on_ready: null,
+    scripts_urls: ['./webp-hero.polyfill.js', './webp-hero.bundle.js'],
+  }
+
+  function WebPHandler(options) {
+    this.options = extend(defaults, options)
+
+    this.webp_machine = null
+    this.supports_webp = true
+    var parent = this
+    this.testWebP(function (supports) {
+      parent.supports_webp = supports
+      if (typeof webpHero === 'undefined') {
+        console.debug('Loading webpHero scripts')
+        parent.options.scripts_urls.forEach(function (scriptUrl) {
+          var script = document.createElement('script')
+          script.type = 'text/javascript'
+          script.src = scriptUrl
+          if (parent.options.scripts_urls[parent.options.scripts_urls.length - 1] === scriptUrl) {
+            // Start webpMachine if we have loaded the last script
+            script.onload = function () {
+              parent.start()
+            }
+          }
+          document.querySelector('body').appendChild(script)
+        })
+      } else {
+        console.debug('webpHero already loaded')
+        parent.start()
+      }
+    })
+    this.cache = {}
+    this.pending = []
+    this.running = false
+  }
+
+  WebPHandler.prototype.start = function () {
+    this.webp_machine = new webpHero.WebpMachine()
+    console.debug(WebPHandler.name, 'initialized. Supports WebP:', this.supports_webp)
+    if (this.options.on_ready) this.options.on_ready(this)
+  }
+
+  WebPHandler.prototype.addToPipe = function (image) {
+    this.pending.push(image)
+  }
+
+  WebPHandler.prototype.polyfillPipe = async function () {
+    if (this.running) return
+    this.running = true
+
+    var image = this.pending.shift()
+    while (image !== undefined) {
+      try {
+        if (this.options.on_error) {
+          image.onerror = this.options.on_error
+        }
+        await this.do_polyfillImage(image)
+      } catch (e) {
+        console.error(e)
+        if (e.name == 'WebpMachineBusyError') {
+          this.addToPipe(image)
+        } else {
+          // failed in our code so browser won't trigger the onerror attr
+          if (this.options.on_error) {
+            this.options.on_error(image)
+          }
+        }
+      }
+      image = this.pending.shift()
+    }
+    this.running = false
+  }
+
+  WebPHandler.prototype.do_polyfillImage = async function (image) {
+    const { src } = image
+    if (this.options.use_cache && this.cache[src]) {
+      image.src = this.cache[src]
+      return
+    }
+    try {
+      const webpData = await webpHero.loadBinaryData(src)
+      const pngData = await this.webp_machine.decode(webpData)
+      if (this.options.use_cache) {
+        image.src = this.cache[src] = pngData
+      } else {
+        image.src = pngData
+      }
+    } catch (error) {
+      if (/busy$/i.test(error.message)) {
+        error.name = 'WebpMachineBusyError'
+      } else {
+        error.name = 'WebpMachineError'
+        error.message = `failed to polyfill image "${src}": ${error.message}`
+      }
+      throw error
+    }
+  }
+
+  WebPHandler.prototype.polyfillImage = async function (image) {
+    const { src } = image
+    if (this.webp_machine.detectWebpImage(image)) {
+      if (this.options.use_cache && this.cache[src]) {
+        image.src = this.cache[src]
+        return
+      }
+      this.addToPipe(image)
+      this.polyfillPipe()
+    }
+  }
+
+  /**
+   * Polyfill webp format on the entire web page
+   */
+  WebPHandler.prototype.polyfillDocument = async function (document) {
+    if (!document) {
+      document = window.document
+    }
+    if (this.supports_webp) return null
+    for (const image of Array.from(document.querySelectorAll('img'))) {
+      try {
+        await this.polyfillImage(image)
+      } catch (error) {
+        error.name = 'WebpMachineError'
+        error.message = `webp image polyfill failed for url "${image.src}": ${error}`
+        throw error
+      }
+    }
+  }
+
+  WebPHandler.prototype.testWebP = function (callback) {
+    var webp_image = new Image()
+    webp_image.onload = webp_image.onerror = function () {
+      callback(webp_image.height === 2)
+    }
+    webp_image.src = 'data:image/webp;base64,UklGRjoAAABXRUJQVlA4IC4AAACyAgCdASoCAAIALmk0mk0iIiIiIgBoSygABc6WWgAA/veff/0PP8bA//LwYAAA'
+  }
+
+  /**
+   * Manually wipe the cache to save memory
+   */
+  WebPHandler.prototype.clearCache = function () {
+    this.cache = {}
+  }
+
+  return WebPHandler
+})()

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -34,7 +34,7 @@ import {
   mkdirPromise,
   sanitizeString,
   saveStaticFiles,
-  importPolyfillModules,
+  addWebpJsScripts,
   extractArticleList,
   getTmpDirectory,
   validateMetadata,
@@ -411,6 +411,11 @@ async function execute(argv: any) {
 
     await saveFavicon(zimCreator, metaDataRequiredKeys['Illustration_48x48@1'])
 
+    if (Downloader.webp) {
+      logger.log('Adding webp polyfilling JS scripts')
+      await addWebpJsScripts(zimCreator)
+    }
+
     await getThumbnailsData()
 
     logger.log('Checking Main Page rendering')
@@ -431,11 +436,6 @@ async function execute(argv: any) {
       { type: 'js', moduleList: Array.from(jsModuleDependencies) },
       { type: 'css', moduleList: Array.from(cssModuleDependencies) },
     ]
-
-    if (Downloader.webp) {
-      logger.log('Downloading polyfill module')
-      await importPolyfillModules(zimCreator)
-    }
 
     logger.log('Downloading module dependencies')
     await Promise.all(

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -16,7 +16,6 @@ export const ALL_READY_FUNCTION = /function allReady\( modules \) {/
 export const DO_PROPAGATION = /mw\.requestIdleCallback\( doPropagation, \{ timeout: 1 \} \);/
 export const LOAD_PHP = /script.src = ".*load\.php.*";/
 export const RULE_TO_REDIRECT = /window\.top !== window\.self/
-export const WEBP_HANDLER_URL = 'https://gist.githubusercontent.com/rgaudin/60bb9cc6f187add506584258028b8ee1/raw/9d575b8e25d67eed2a9c9a91d3e053a0062d2fc7/web-handler.js'
 export const MAX_FILE_DOWNLOAD_RETRIES = 5
 export const BLACKLISTED_NS = ['Story'] // 'Story' Wikipedia namespace is content, but not indgestable by Parsoid https://github.com/openzim/mwoffliner/issues/1853
 export const RENDERERS_LIST = ['WikimediaDesktop', 'VisualEditor', 'WikimediaMobile', 'RestApi', 'ActionParse']

--- a/src/util/dump.ts
+++ b/src/util/dump.ts
@@ -8,7 +8,7 @@ import { config } from '../config.js'
 import MediaWiki from '../MediaWiki.js'
 import { Creator, StringItem } from '@openzim/libzim'
 import fs from 'fs'
-import { DO_PROPAGATION, ALL_READY_FUNCTION, WEBP_HANDLER_URL, LOAD_PHP, RULE_TO_REDIRECT } from './const.js'
+import { DO_PROPAGATION, ALL_READY_FUNCTION, LOAD_PHP, RULE_TO_REDIRECT } from './const.js'
 import * as path from 'path'
 import urlHelper from './url.helper.js'
 import { zimCreatorMutex } from '../mutex.js'
@@ -152,21 +152,13 @@ export async function downloadAndSaveModule(zimCreator: Creator, module: string,
 }
 
 // URLs should be kept the same as Kiwix JS relies on it.
-export async function importPolyfillModules(zimCreator: Creator) {
+export async function addWebpJsScripts(zimCreator: Creator) {
   ;[
     { name: 'webpHeroPolyfill', path: path.join(__dirname, '../../node_modules/webp-hero/dist-cjs/polyfills.js') },
     { name: 'webpHeroBundle', path: path.join(__dirname, '../../node_modules/webp-hero/dist-cjs/webp-hero.bundle.js') },
+    { name: 'webpHandler', path: path.join(__dirname, '../../res/webpHandler.js') },
   ].forEach(async ({ name, path }) => {
     const item = new StringItem(jsPath(name), 'text/javascript', null, { FRONT_ARTICLE: 0 }, fs.readFileSync(path, 'utf8').toString())
     await zimCreatorMutex.runExclusive(() => zimCreator.addItem(item))
   })
-
-  const content = await Downloader.request({ url: WEBP_HANDLER_URL, method: 'GET', ...Downloader.arrayBufferRequestOptions })
-    .then((a) => a.data)
-    .catch((err) => {
-      throw new Error(`Failed to download webpHandler from [${WEBP_HANDLER_URL}]: ${err}`)
-    })
-
-  const item = new StringItem(jsPath('webpHandler'), 'text/javascript', null, { FRONT_ARTICLE: 0 }, content)
-  await zimCreatorMutex.runExclusive(() => zimCreator.addItem(item))
 }


### PR DESCRIPTION
Fix #2316 

Changes:

- add webp-related files in the ZIM before processing articles
- rename the function doing this for clarity
- add webpHandler.js in current repo and use it instead of online version

Unrelated change:
- fix pre-commit-config.yaml configuration to use local `eslint.config.js` (for some reason, it is not loaded automatically)
  - while mostly unrelated, eslint was trying to parse / fix `webpHandler.js` script despite being in `res` folder which is ignored by `eslint.config.js`