### PR TITLE
Do not add JS scripts/modules in the ZIM with ActionParser renderer for now

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -23,6 +23,7 @@ Unreleased:
 * FIX: Stop creating links to titles which are known to be in error (@benoit74 #2303)
 * FIX: Fix webpHandler.js script handling (@benoit74 #2316)
 * FIX: Truncate article titles to 245 bytes (@benoit74 #2320)
+* FIX: Do not add JS scripts/modules in the ZIM with ActionParser renderer for now (@benoit74 #2319)
 
 1.14.2:
 * FIX: Ignore pages without a single revision / revid (@benoit74 #2091)

--- a/src/renderers/action-parse.renderer.ts
+++ b/src/renderers/action-parse.renderer.ts
@@ -5,7 +5,7 @@ import { config } from '../config.js'
 import { genCanonicalLink, genHeaderScript, genHeaderCSSLink, getStaticFiles, getRelativeFilePath } from '../util/misc.js'
 import MediaWiki from '../MediaWiki.js'
 import { htmlVectorLegacyTemplateCode, htmlVector2022TemplateCode } from '../Templates.js'
-import Downloader, { DownloaderClass, DownloadError } from '../Downloader.js'
+import Downloader, { DownloadError } from '../Downloader.js'
 
 // Represent 'https://{wikimedia-wiki}/w/api.php?action=parse&format=json&prop=modules|jsconfigvars|text&parsoid=1&page={article_title}&skin=vector-2022'
 export class ActionParseRenderer extends Renderer {
@@ -81,8 +81,9 @@ export class ActionParseRenderer extends Renderer {
     }
 
     const moduleDependencies = {
-      jsConfigVars: DownloaderClass.extractJsConfigVars(data.parse.headhtml['*']),
-      jsDependenciesList: config.output.mw.js_simplified.concat(data.parse.modules),
+      // Do not add JS-related stuff for now with ActionParse, see #2310
+      jsConfigVars: '', // DownloaderClass.extractJsConfigVars(data.parse.headhtml['*']),
+      jsDependenciesList: [], // config.output.mw.js_simplified.concat(data.parse.modules),
       styleDependenciesList: config.output.mw.css_simplified.concat(data.parse.modulestyles),
     }
 


### PR DESCRIPTION
This is a "containment" change for #2310, not the long term fix.

See https://github.com/openzim/mwoffliner/issues/2310#issuecomment-2894221966 for details