### PR TITLE
Truncate article titles to 245 bytes

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -22,6 +22,7 @@ Unreleased:
 * FIX: Introduce the concept of soft/hard article download errors (@benoit74 #2302)
 * FIX: Stop creating links to titles which are known to be in error (@benoit74 #2303)
 * FIX: Fix webpHandler.js script handling (@benoit74 #2316)
+* FIX: Truncate article titles to 245 bytes (@benoit74 #2320)
 
 1.14.2:
 * FIX: Ignore pages without a single revision / revid (@benoit74 #2091)


### PR DESCRIPTION
This is an interim bug fix for #2318 until upstream issue settles (or maybe a definitive fix should we discover this is just a documentation issue)

Changes:
- truncate article titles to 245 bytes in an efficient manner