### PR TITLE
Do not fail when all articles retrieved have no revision

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,5 @@
 Unreleased:
+* FIX: Do not fail when all articles retrieved have no revision (@benoit74 #2346)
 
 1.15.0:
 * NEW: Check early for availability APIs + add check for module API (@benoit74 #2246 / #2248)

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -71,7 +71,11 @@ export async function getArticlesByIds(articleIds: string[], log = true): Promis
             )
           }
         }
-        const existingArticleDetails = await articleDetailXId.getMany(Object.keys(articleDetails))
+        const keys = Object.keys(articleDetails)
+        if (keys.length == 0) {
+          return
+        }
+        const existingArticleDetails = await articleDetailXId.getMany(keys)
         await articleDetailXId.setMany(deepmerge(existingArticleDetails, articleDetails))
       }
     },


### PR DESCRIPTION
Fix #1387 

Problem was that when retrieving articles by IDs, we then remove from the list the ones which have no revisions. Under rare occasions, we might end-up with an empty list. Code was then calling Redis to retrieve items matching this empty list ... which makes no sense.