### PR TITLE
Retry more transient errors

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -7,6 +7,7 @@ Unreleased:
 * FIX: Always use proper UserAgent and other shared http request settings (@benoit74 #2359)
 * FIX: Enhance login logs (@benoit74 #2362)
 * FIX: Properly store/reuse Cookies across HTTP calls (@benoit74 #2361)
+* FIX: Retry more transient errors (@benoit #2366)
 
 1.15.0:
 * NEW: Check early for availability APIs + add check for module API (@benoit74 #2246 / #2248)

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -198,6 +198,8 @@ class Downloader {
             'internal_api_error_DBConnectionError',
             'internal_api_error_DBUnexpectedError',
             'internal_api_error_Wikibase\\DataModel\\Services\\Lookup\\EntityLookupException',
+            'internal_api_error_Shellbox\\ShellboxError',
+            'internal_api_error_Wikimedia\\FileBackend\\FileBackendError',
           ].includes(err.responseData?.error?.code)
         ) {
           logger.log(`Retrying ${requestedUrl} URL due to ${err.responseData?.error?.code} Mediawiki error`)


### PR DESCRIPTION
internal_api_error_Shellbox\ShellboxError and
internal_api_error_Wikimedia\FileBackend\FileBackendError errors seems to be transient as well, let's retry them

Fix #2366 