### PR TITLE
Retrieve CSS from CSS-only gadgets automatically

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -8,6 +8,7 @@ Unreleased:
 * FIX: Ensure illustration metadata is really 48x48 even if source image is not square (@benoit74 #2368)
 * FIX: Also rewrite inline <style> tags found in article HTML (@benoit74 #1807)
 * FIX: Better RTL support (@Markus-Rost #1865 #2367)
+* CHANGED: Retrieve CSS from CSS-only gadgets automatically (@benoit74 #2212)
 
 1.15.1:
 * FIX: Do not fail when all articles retrieved have no revision (@benoit74 #2346)

--- a/res/templates/pageVector2022.html
+++ b/res/templates/pageVector2022.html
@@ -1,13 +1,21 @@
-<!DOCTYPE html>
-<html class="client-js" __ARTICLE_LANG_DIR__>
+<!doctype html>
+<html class="client-nojs" __ARTICLE_LANG_DIR__>
   <head>
-    <meta charset="UTF-8"/>
+    <meta charset="UTF-8" />
     <title></title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/> __ARTICLE_CANONICAL_LINK__ __ARTICLE_CSS_LIST__
-    <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH__footer.css">
-    <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH__vector-2022.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    __ARTICLE_CANONICAL_LINK__ __ARTICLE_CSS_BEFORE_META__
+    <meta name="ResourceLoaderDynamicStyles" content="" />
+    __ARTICLE_CSS_AFTER_META__
+    <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH__mw/site.styles.css" />
+    <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH__mw/noscript.css" />
+    <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH__footer.css" />
+    <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH__vector-2022.css" />
   </head>
-  <body class="skin--responsive skin-vector skin-vector-search-vue mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable skin-vector-2022 action-view uls-dialog-sticky-hide" cz-shortcut-listen="true">
+  <body
+    class="skin--responsive skin-vector skin-vector-search-vue mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable skin-vector-2022 action-view uls-dialog-sticky-hide"
+    cz-shortcut-listen="true"
+  >
     <div class="mw-page-container">
       <div class="mw-page-container-inner">
         <div class="mw-content-container">
@@ -24,8 +32,7 @@
           </main>
         </div>
       </div>
-    </div>    
-    __ARTICLE_CONFIGVARS_LIST__
-    __ARTICLE_JS_LIST__
+    </div>
+    __ARTICLE_CONFIGVARS_LIST__ __ARTICLE_JS_LIST__
   </body>
 </html>

--- a/res/templates/pageVectorLegacy.html
+++ b/res/templates/pageVectorLegacy.html
@@ -1,12 +1,16 @@
-<!DOCTYPE html>
-<html class="client-js" __ARTICLE_LANG_DIR__>
+<!doctype html>
+<html class="client-nojs" __ARTICLE_LANG_DIR__>
   <head>
     <meta charset="UTF-8" />
     <title></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    __ARTICLE_CANONICAL_LINK__ __ARTICLE_CSS_LIST__
-    <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH__footer.css">
-    <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH__vector.css">
+    __ARTICLE_CANONICAL_LINK__ __ARTICLE_CSS_BEFORE_META__
+    <meta name="ResourceLoaderDynamicStyles" content="" />
+    __ARTICLE_CSS_AFTER_META__
+    <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH__mw/site.styles.css" />
+    <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH__mw/noscript.css" />
+    <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH__footer.css" />
+    <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH__vector.css" />
   </head>
 
   <body

--- a/res/vector-2022.css
+++ b/res/vector-2022.css
@@ -3,13 +3,3 @@
   font-size: 1rem;
   line-height: 1.6;
 }
-
-/* Customize infobox on small screens, for some reason this seems to not be done automatically */
-@media screen {
-  @media (max-width: calc(639px)) {
-    table.infobox {
-      width: 100% !important;
-      display: table;
-    }
-  }
-}

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -133,7 +133,7 @@ class Downloader {
   private backoffOptions: BackoffOptions
   private optimisationCacheUrl: string
   private s3: S3
-  private apiUrlDirector: ApiURLDirector
+  private _apiUrlDirector: ApiURLDirector
   private cookierJar: CookieJar
 
   private articleUrlDirector: URLDirector
@@ -162,6 +162,9 @@ class Downloader {
   get streamRequestOptions() {
     return this._streamRequestOptions
   }
+  get apiUrlDirector() {
+    return this._apiUrlDirector
+  }
 
   set init({ uaString, speed, reqTimeout, optimisationCacheUrl, s3, webp, backoffOptions, insecure }: DownloaderOpts) {
     this.reset()
@@ -172,7 +175,7 @@ class Downloader {
     this.optimisationCacheUrl = optimisationCacheUrl
     this._webp = webp
     this.s3 = s3
-    this.apiUrlDirector = new ApiURLDirector(MediaWiki.actionApiUrl.href)
+    this._apiUrlDirector = new ApiURLDirector(MediaWiki.actionApiUrl.href)
     this.insecure = insecure
     this.cookierJar = new CookieJar()
 
@@ -268,7 +271,7 @@ class Downloader {
     this.optimisationCacheUrl = undefined
     this._webp = false
     this.s3 = undefined
-    this.apiUrlDirector = undefined
+    this._apiUrlDirector = undefined
     this.insecure = false
 
     this.backoffOptions = undefined

--- a/src/Gadgets.ts
+++ b/src/Gadgets.ts
@@ -1,0 +1,108 @@
+import Downloader from './Downloader.js'
+import * as logger from './Logger.js'
+import MediaWiki from './MediaWiki.js'
+
+class Gadgets {
+  private static instance: Gadgets
+  private gadgets: Gadget[] | undefined
+
+  public static getInstance() {
+    if (!Gadgets.instance) {
+      Gadgets.instance = new Gadgets()
+    }
+    return Gadgets.instance
+  }
+
+  public async fetchGadgets() {
+    const gadgetsUrl = Downloader.apiUrlDirector.buildGadgetsUrl()
+    const gadgetsResponse = await Downloader.getJSON<GadgetQueryResult>(gadgetsUrl)
+    if (!gadgetsResponse.batchcomplete) {
+      throw new Error(`Error while fetching gadgets with ${gadgetsUrl}, batch seems to be incomplete, scraper does not expect/support pagination here`)
+    }
+    this.gadgets = gadgetsResponse.query?.gadgets
+    logger.info(this.gadgets === undefined ? 'Gadgets are not supported on this wiki' : `${this.gadgets.length} gadgets retrieved`)
+  }
+
+  /*
+   * Get list of gadgets which are not listed on action=parse results
+   */
+  public getActiveGadgetsByType(articleDetail: ArticleDetail) {
+    const cssGadgets = []
+    const jsGadgets = []
+
+    const activeGadgets = (this.gadgets || []).filter((gadget) => {
+      const settings = gadget.metadata.settings
+      if (settings.skins && settings.skins.length && !settings.skins.includes(MediaWiki.skin)) return false
+      if (settings.actions && settings.actions.length && !settings.actions.includes('view')) return false
+      if (settings.namespaces && settings.namespaces.length && !settings.namespaces.includes(articleDetail.ns || 0)) return false
+      if (settings.contentModels && settings.contentModels.length && !settings.contentModels.includes(articleDetail.contentmodel || 'wikitext')) return false
+      return true
+    })
+
+    activeGadgets.map((gadget) => {
+      const module = gadget.metadata.module
+      if (module.peers && module.peers.length) {
+        // Only JS Gadgets can have peers
+        cssGadgets.concat(module.peers)
+        return jsGadgets.push(gadget.id)
+      }
+      if (module.scripts && module.scripts.length) return jsGadgets.push(gadget.id)
+      if (module.dependencies && module.dependencies.length) return jsGadgets.push(gadget.id)
+      if (module.datas && module.datas.length) return jsGadgets.push(gadget.id)
+      if (module.messages && module.messages.length) return jsGadgets.push(gadget.id)
+      // Anything left now is a CSS-only Gagdet
+      if (module.styles && module.styles.length) return cssGadgets.push(gadget.id)
+    })
+
+    return { cssGadgets, jsGadgets }
+  }
+}
+
+export interface GadgetQueryResult {
+  batchcomplete: boolean
+  query: Query
+}
+
+export interface Query {
+  gadgets: Gadget[]
+}
+
+export interface Gadget {
+  id: string
+  metadata: Metadata
+}
+
+export interface Metadata {
+  settings: Settings
+  module: Module
+}
+
+export interface Settings {
+  rights: string[]
+  skins: string[]
+  actions: string[]
+  namespaces: number[]
+  contentModels: string[]
+  default: boolean
+  hidden: boolean
+  package: boolean
+  shared: boolean
+  category: string
+  legacyscripts: boolean
+  requiresES6: boolean
+  supportsUrlLoad: boolean
+}
+
+export interface Module {
+  scripts: string[]
+  styles: string[]
+  datas: string[]
+  dependencies: string[]
+  peers: string[]
+  messages: string[]
+}
+
+export { Gadgets as GadgetsClass }
+
+const gadgets = Gadgets.getInstance()
+export default gadgets as Gadgets

--- a/src/config.ts
+++ b/src/config.ts
@@ -96,10 +96,7 @@ const config = {
         'ext.gadget.VisibilityToggles',
         'ext.gadget.defaultVisibilityToggles',
       ],
-      css_simplified: [
-        // infobox styles needed at least on hu.wikipedia.org
-        'ext.gadget.infobox,wikiMenuStyles',
-      ],
+      css_simplified: [],
       js_simplified: [
         // base JS scripts always needed / never returned on API calls
         'startup',

--- a/src/config.ts
+++ b/src/config.ts
@@ -96,7 +96,10 @@ const config = {
         'ext.gadget.VisibilityToggles',
         'ext.gadget.defaultVisibilityToggles',
       ],
-      css_simplified: [],
+      css_simplified: [
+        'site.styles', // always needed
+        'noscript', // recommended until we solve https://github.com/openzim/mwoffliner/issues/2310
+      ],
       js_simplified: [
         // base JS scripts always needed / never returned on API calls
         'startup',

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -49,6 +49,7 @@ import { Dump } from './Dump.js'
 import { config } from './config.js'
 import MediaWiki from './MediaWiki.js'
 import Downloader from './Downloader.js'
+import Gadgets from './Gadgets.js'
 import RenderingContext from './renderers/rendering.context.js'
 import { articleListHomeTemplate } from './Templates.js'
 import { downloadFiles, saveArticles } from './util/saveArticles.js'
@@ -428,6 +429,9 @@ async function execute(argv: any) {
 
     logger.log('Checking Main Page rendering')
     await getMainPage(dump, true, zimCreator)
+
+    logger.log('Getting gadgets')
+    await Gadgets.fetchGadgets()
 
     logger.log('Getting articles')
     stime = Date.now()

--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -49,9 +49,15 @@ export interface DownloadRes {
   redirects: Redirect[]
 }
 
+export interface RenderOptsModules {
+  jsConfigVars: string
+  jsDependenciesList: string[]
+  styleDependenciesList: string[]
+}
+
 export interface RenderOpts {
   data?: any
-  moduleDependencies: any
+  moduleDependencies: RenderOptsModules
   articleId?: string
   articleDetailXId?: RKVS<ArticleDetail>
   articleDetail?: ArticleDetail

--- a/src/renderers/action-parse.renderer.ts
+++ b/src/renderers/action-parse.renderer.ts
@@ -31,17 +31,28 @@ export class ActionParseRenderer extends Renderer {
     const articleConfigVarsList = jsConfigVars === '' ? '' : genHeaderScript(config, 'jsConfigVars', articleId, config.output.dirs.mediawiki)
     const articleJsList =
       jsDependenciesList.length === 0 ? '' : jsDependenciesList.map((oneJsDep: string) => genHeaderScript(config, oneJsDep, articleId, config.output.dirs.mediawiki)).join('\n')
-    const articleCssList =
-      styleDependenciesList.length === 0
-        ? ''
-        : styleDependenciesList.map((oneCssDep: string) => genHeaderCSSLink(config, oneCssDep, articleId, config.output.dirs.mediawiki)).join('\n')
+    const articleCssBeforeMeta = styleDependenciesList
+      .filter((oneCssDep: string) => {
+        return !oneCssDep.startsWith('ext.gadget') && !['site.styles', 'noscript'].includes(oneCssDep)
+      })
+      .sort()
+      .map((oneCssDep: string) => genHeaderCSSLink(config, oneCssDep, articleId, config.output.dirs.mediawiki))
+      .join('\n    ')
+    const articleCssAfterMeta = styleDependenciesList
+      .filter((oneCssDep: string) => {
+        return oneCssDep.startsWith('ext.gadget')
+      })
+      .sort()
+      .map((oneCssDep: string) => genHeaderCSSLink(config, oneCssDep, articleId, config.output.dirs.mediawiki))
+      .join('\n    ')
 
     const htmlTemplateString = htmlTemplateCode()
       .replace(/__ARTICLE_LANG_DIR__/g, articleLangDir)
       .replace('__ARTICLE_CANONICAL_LINK__', genCanonicalLink(config, MediaWiki.webUrl.href, articleId))
       .replace('__ARTICLE_CONFIGVARS_LIST__', articleConfigVarsList)
       .replace('__ARTICLE_JS_LIST__', articleJsList)
-      .replace('__ARTICLE_CSS_LIST__', articleCssList)
+      .replace('__ARTICLE_CSS_BEFORE_META__', articleCssBeforeMeta)
+      .replace('__ARTICLE_CSS_AFTER_META__', articleCssAfterMeta)
       .replace(/__RELATIVE_FILE_PATH__/g, getRelativeFilePath(articleId, ''))
 
     return domino.createDocument(htmlTemplateString)

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -39,6 +39,7 @@ type ArticleDetail = PageInfo & {
   missing?: string
   pagelang?: string
   pagedir?: TextDirection
+  contentmodel?: string
 }
 
 type FileDetail = {
@@ -112,6 +113,7 @@ interface QueryRet {
   redirects?: QueryRedirectsRet
   pagelanguagehtmlcode?: string
   pagelanguagedir?: TextDirection
+  contentmodel: string
 
   thumbnail?: {
     source: string

--- a/src/util/builders/url/api.director.ts
+++ b/src/util/builders/url/api.director.ts
@@ -55,4 +55,11 @@ export default class ApiURLDirector {
       .setQueryParams({ action: 'parse', format: 'json', prop: 'modules|jsconfigvars|headhtml', formatversion: '2', page: articleId })
       .build()
   }
+
+  buildGadgetsUrl() {
+    return urlBuilder
+      .setDomain(this.baseDomain)
+      .setQueryParams({ action: 'query', list: 'gadgets', gaprop: 'id|metadata', gaallowedonly: '1', gaenabledonly: '1', format: 'json', formatversion: '2' })
+      .build()
+  }
 }

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -291,6 +291,7 @@ export function mwRetToArticleDetail(obj: QueryMwRet): KVS<ArticleDetail> {
       pagelang: val.pagelanguagehtmlcode,
       pagedir: val.pagelanguagedir,
       ...(val.ns !== 0 ? { ns: val.ns } : {}),
+      ...(val.contentmodel !== 'wikitext' ? { contentmodel: val.contentmodel } : {}),
       ...(rev ? { revisionId: rev.revid, timestamp: rev.timestamp } : {}),
       ...(geo ? { coordinates: `${geo.lat};${geo.lon}` } : {}),
     }

--- a/test/e2e/cssModules.e2e.test.ts
+++ b/test/e2e/cssModules.e2e.test.ts
@@ -1,0 +1,61 @@
+import { testRenders } from '../testRenders.js'
+import domino from 'domino'
+import { zimdump, zimcheck } from '../util.js'
+import 'dotenv/config.js'
+import { jest } from '@jest/globals'
+import { rimraf } from 'rimraf'
+
+jest.setTimeout(60000)
+
+const parameters = {
+  mwUrl: 'https://de.wikipedia.org',
+  articleList: 'Monty_Python’s_Flying_Circus', // use article with a slash in its name to check relative links are properly handled
+  adminEmail: 'test@kiwix.org',
+}
+
+await testRenders(
+  'cssModules',
+  parameters,
+  async (outFiles) => {
+    const articleFromDump = await zimdump(`show --url "${parameters.articleList.replace(' ', '_')}" ${outFiles[0].outFile}`)
+    const window = domino.createWindow(articleFromDump)
+    const articleDoc = window.document
+    // @ts-expect-error Node is not defined but does exists
+    const Node = window.Node
+
+    test(`test ZIM integrity for ${outFiles[0]?.renderer} renderer`, async () => {
+      await expect(zimcheck(outFiles[0].outFile)).resolves.not.toThrowError()
+    })
+
+    test(`test preceding modules for ${outFiles[0]?.renderer} renderer`, async () => {
+      const module = articleDoc.querySelector('link[rel="stylesheet"][href="./mw/ext.cite.parsoid.styles.css"]')
+      const meta = articleDoc.querySelector('meta[name="ResourceLoaderDynamicStyles"]')
+      expect(module).toBeTruthy()
+      expect(meta).toBeTruthy()
+      expect(meta.compareDocumentPosition(module) & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy()
+    })
+
+    test(`test following modules for ${outFiles[0]?.renderer} renderer`, async () => {
+      const module = articleDoc.querySelector('link[rel="stylesheet"][href="./mw/ext.gadget.citeRef.css"]')
+      const meta = articleDoc.querySelector('meta[name="ResourceLoaderDynamicStyles"]')
+      expect(module).toBeTruthy()
+      expect(meta).toBeTruthy()
+      expect(meta.compareDocumentPosition(module) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+
+    test(`test site.styles position for ${outFiles[0]?.renderer} renderer`, async () => {
+      const gadgetModule = articleDoc.querySelector('link[rel="stylesheet"][href="./mw/ext.gadget.citeRef.css"]')
+      const siteStylesModule = articleDoc.querySelector('link[rel="stylesheet"][href="./mw/site.styles.css"]')
+      expect(gadgetModule).toBeTruthy()
+      expect(siteStylesModule).toBeTruthy()
+      expect(siteStylesModule.compareDocumentPosition(gadgetModule) & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy()
+    })
+
+    afterAll(() => {
+      if (!process.env.KEEP_ZIMS) {
+        rimraf.sync(`./${outFiles[0].testId}`)
+      }
+    })
+  },
+  ['ActionParse'],
+)


### PR DESCRIPTION
Fix #2212 

Until https://phabricator.wikimedia.org/T161278 is solved, we implement this workaround to automatically add CSS-only gadget modules to appropriate  pages. This is done in a way which is compatible with T161278 being solved, i.e. the scraper will still behave correctly once this issue is solved upstream.

Changes:
- at scraper begin, retrieve list of all gadgets and store it in memory
- use this list to add more style modules to download / add to the article HTML based on article properties
- these new modules are then automatically downloaded just like any style module
- remove "hacks" which are not needed anymore now that everything is automatically retrieved (only in ActionParse renderer, details of other hacks are too unknown

Other more or less related changed:
- stop passing `debug=true` when fetching modules, this causes bigger than necessary CSS/JS
- stop passing `lang=en` when fetching modules, this is wrong on all non-EN wikis ; using default is assumed to be more correct
- stop passing weird `version=&*` which seems unnecessary and only causing confusion
- request `info` when fetching list of articles by NS, so that we can have their `contentmodel`

Nota: inclusion of a gadget on a specific article page can be restricted based on article namespace and contentmodel. Code has been adapted to take this into account, but this has not been tested in the wild with a real gadget really applying only to one namespace or one module, since I don't know where to find them. Should a bug appear, the fix will anyway be minimal. In most cases, gadgets apply to all namespace and all contentmodel, and this works fine.