### PR TITLE
Better RTL support

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -7,6 +7,7 @@ Unreleased:
 * FIX: Fix/simplify retrieval of siteinfo metadata (@benoit74 #2328)
 * FIX: Ensure illustration metadata is really 48x48 even if source image is not square (@benoit74 #2368)
 * FIX: Also rewrite inline <style> tags found in article HTML (@benoit74 #1807)
+* FIX: Better RTL support (@Markus-Rost #1865 #2367)
 
 1.15.1:
 * FIX: Do not fail when all articles retrieved have no revision (@benoit74 #2346)

--- a/res/templates/pageVector2022.html
+++ b/res/templates/pageVector2022.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class='client-js'>
+<html class="client-js" __ARTICLE_LANG_DIR__>
   <head>
     <meta charset="UTF-8"/>
     <title></title>

--- a/res/templates/pageVectorLegacy.html
+++ b/res/templates/pageVectorLegacy.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="client-js">
+<html class="client-js" __ARTICLE_LANG_DIR__>
   <head>
     <meta charset="UTF-8" />
     <title></title>
@@ -15,9 +15,9 @@
   >
     <div id="content" class="mw-body" role="main">
       <a id="top"></a>
-      <h1 id="firstHeading" class="firstHeading" lang="en"><span id="openzim-page-title"></span></h1>
-      <div id="bodyContent" class="mw-body-content">
-        <div id="mw-content-text" lang="en" dir="ltr" class="mw-content-ltr"></div>
+      <h1 id="firstHeading" class="firstHeading" __ARTICLE_LANG_DIR__><span id="openzim-page-title"></span></h1>
+      <div id="bodyContent" class="vector-body">
+        <div id="mw-content-text" class="mw-body-content"></div>
       </div>
     </div>
     __ARTICLE_CONFIGVARS_LIST__ __ARTICLE_JS_LIST__

--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -507,8 +507,11 @@ export abstract class Renderer {
     articleId: string,
   ) {
     /* Create final document by merging template and parsoid documents */
-    htmlTemplateDoc.getElementById('mw-content-text').style.setProperty('direction', dump.mwMetaData.textDir)
-    htmlTemplateDoc.getElementById('mw-content-text').innerHTML = parsoidDoc.getElementsByTagName('body')[0].innerHTML
+    const mwContentText = htmlTemplateDoc.getElementById('mw-content-text')
+    mwContentText.lang = articleDetail.pagelang
+    mwContentText.dir = articleDetail.pagedir
+    mwContentText.classList.add('mw-content-' + articleDetail.pagedir)
+    mwContentText.innerHTML = parsoidDoc.getElementsByTagName('body')[0].innerHTML
 
     /* Title */
     const articleTitle = htmlTemplateDoc.getElementById('title_0') ? htmlTemplateDoc.getElementById('title_0').textContent : articleId.replace(/_/g, ' ')

--- a/src/renderers/action-parse.renderer.ts
+++ b/src/renderers/action-parse.renderer.ts
@@ -30,6 +30,7 @@ export class ActionParseRenderer extends Renderer {
       throw new Error(`Skin ${MediaWiki.skin} is not supported by ActionParse renderer`)
     }
 
+    const articleLangDir = `lang="${MediaWiki.metaData?.langMw || 'en'}" dir="${MediaWiki.metaData?.textDir || 'ltr'}"`
     const articleConfigVarsList = jsConfigVars === '' ? '' : genHeaderScript(config, 'jsConfigVars', articleId, config.output.dirs.mediawiki)
     const articleJsList =
       jsDependenciesList.length === 0 ? '' : jsDependenciesList.map((oneJsDep: string) => genHeaderScript(config, oneJsDep, articleId, config.output.dirs.mediawiki)).join('\n')
@@ -39,6 +40,7 @@ export class ActionParseRenderer extends Renderer {
         : styleDependenciesList.map((oneCssDep: string) => genHeaderCSSLink(config, oneCssDep, articleId, config.output.dirs.mediawiki)).join('\n')
 
     const htmlTemplateString = htmlTemplateCode()
+      .replace(/__ARTICLE_LANG_DIR__/g, articleLangDir)
       .replace('__ARTICLE_CANONICAL_LINK__', genCanonicalLink(config, MediaWiki.webUrl.href, articleId))
       .replace('__ARTICLE_CONFIGVARS_LIST__', articleConfigVarsList)
       .replace('__ARTICLE_JS_LIST__', articleJsList)

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -37,6 +37,8 @@ type ArticleDetail = PageInfo & {
   nextArticleId?: string
   prevArticleId?: string
   missing?: string
+  pagelang?: string
+  pagedir?: TextDirection
 }
 
 type FileDetail = {
@@ -108,6 +110,8 @@ interface QueryRet {
   revisions?: QueryRevisionsRet
   coordinates?: QueryCoordinatesRet
   redirects?: QueryRedirectsRet
+  pagelanguagehtmlcode?: string
+  pagelanguagedir?: TextDirection
 
   thumbnail?: {
     source: string
@@ -158,6 +162,7 @@ interface MWMetaData {
   creator: string
   mainPage: string
   textDir: TextDirection
+  langMw: string
   logo: string
 
   baseUrl: string

--- a/src/util/dump.ts
+++ b/src/util/dump.ts
@@ -90,6 +90,7 @@ export async function downloadModule(module: string, type: 'js' | 'css') {
     )
   }
 
+  const langMw = MediaWiki.metaData?.langMw || 'en'
   let apiParameterOnly
   let moduleApiUrl: string
   if (type === 'js') {
@@ -99,7 +100,7 @@ export async function downloadModule(module: string, type: 'js' | 'css') {
   }
 
   if (!module.includes('javascript/mobile') && !module.includes('css/mobile')) {
-    moduleApiUrl = encodeURI(`${MediaWiki.modulePath}debug=true&lang=en&modules=${module}&only=${apiParameterOnly}&skin=${MediaWiki.skin}&version=&*`)
+    moduleApiUrl = encodeURI(`${MediaWiki.modulePath}lang=${langMw}&modules=${module}&only=${apiParameterOnly}&skin=${MediaWiki.skin}`)
   } else {
     moduleApiUrl = encodeURI(`https:${module}`)
   }

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -288,6 +288,8 @@ export function mwRetToArticleDetail(obj: QueryMwRet): KVS<ArticleDetail> {
       subCategories: val.subCategories,
       thumbnail: newThumbnail,
       missing: val.missing,
+      pagelang: val.pagelanguagehtmlcode,
+      pagedir: val.pagelanguagedir,
       ...(val.ns !== 0 ? { ns: val.ns } : {}),
       ...(rev ? { revisionId: rev.revid, timestamp: rev.timestamp } : {}),
       ...(geo ? { coordinates: `${geo.lat};${geo.lon}` } : {}),

--- a/test/unit/util/dump.test.ts
+++ b/test/unit/util/dump.test.ts
@@ -21,10 +21,10 @@ describe('Download CSS or JS Module', () => {
     const { text: content, moduleApiUrl } = await downloadModule('skins.vector.styles', 'css')
 
     // URL expected to be used to retrieve CSS module
-    expect(moduleApiUrl).toBe('https://en.wikipedia.org/w/load.php?debug=true&lang=en&modules=skins.vector.styles&only=styles&skin=vector&version=&*')
+    expect(moduleApiUrl).toBe('https://en.wikipedia.org/w/load.php?lang=en&modules=skins.vector.styles&only=styles&skin=vector')
 
     // Check if CSS module still contain this background image
-    expect(content).toContain(`background-image: url(link.ernal-small-ltr-progressive.svg`)
+    expect(content).toContain(`background-image:url(link.ernal-small-ltr-progressive.svg`)
 
     // One SVG (among others) expected to be used inside the CSS
     expect(Object.keys(Downloader.cssDependenceUrls)).toContain(
@@ -34,7 +34,7 @@ describe('Download CSS or JS Module', () => {
 
   test('rewrite standalone CSS', async () => {
     const rewrittenCSS = processStylesheetContent(
-      'https://en.wikipedia.org/w/load.php?debug=true&lang=en&modules=skins.vector.styles&only=styles&skin=vector&version=&*',
+      'https://en.wikipedia.org/w/load.php?lang=en&modules=skins.vector.styles&only=styles&skin=vector',
       '',
       'a.external { background-image: url(/w/skins/Vector/resources/skins.vector.styles/images/link-external-small-ltr-progressive.svg?fb64d)); }',
       '',
@@ -49,7 +49,7 @@ describe('Download CSS or JS Module', () => {
 
   test('rewrite inline CSS with relative path', async () => {
     const rewrittenCSS = processStylesheetContent(
-      'https://en.wikipedia.org/w/load.php?debug=true&lang=en&modules=skins.vector.styles&only=styles&skin=vector&version=&*',
+      'https://en.wikipedia.org/w/load.php?lang=en&modules=skins.vector.styles&only=styles&skin=vector',
       '',
       'a.external { background-image: url(/w/skins/Vector/resources/skins.vector.styles/images/link-external-small-ltr-progressive.svg?fb64d)); }',
       'article/with/slashes',
@@ -64,7 +64,7 @@ describe('Download CSS or JS Module', () => {
 
   test('rewrite inline CSS with absolute path', async () => {
     const rewrittenCSS = processStylesheetContent(
-      'https://en.wikipedia.org/w/load.php?debug=true&lang=en&modules=skins.vector.styles&only=styles&skin=vector&version=&*',
+      'https://en.wikipedia.org/w/load.php?lang=en&modules=skins.vector.styles&only=styles&skin=vector',
       '',
       'a.external { background-image: url(//upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/64px-Commons-logo.svg.png)); }',
       'articleTitle',


### PR DESCRIPTION
Set the proper `lang=` and `dir=` attributes as well as the correct `mw-content-ltr/rtl` class in the HTML. 

Load modules using the actual default language of the wiki (this includes the parameter changes from #2375)

Fix #2367
Fix #1895