### PR TITLE
Fetch article <html> and <body> CSS class from headhtml response 

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -17,6 +17,7 @@ Unreleased:
 * FIX: Use correct license and creator name in the footer (@Markus-Rost #2344 #2345)
 * FIX: Implement fallback index page names to avoid conflicts with articles (@benoit74 #2335)
 * CHANGED: Use wiki default parser instead of forcing Parsoid with ActionParse (@Markus-Rost #2391)
+* CHANGED: Fetch article <html> and <body> CSS class from headhtml response of the action=parse request (@benoit74 #2356)
 
 1.15.1:
 * FIX: Do not fail when all articles retrieved have no revision (@benoit74 #2346)

--- a/res/templates/pageVector2022.html
+++ b/res/templates/pageVector2022.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="client-nojs" __ARTICLE_LANG_DIR__>
+<html class="__ARTICLE_HTML_CSS_CLASS__" __ARTICLE_LANG_DIR__>
   <head>
     <meta charset="UTF-8" />
     <title></title>
@@ -12,10 +12,7 @@
     <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH__footer.css" />
     <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH__vector-2022.css" />
   </head>
-  <body
-    class="skin--responsive skin-vector skin-vector-search-vue mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable skin-vector-2022 action-view uls-dialog-sticky-hide"
-    cz-shortcut-listen="true"
-  >
+  <body class="__ARTICLE_BODY_CSS_CLASS__">
     <div class="mw-page-container">
       <div class="mw-page-container-inner">
         <div class="mw-content-container">

--- a/res/templates/pageVectorLegacy.html
+++ b/res/templates/pageVectorLegacy.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="client-nojs" __ARTICLE_LANG_DIR__>
+<html class="__ARTICLE_HTML_CSS_CLASS__" __ARTICLE_LANG_DIR__>
   <head>
     <meta charset="UTF-8" />
     <title></title>
@@ -13,10 +13,7 @@
     <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH__vector.css" />
   </head>
 
-  <body
-    class="mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable skin-vector action-view minerva--history-page-action-enabled skin-vector-legacy"
-    cz-shortcut-listen="true"
-  >
+  <body class="__ARTICLE_BODY_CSS_CLASS__">
     <div id="content" class="mw-body" role="main">
       <a id="top"></a>
       <h1 id="firstHeading" class="firstHeading" __ARTICLE_LANG_DIR__><span id="openzim-page-title"></span></h1>

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -444,7 +444,6 @@ class Downloader {
     articleUrl,
     dump: Dump,
     articleDetail?: ArticleDetail,
-    isMainPage?: boolean,
   ): Promise<any> {
     logger.info(`Getting article [${articleId}] from ${articleUrl}`)
 
@@ -474,7 +473,6 @@ class Downloader {
         articleDetailXId,
         articleDetail,
         displayTitle,
-        isMainPage,
         dump,
       })
     } catch (err) {

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -448,7 +448,7 @@ class Downloader {
     logger.info(`Getting article [${articleId}] from ${articleUrl}`)
 
     try {
-      const { data, moduleDependencies, redirects, displayTitle } = await articleRenderer.download({
+      const { data, moduleDependencies, redirects, displayTitle, bodyCssClass, htmlCssClass } = await articleRenderer.download({
         articleId,
         articleUrl,
         articleDetail,
@@ -473,6 +473,8 @@ class Downloader {
         articleDetailXId,
         articleDetail,
         displayTitle,
+        bodyCssClass,
+        htmlCssClass,
         dump,
       })
     } catch (err) {

--- a/src/Dump.ts
+++ b/src/Dump.ts
@@ -35,9 +35,6 @@ export class Dump {
   public strings: KVS<string>
   public mwMetaData: MWMetaData
   public outFile: string
-  public isMainPage = (articleId: string): boolean => {
-    return this.mwMetaData.mainPage === articleId ? true : false
-  }
   public maxHardFailedArticles: number = 0
   public status = {
     files: {

--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -12,6 +12,7 @@ import { rewriteUrlsOfDoc } from '../util/rewriteUrls.js'
 import { footerTemplate } from '../Templates.js'
 import { getFullUrl, getMediaBase, getRelativeFilePath, interpolateTranslationString, encodeArticleIdForZimHtmlUrl, getStaticFiles } from '../util/misc.js'
 import { processStylesheetContent } from '../util/dump.js'
+import { isMainPage, isSubpage } from '../util/articles.js'
 
 type renderType = 'auto' | 'desktop' | 'mobile' | 'specific'
 export type renderName = 'VisualEditor' | 'WikimediaDesktop' | 'WikimediaMobile' | 'RestApi' | 'ActionParse'
@@ -63,7 +64,6 @@ export interface RenderOpts {
   articleDetailXId?: RKVS<ArticleDetail>
   articleDetail?: ArticleDetail
   displayTitle?: string
-  isMainPage?: boolean
   dump: Dump
 }
 
@@ -471,7 +471,7 @@ export abstract class Renderer {
         }),
     )
 
-    if (!dump.isMainPage(articleId) && dump.customProcessor?.preProcessArticle) {
+    if (!isMainPage(articleId) && dump.customProcessor?.preProcessArticle) {
       doc = await dump.customProcessor.preProcessArticle(articleId, doc)
     }
 
@@ -533,7 +533,7 @@ export abstract class Renderer {
     DOMUtils.deleteNode(htmlTemplateDoc.getElementById('titleHeading'))
 
     /* Subpage */
-    if (this.isSubpage(articleId) && !dump.isMainPage(articleId)) {
+    if (isSubpage(articleId) && !isMainPage(articleId)) {
       const headingNode = htmlTemplateDoc.getElementById('mw-content-text')
       const subpagesNode = htmlTemplateDoc.createElement('span')
       const parents = articleId.split('/')

--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -49,6 +49,8 @@ export interface DownloadRes {
   moduleDependencies: any
   redirects: Redirect[]
   displayTitle?: string
+  bodyCssClass?: string
+  htmlCssClass?: string
 }
 
 export interface RenderOptsModules {
@@ -64,6 +66,8 @@ export interface RenderOpts {
   articleDetailXId?: RKVS<ArticleDetail>
   articleDetail?: ArticleDetail
   displayTitle?: string
+  bodyCssClass?: string
+  htmlCssClass?: string
   dump: Dump
 }
 
@@ -600,17 +604,6 @@ export abstract class Renderer {
   private addNoIndexCommentToElement(element: DominoElement) {
     const slices = element.parentElement.innerHTML.split(element.outerHTML)
     element.parentElement.innerHTML = `${slices[0]}<!--htdig_noindex-->${element.outerHTML}<!--/htdig_noindex-->${slices[1]}`
-  }
-
-  private isSubpage(id: string) {
-    if (id && id.indexOf('/') >= 0) {
-      const namespace = id.indexOf(':') >= 0 ? id.substring(0, id.indexOf(':')) : ''
-      const ns = MediaWiki.namespaces[namespace] // namespace already defined
-      if (ns !== undefined) {
-        return ns.allowedSubpages
-      }
-    }
-    return false
   }
 
   private clearLinkAndInputTags(parsoidDoc: DominoElement, filtersConfig: any, dump: Dump) {

--- a/src/renderers/rest-api.renderer.ts
+++ b/src/renderers/rest-api.renderer.ts
@@ -2,6 +2,7 @@ import domino from 'domino'
 import { DesktopRenderer } from './abstractDesktop.render.js'
 import { getStrippedTitleFromHtml } from '../util/misc.js'
 import { RenderOpts, RenderOutput } from './abstract.renderer.js'
+import { isMainPage } from '../util/articles.js'
 
 // Represent 'https://{wikimedia-wiki}/api/rest.php/v1/page/html/'
 export class RestApiRenderer extends DesktopRenderer {
@@ -34,7 +35,7 @@ export class RestApiRenderer extends DesktopRenderer {
 
   public async render(renderOpts: RenderOpts): Promise<any> {
     const result: RenderOutput = []
-    const { data, articleId, articleDetailXId, moduleDependencies, isMainPage, dump } = renderOpts
+    const { data, articleId, articleDetailXId, moduleDependencies, dump } = renderOpts
 
     /* istanbul ignore if */
     if (!data) {
@@ -49,7 +50,7 @@ export class RestApiRenderer extends DesktopRenderer {
     for (let i = 0; i < numberOfPagesToSplitInto; i++) {
       const { strippedTitle, _articleId } = await this.retrieveHtml(data, i, articleId, articleDetail, numberOfPagesToSplitInto, articleDetailXId)
       let dataWithHeader = ''
-      if (!isMainPage) {
+      if (!isMainPage(articleId)) {
         dataWithHeader = super.injectH1TitleToHtml(data, articleDetail)
       }
       const { finalHTML, mediaDependencies, videoDependencies, imageDependencies, subtitles } = await super.processHtml(

--- a/src/renderers/visual-editor.renderer.ts
+++ b/src/renderers/visual-editor.renderer.ts
@@ -4,6 +4,7 @@ import { DesktopRenderer } from './abstractDesktop.render.js'
 import { getStrippedTitleFromHtml } from '../util/misc.js'
 import { RenderOpts, RenderOutput } from './abstract.renderer.js'
 import { DownloadError } from '../Downloader.js'
+import { isMainPage } from '../util/articles.js'
 
 /*
 Relies on VisualEditor API typically looking like 'https://{wiki-host}/w/api.php?action=visualeditor&mobileformat=html&format=json&paction=parse&page={title}'
@@ -14,7 +15,7 @@ export class VisualEditorRenderer extends DesktopRenderer {
   }
 
   private async retrieveHtml(renderOpts: RenderOpts): Promise<any> {
-    const { data, articleId, articleDetail, isMainPage } = renderOpts
+    const { data, articleId, articleDetail } = renderOpts
 
     /* istanbul ignore if */
     if (!data) {
@@ -31,7 +32,7 @@ export class VisualEditorRenderer extends DesktopRenderer {
         logger.error(DELETED_ARTICLE_ERROR)
         throw new DownloadError(DELETED_ARTICLE_ERROR, null, null, null, DELETED_ARTICLE_ERROR)
       }
-      html = isMainPage ? data.visualeditor.content : super.injectH1TitleToHtml(data.visualeditor.content, articleDetail)
+      html = isMainPage(articleId) ? data.visualeditor.content : super.injectH1TitleToHtml(data.visualeditor.content, articleDetail)
       strippedTitle = getStrippedTitleFromHtml(html)
       displayTitle = strippedTitle || articleId.replace('_', ' ')
       return { html, displayTitle }

--- a/src/util/articles.ts
+++ b/src/util/articles.ts
@@ -1,0 +1,80 @@
+import MediaWiki from '../MediaWiki.js'
+import * as domino from 'domino'
+
+/**
+ * Check if a given article title or id is main page of the target ZIM
+ */
+export function isMainPage(articleTitleOrId: string): boolean {
+  return MediaWiki.metaData.mainPage === articleTitleOrId || MediaWiki.metaData.mainPage === articleTitleOrId.replace(/ /g, '_')
+}
+
+/**
+ * Check if a given article title or id is a subpage or not
+ *
+ * A given is a subpage if subpages are activated on its namespace and it contains a / in its title/id
+ */
+export function isSubpage(articleTitleOrId: string) {
+  if (articleTitleOrId && articleTitleOrId.indexOf('/') >= 0) {
+    if (articleTitleOrId.indexOf(':') < 0) {
+      // namespace 0 never allows subpages
+      return false
+    }
+    const namespace = articleTitleOrId.substring(0, articleTitleOrId.indexOf(':'))
+    const ns = MediaWiki.namespaces[namespace]
+    if (ns !== undefined) {
+      return ns.allowedSubpages
+    }
+  }
+  return false
+}
+
+/**
+ * For a given namespace number, get the namespace name
+ */
+export function getNamespaceName(namespace: number) {
+  return Object.entries(MediaWiki.namespaces).find(([, data]) => data.num === namespace)?.[0]
+}
+
+/**
+ * Extract the CSS class to apply on article <body> tag from its headHtml, typically returned by MW API call when fetching article content
+ */
+export function extractBodyCssClass(headHtml: string): string {
+  const document = domino.createDocument(headHtml)
+  let cssClass = document.body.className
+  // drop some known classes which do not makes sense in a ZIM
+  for (const blacklistedClass of ['mw-editable']) {
+    cssClass = cssClass.replace(blacklistedClass, '')
+  }
+  // drop repetitions of two spaces
+  return cssClass
+    .split(' ')
+    .filter((cssClass) => cssClass)
+    .join(' ')
+}
+
+/**
+ * Extract the CSS class to apply on article <html> tag from its headHtml, typically returned by MW API call when fetching article content
+ */
+export function extractHtmlCssClass(headHtml: string): string {
+  const document = domino.createDocument(headHtml)
+  let cssClass = document.documentElement.className
+  // drop some known classes:
+  // - client-js / client-nojs: scraper will add proper class on its own
+  // - vector-feature-night-mode-xxx and skin-theme-clientpref-xxx : scraper will add proper class on its own once dark mode is supported
+  for (const blacklistedClass of [
+    'client-js',
+    'client-nojs',
+    'vector-feature-night-mode-disabled',
+    'vector-feature-night-mode-enabled',
+    'skin-theme-clientpref-day',
+    'skin-theme-clientpref-night',
+    'skin-theme-clientpref-os',
+  ]) {
+    cssClass = cssClass.replace(blacklistedClass, '')
+  }
+  // drop repetitions of two spaces
+  return cssClass
+    .split(' ')
+    .filter((cssClass) => cssClass)
+    .join(' ')
+}

--- a/test/e2e/en.e2e.test.ts
+++ b/test/e2e/en.e2e.test.ts
@@ -37,6 +37,52 @@ await testAllRenders('en-wikipedia', parameters, async (outFiles) => {
     test(`test article header for ${outFiles[0]?.renderer} renderer`, async () => {
       expect(articleDoc.querySelector('h1.firstHeading > span#openzim-page-title, h1.article-header, h1.pcs-edit-section-title')).toBeTruthy()
     })
+
+    test(`test article <body> CSS class for ${outFiles[0]?.renderer} renderer`, async () => {
+      // This is implemented correctly only with ActionParse renderer for now
+      if (outFiles[0]?.renderer !== 'ActionParse') {
+        return
+      }
+      const expectedClasses = [
+        'action-view',
+        'ltr',
+        'mediawiki',
+        'mw-hide-empty-elt',
+        'ns-0',
+        'ns-subject',
+        'page-Providence_Stoughton_Line',
+        'rootpage-Providence_Stoughton_Line',
+        'sitedir-ltr',
+        'skin--responsive',
+        'skin-vector',
+        'skin-vector-2022',
+        'skin-vector-search-vue',
+      ].sort()
+      expect(articleDoc.body.className.split(' ').sort()).toEqual(expectedClasses)
+    })
+
+    test(`test article <html> CSS class for ${outFiles[0]?.renderer} renderer`, async () => {
+      // This is implemented correctly only with ActionParse renderer for now
+      if (outFiles[0]?.renderer !== 'ActionParse') {
+        return
+      }
+      const expectedClasses = [
+        'client-nojs',
+        'vector-feature-appearance-pinned-clientpref-1',
+        'vector-feature-custom-font-size-clientpref-1',
+        'vector-feature-language-in-header-enabled',
+        'vector-feature-language-in-main-page-header-disabled',
+        'vector-feature-limited-width-clientpref-1',
+        'vector-feature-limited-width-content-enabled',
+        'vector-feature-main-menu-pinned-disabled',
+        'vector-feature-night-mode-disabled',
+        'vector-feature-page-tools-pinned-disabled',
+        'vector-feature-toc-pinned-clientpref-1',
+        'vector-sticky-header-enabled',
+      ].sort()
+      expect(articleDoc.documentElement.className.split(' ').sort()).toEqual(expectedClasses)
+    })
+
     test(`test article image integrity for ${outFiles[0]?.renderer} renderer`, async () => {
       const allFiles = await zimdump(`list ${outFiles[0].outFile}`)
       const allFilesArr = allFiles.split('\n')

--- a/test/unit/downloader.test.ts
+++ b/test/unit/downloader.test.ts
@@ -162,15 +162,7 @@ describe('Downloader class - wikipedia EN', () => {
         timestamp: '2023-08-20T14:54:01Z',
         coordinates: '51.50722222;-0.1275',
       }
-      const LondonArticle = await Downloader.getArticle(
-        articleId,
-        RedisStore.articleDetailXId,
-        wikimediaMobileRenderer,
-        articleUrl,
-        dump,
-        articleDetail,
-        dump.isMainPage(articleId),
-      )
+      const LondonArticle = await Downloader.getArticle(articleId, RedisStore.articleDetailXId, wikimediaMobileRenderer, articleUrl, dump, articleDetail)
       expect(LondonArticle).toHaveLength(1)
     })
 
@@ -185,15 +177,7 @@ describe('Downloader class - wikipedia EN', () => {
       }
       // Enforce desktop url here as this test desktop API-specific
       const articleUrl = `https://en.wikipedia.org/api/rest_v1/page/html/${articleId}`
-      const PaginatedArticle = await Downloader.getArticle(
-        articleId,
-        RedisStore.articleDetailXId,
-        wikimediaDesktopRenderer,
-        articleUrl,
-        dump,
-        articleDetail,
-        dump.isMainPage(articleId),
-      )
+      const PaginatedArticle = await Downloader.getArticle(articleId, RedisStore.articleDetailXId, wikimediaDesktopRenderer, articleUrl, dump, articleDetail)
       expect(PaginatedArticle.length).toBeGreaterThan(100)
     })
   })
@@ -221,7 +205,6 @@ describe('Downloader class - wikipedia EN', () => {
           articleUrl,
           dump,
           articleDetail,
-          dump.isMainPage(articleId),
         )
         expect(neverExistingArticleResult).toHaveLength(1)
         expect(neverExistingArticleResult[0].articleId).toBe('NeverExistingArticle')
@@ -376,7 +359,6 @@ describe('Downloader class - wikipedia ES', () => {
           Downloader.getArticleUrl(articleId),
           dump,
           articleDetails[articleId],
-          dump.isMainPage(articleId),
         )
         expect(articleResult).toHaveLength(1)
         expect(articleResult[0].articleId).toBe('Alejandro_González_y_Robleto')
@@ -420,7 +402,6 @@ describe('Downloader class - wikipedia ES', () => {
       Downloader.getArticleUrl(articleId),
       dump,
       articleDetails[articleId],
-      dump.isMainPage(articleId),
     )
     expect(articleResult).toHaveLength(1)
     expect(articleResult[0].articleId).toBe('Alejandro_González_y_Robleto')
@@ -433,7 +414,6 @@ describe('Downloader class - wikipedia ES', () => {
       Downloader.getArticleUrl(redirectArticleId),
       dump,
       articleDetails[redirectArticleId],
-      dump.isMainPage(redirectArticleId),
     )
     expect(redirectArticleResult).toHaveLength(1)
     expect(redirectArticleResult[0].articleId).toBe('Vicente_Alejandro_González_y_Robleto')

--- a/test/unit/renderers/article.renderer.test.ts
+++ b/test/unit/renderers/article.renderer.test.ts
@@ -14,7 +14,7 @@ jest.setTimeout(10000)
 describe('ArticleRenderer', () => {
   describe('test Visual Editor renderer', () => {
     const prepareFixtures = (json: Record<string, any> | null) => {
-      MediaWiki.metaData.mainPage = '456'
+      MediaWiki.metaData = { mainPage: '456' }
       return {
         data: json,
         articleId: '123',

--- a/test/unit/renderers/article.renderer.test.ts
+++ b/test/unit/renderers/article.renderer.test.ts
@@ -14,11 +14,11 @@ jest.setTimeout(10000)
 describe('ArticleRenderer', () => {
   describe('test Visual Editor renderer', () => {
     const prepareFixtures = (json: Record<string, any> | null) => {
+      MediaWiki.metaData.mainPage = '456'
       return {
         data: json,
         articleId: '123',
         articleDetail: { title: 'Brian May', timestamp: '2023-08-24T02:19:04Z' },
-        isMainPage: false,
       }
     }
     const visualEditorRenderer = new VisualEditorRenderer()
@@ -43,13 +43,13 @@ describe('ArticleRenderer', () => {
       const { dump } = await setupScrapeClasses()
       const { data, articleId, articleDetail } = prepareFixtures({ visualeditor: { content: 'Lorem ipsum dolor sit amet' } })
       const moduleDependencies = await Downloader.getModuleDependencies(articleDetail.title)
+      MediaWiki.metaData.mainPage = articleId
       const result = await visualEditorRenderer.render({
         data,
         webp: Downloader.webp,
         moduleDependencies,
         articleId,
         articleDetail,
-        isMainPage: true,
         dump,
       } as RenderOpts)
 
@@ -70,7 +70,6 @@ describe('ArticleRenderer', () => {
         moduleDependencies,
         articleId,
         articleDetail: { title: 'consectetur adipiscing elit', timestamp: '2023-08-24T02:19:04Z' },
-        isMainPage: false,
         dump,
       } as RenderOpts)
 
@@ -89,7 +88,6 @@ describe('ArticleRenderer', () => {
         moduleDependencies,
         articleId,
         articleDetail,
-        isMainPage: false,
         dump,
       } as RenderOpts)
 
@@ -110,7 +108,6 @@ describe('ArticleRenderer', () => {
         moduleDependencies,
         articleId,
         articleDetail,
-        isMainPage: false,
         dump,
       } as RenderOpts)
 
@@ -130,7 +127,6 @@ describe('ArticleRenderer', () => {
         moduleDependencies,
         articleId,
         articleDetail,
-        isMainPage: false,
         dump,
       } as RenderOpts)
 

--- a/test/unit/saveArticles.test.ts
+++ b/test/unit/saveArticles.test.ts
@@ -68,7 +68,7 @@ describe('saveArticles', () => {
       const { articleDetailXId } = RedisStore
       const articleDetail = { title: articleId, timestamp: '2023-09-10T17:36:04Z' }
       articleDetailXId.setMany(articlesDetail)
-      const result = await Downloader.getArticle(articleId, articleDetailXId, RenderingContext.mainPageRenderer, articleUrl, dump, articleDetail, dump.isMainPage(articleId))
+      const result = await Downloader.getArticle(articleId, articleDetailXId, RenderingContext.mainPageRenderer, articleUrl, dump, articleDetail)
 
       const articleDoc = domino.createDocument(result[0].html)
 
@@ -91,7 +91,7 @@ describe('saveArticles', () => {
       const { articleDetailXId } = RedisStore
       const articleDetail = { title: articleId, timestamp: '2023-08-20T14:54:01Z' }
       articleDetailXId.setMany(articlesDetail)
-      const result = await Downloader.getArticle(articleId, articleDetailXId, RenderingContext.mainPageRenderer, articleUrl, dump, articleDetail, dump.isMainPage(articleId))
+      const result = await Downloader.getArticle(articleId, articleDetailXId, RenderingContext.mainPageRenderer, articleUrl, dump, articleDetail)
       const articleDoc = domino.createDocument(result[0].html)
       expect(articleDoc.querySelector('h1.article-header')).toBeFalsy()
     })
@@ -170,7 +170,7 @@ describe('saveArticles', () => {
       const { articleDetailXId } = RedisStore
       const articleDetail = { title: articleId, timestamp: '2023-08-20T14:54:01Z' }
       articleDetailXId.setMany(articlesDetail)
-      const result = await Downloader.getArticle(articleId, articleDetailXId, RenderingContext.mainPageRenderer, articleUrl, dump, articleDetail, dump.isMainPage(articleId))
+      const result = await Downloader.getArticle(articleId, articleDetailXId, RenderingContext.mainPageRenderer, articleUrl, dump, articleDetail)
 
       const articleDoc = domino.createDocument(result[0].html)
 

--- a/test/unit/util/articles.test.ts
+++ b/test/unit/util/articles.test.ts
@@ -1,0 +1,75 @@
+import { isSubpage, isMainPage, getNamespaceName, extractBodyCssClass, extractHtmlCssClass } from '../../../src/util/articles.js'
+import MediaWiki from '../../../src/MediaWiki.js'
+
+describe('articles utility', () => {
+  const fakeHeadHtml = `<!DOCTYPE html>\n<html class="client-js vector-feature-language-in-header-enabled vector-feature-language-in-main-page-header-disabled vector-feature-page-tools-pinned-disabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-disabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-custom-font-size-clientpref-1 vector-feature-appearance-pinned-clientpref-1 vector-feature-night-mode-enabled skin-theme-clientpref-day vector-sticky-header-enabled" lang="hu" dir="ltr">\n<head>\n<meta charset="UTF-8">\n<title> – Wikipédia</title>\n<script>(function(){var className="client-js vector-feature-language-in-header-enabled vector-feature-language-in-main-page-header-disabled vector-feature-page-tools-pinned-disabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-disabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-custom-font-size-clientpref-1 vector-feature-appearance-pinned-clientpref-1 vector-feature-night-mode-disabled skin-theme-clientpref-day vector-sticky-header-enabled";var cookie=document.cookie.match(/(?:^|; )huwikimwclientpreferences=([^;]+)/);if(cookie){cookie[1].split('%2C').forEach(function(pref){className=className.replace(new RegExp('(^| )'+pref.replace(/-clientpref-\\w+$|[^\\w-]+/g,'')+'-clientpref-\\\\w+( |$)'),'$1'+pref+'$2');});}document.documentElement.className=className;}());RLCONF={"wgBreakFrames":true,"wgSeparatorTransformTable":[",\\t."," \\t,"],"wgDigitTransformTable":["",""],"wgDefaultDateFormat":"ymd","wgMonthNames":["","január","február","március","április","május","június","július","augusztus","szeptember","október","november","december"],"wgRequestId":"0885a2d2-9450-4674-a4ed-1c624a117550","wgCanonicalNamespace":"","wgCanonicalSpecialPageName":false,"wgNamespaceNumber":0,"wgPageName":"Brian_May","wgTitle":"Brian May","wgCurRevisionId":28075618,"wgRevisionId":0,"wgArticleId":19638,"wgIsArticle":true,"wgIsRedirect":false,"wgAction":"view","wgUserName":null,"wgUserGroups":["*"],"wgCategories":["Mágikus ISBN-linkeket használó lapok","Wikipédia-szócikkek VIAF-azonosítóval","Wikipédia-szócikkek LCCN-azonosítóval","Wikipédia-szócikkek ISNI-azonosítóval","Wikipédia-szócikkek ORCID-azonosítóval","Wikipédia-szócikkek GND-azonosítóval","Wikipédia-szócikkek BNF-azonosítóval","Wikipédia-szócikkek SBN-azonosítóval","Wikipédia-szócikkek KKT-azonosítóval","Wikipédia-szócikkek BIBSYS-azonosítóval","1947-ben született személyek","Londoniak","Élő személyek","Queen","Brit rockgitárosok","Brit zeneszerzők","A Brit Birodalom Rendjével kitüntetett személyek","Minden idők 100 legjobb gitárosa (Rolling Stone magazin)"],"wgPageViewLanguage":"hu","wgPageContentLanguage":"hu","wgPageContentModel":"wikitext","wgRelevantPageName":"Brian_May","wgRelevantArticleId":19638,"wgIsProbablyEditable":true,"wgRelevantPageIsProbablyEditable":true,"wgRestrictionEdit":[],"wgRestrictionMove":[],"wgNoticeProject":"wikipedia","wgCiteReferencePreviewsActive":true,"wgFlaggedRevsParams":{"tags":{"accuracy":{"levels":2}}},"wgStableRevisionId":28075618,"wgMediaViewerOnClick":true,"wgMediaViewerEnabledByDefault":true,"wgPopupsFlags":0,"wgVisualEditor":{"pageLanguageCode":"hu","pageLanguageDir":"ltr","pageVariantFallbacks":"hu"},"wgMFDisplayWikibaseDescriptions":{"search":true,"watchlist":true,"tagline":true,"nearby":true},"wgWMESchemaEditAttemptStepOversample":false,"wgWMEPageLength":70000,"parsermigration-parsoid":true};\nRLSTATE={"site.styles":"ready","user.styles":"ready","user":"ready","user.options":"loading","skins.vector.search.codex.styles":"ready","skins.vector.styles":"ready","skins.vector.icons":"ready","ext.cite.parsoid.styles":"ready","ext.cite.styles":"ready","ext.tmh.player.styles":"ready","mediawiki.skinning.content.parsoid":"ready"};RLPAGEMODULES=["site","mediawiki.page.ready","skins.vector.js","ext.cite.ux-enhancements","mediawiki.page.media","ext.tmh.player"];</script>\n<script>(RLQ=window.RLQ||[]).push(function(){mw.loader.impl(function(){return["user.options@12s5i",function($,jQuery,require,module){mw.user.tokens.set({"patrolToken":"+\\\\","watchToken":"+\\\\","csrfToken":"+\\\\"});\n}];});});</script>\n<link rel="stylesheet" href="/w/load.php?lang=hu&amp;modules=ext.cite.parsoid.styles%7Cext.cite.styles%7Cext.tmh.player.styles%7Cmediawiki.skinning.content.parsoid%7Cskins.vector.icons%2Cstyles%7Cskins.vector.search.codex.styles&amp;only=styles&amp;skin=vector-2022">\n<script async="" src="/w/load.php?lang=hu&amp;modules=startup&amp;only=scripts&amp;raw=1&amp;skin=vector-2022"></script>\n<meta name="ResourceLoaderDynamicStyles" content="">\n<link rel="stylesheet" href="/w/load.php?lang=hu&amp;modules=site.styles&amp;only=styles&amp;skin=vector-2022">\n<meta name="generator" content="MediaWiki 1.45.0-wmf.7">\n<meta name="referrer" content="origin">\n<meta name="referrer" content="origin-when-cross-origin">\n<meta name="robots" content="max-image-preview:standard">\n<meta name="format-detection" content="telephone=no">\n<link rel="preconnect" href="//upload.wikimedia.org">\n<link rel="alternate" type="application/x-wiki" title="Szerkesztés" href="/w/index.php?title=Brian_May&amp;action=edit">\n<link rel="apple-touch-icon" href="/static/apple-touch/wikipedia.png">\n<link rel="icon" href="/static/favicon/wikipedia.ico">\n<link rel="search" type="application/opensearchdescription+xml" href="/w/rest.php/v1/search" title="Wikipédia (hu)">\n<link rel="EditURI" type="application/rsd+xml" href="//hu.wikipedia.org/w/api.php?action=rsd">\n<link rel="canonical" href="https://hu.wikipedia.org/wiki/Brian_May">\n<link rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/deed.hu">\n<link rel="alternate" type="application/atom+xml" title="Wikipédia Atom-hírcsatorna" href="/w/index.php?title=Speci%C3%A1lis:Friss_v%C3%A1ltoztat%C3%A1sok&amp;feed=atom">\n</head>\n<body class="skin--responsive skin-vector skin-vector-search-vue mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject mw-editable page-Brian_May rootpage-Brian_May skin-vector-2022 action-view">`
+
+  beforeAll(() => {
+    MediaWiki.reset()
+    MediaWiki.namespaces = {
+      '': {
+        num: 0,
+        isContent: true,
+        allowedSubpages: false,
+      },
+      Talk: {
+        num: 1,
+        isContent: false,
+        allowedSubpages: true,
+      },
+      User: {
+        num: 2,
+        isContent: false,
+        allowedSubpages: true,
+      },
+      Foo: {
+        num: 100,
+        isContent: true,
+        allowedSubpages: true,
+      },
+    }
+  })
+
+  test.each(['Foo', 'Foo/Bar', 'Foo/Bar/Alix', 'Foo:Bar', 'Talk:Foo Bar', 'Talk:Foo_Bar'])('article is not subpage', (articleTitle) => {
+    expect(isSubpage(articleTitle)).toBe(false)
+  })
+
+  test.each(['Foo:Bar/Alix', 'Talk:Foo/Bar', 'Talk:Foo/Bar Alix'])('article is a subpage', (articleTitle) => {
+    expect(isSubpage(articleTitle)).toBe(true)
+  })
+
+  test.each(['Foo_Bar', 'Foo Bar'])('article is main page', (articleTitle) => {
+    MediaWiki.metaData = { mainPage: 'Foo_Bar' }
+    expect(isMainPage(articleTitle)).toBe(true)
+  })
+
+  test.each(['Foo:Bar/Alix', 'Talk:Foo/Bar', 'Talk:Foo/Bar Alix'])('article is not main page', (articleTitle) => {
+    MediaWiki.metaData = { mainPage: 'Foo_Bar' }
+    expect(isMainPage(articleTitle)).toBe(false)
+  })
+
+  test.each([
+    [0, 'Foo'],
+    [1, 'Bar'],
+    [999, undefined],
+  ])('getNamespaceName', (namespaceNumber, expectedNamespaceName) => {
+    MediaWiki.namespaces = { Foo: { num: 0, allowedSubpages: false, isContent: true }, Bar: { num: 1, allowedSubpages: false, isContent: false } }
+    expect(getNamespaceName(namespaceNumber)).toBe(expectedNamespaceName)
+  })
+
+  test('extractBodyCssClass', () => {
+    expect(extractBodyCssClass(fakeHeadHtml).split(' ').sort()).toEqual(
+      'skin--responsive skin-vector skin-vector-search-vue mediawiki ltr sitedir-ltr mw-hide-empty-elt ns-0 ns-subject page-Brian_May rootpage-Brian_May skin-vector-2022 action-view'
+        .split(' ')
+        .sort(),
+    )
+  })
+
+  test('extractHtmlCssClass', () => {
+    expect(extractHtmlCssClass(fakeHeadHtml).split(' ').sort()).toEqual(
+      'vector-feature-language-in-header-enabled vector-feature-language-in-main-page-header-disabled vector-feature-page-tools-pinned-disabled vector-feature-toc-pinned-clientpref-1 vector-feature-main-menu-pinned-disabled vector-feature-limited-width-clientpref-1 vector-feature-limited-width-content-enabled vector-feature-custom-font-size-clientpref-1 vector-feature-appearance-pinned-clientpref-1 vector-sticky-header-enabled'
+        .split(' ')
+        .sort(),
+    )
+  })
+})


### PR DESCRIPTION
Fix #2356 

Changes:
- ~~automatically compute all body CSS classes in ActionParse renderer~~
  - ~~for this I had to pass `articleDetails` to the template rendering function~~
- fetch article body CSS class from `headhtml` response of the action=parse request
- side-effect: I realized that we were passing `isMainPage` info around while it is a known property of current `Mediawiki` singleton ; nothing to do inside the dump (all dumps have the same main page) and no reason to pass this metadata around while it can be easily (and cheaply) recomputed with `Mediawiki` singleton