### PR TITLE
Support section redirects

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,5 @@
 Unreleased:
+* FIX: Support section redirects (@Markus-Rost @benoit74 #2382)
 
 1.16.0:
 * CHANGED: ActionParse renderer is now the preferred one when available (@benoit74 #2183)

--- a/res/templates/html_redirect.html
+++ b/res/templates/html_redirect.html
@@ -1,0 +1,7 @@
+<html>
+  <head>
+    <title>__TITLE__</title>
+    <meta http-equiv="refresh" content="0;URL='__RELATIVE_FILE_PATH____TARGET__'" />
+  </head>
+  <body></body>
+</html>

--- a/res/templates/html_redirect.html
+++ b/res/templates/html_redirect.html
@@ -3,5 +3,7 @@
     <title>__TITLE__</title>
     <meta http-equiv="refresh" content="0;URL='__RELATIVE_FILE_PATH____TARGET__'" />
   </head>
-  <body></body>
+  <body>
+    <a href="__RELATIVE_FILE_PATH____TARGET__">__TITLE__</a>
+  </body>
 </html>

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -462,7 +462,7 @@ class Downloader {
       // from new location to original location. Note that only ActionParse API gives proper redirects info.
       for (const redirect of redirects) {
         if (!(await RedisStore.articleDetailXId.exists(redirect.to)) && !(await RedisStore.redirectsXId.exists(redirect.to))) {
-          RedisStore.redirectsXId.set(redirect.to, { targetId: redirect.from, title: redirect.to })
+          RedisStore.redirectsXId.set(redirect.to, { targetId: redirect.from, title: redirect.to, fragment: '' })
         }
       }
 

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -22,6 +22,7 @@ export interface QueryOpts {
   prop: string
   rdlimit: string
   rdnamespace: string | number
+  rdprop: string
   redirects?: boolean
   formatversion: string
 }
@@ -169,7 +170,8 @@ class MediaWiki {
       format: 'json',
       prop: 'info|redirects|revisions',
       rdlimit: 'max',
-      rdnamespace: 0,
+      rdnamespace: '0',
+      rdprop: 'title|fragment',
       redirects: false,
       formatversion: '2',
     }
@@ -249,7 +251,7 @@ class MediaWiki {
       const reqOpts = {
         ...this.queryOpts,
         prop: this.queryOpts.prop + '|coordinates', // add coordinates for this call to get proper warning if not supported
-        rdnamespace: validNamespaceIds,
+        rdnamespace: validNamespaceIds.join('|'),
       }
 
       const resp = await Downloader.getJSON<MwApiResponse>(this.#apiUrlDirector.buildQueryURL(reqOpts))

--- a/src/RedisStore.ts
+++ b/src/RedisStore.ts
@@ -132,6 +132,7 @@ class RedisStore implements RS {
       n: 'title',
     })
     this.#redirectsXId = new RedisKvs(this.#client, `${Date.now()}-redirect`, {
+      f: 'fragment',
       t: 'targetId',
       n: 'title',
     })

--- a/src/Templates.ts
+++ b/src/Templates.ts
@@ -38,6 +38,10 @@ const htmlVector2022TemplateCode = () => {
   return readTemplate(config.output.templates.pageVector2022)
 }
 
+const htmlRedirectTemplateCode = () => {
+  return readTemplate(config.output.templates.htmlRedirect)
+}
+
 const articleListHomeTemplate = readTemplate(config.output.templates.articleListHomeTemplate)
 
 export {
@@ -49,6 +53,7 @@ export {
   htmlWikimediaDesktopTemplateCode,
   htmlVectorLegacyTemplateCode,
   htmlVector2022TemplateCode,
+  htmlRedirectTemplateCode,
   articleListHomeTemplate,
   categoriesTemplate,
   subCategoriesTemplate,

--- a/src/config.ts
+++ b/src/config.ts
@@ -147,6 +147,9 @@ const config = {
 
       /* Template for article download error */
       downloadErrorPlaceholder: './templates/download_error_placeholder.html',
+
+      /* Template for HTML-based redirects (to section of an article typically) */
+      htmlRedirect: './templates/html_redirect.html',
     },
   },
 }

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -484,7 +484,7 @@ async function execute(argv: any) {
 
   async function writeArticleRedirects(dump: Dump, zimCreator: Creator) {
     await redirectsXId.iterateItems(Downloader.speed, async (redirects) => {
-      for (const [redirectId, { targetId }] of Object.entries(redirects)) {
+      for (const [redirectId, { targetId, fragment }] of Object.entries(redirects)) {
         if (await RedisStore.articleDetailXId.exists(redirectId)) {
           logger.warn(`Skipping redirect of '${redirectId}' because it already exists as an article`)
           continue
@@ -501,7 +501,7 @@ async function execute(argv: any) {
           redirectId,
           // We fake a title, by just removing the underscores
           truncateUtf8Bytes(String(redirectId).replace(/_/g, ' '), 245),
-          targetId,
+          targetId + ( fragment ? '#' + fragment : '' ),
           { FRONT_ARTICLE: 1 },
         )
 

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -16,7 +16,7 @@ import semver from 'semver'
 import * as path from 'path'
 import { Blob, Compression, ContentProvider, Creator, StringItem } from '@openzim/libzim'
 import { checkApiAvailability, getArticleIds } from './util/mw-api.js'
-
+import { zimCreatorMutex } from './mutex.js'
 import { check_all } from './sanitize-argument.js'
 
 import {
@@ -51,7 +51,7 @@ import MediaWiki from './MediaWiki.js'
 import Downloader from './Downloader.js'
 import Gadgets from './Gadgets.js'
 import RenderingContext from './renderers/rendering.context.js'
-import { articleListHomeTemplate } from './Templates.js'
+import { articleListHomeTemplate, htmlRedirectTemplateCode } from './Templates.js'
 import { downloadFiles, saveArticles } from './util/saveArticles.js'
 import { getCategoriesForArticles, trimUnmirroredPages } from './util/categories.js'
 import urlHelper from './util/url.helper.js'
@@ -497,13 +497,22 @@ async function execute(argv: any) {
           logger.warn(`Skipping redirect of '${redirectId}' to '${targetId}' because target is not a known article`)
           continue
         }
-        zimCreator.addRedirection(
-          redirectId,
-          // We fake a title, by just removing the underscores
-          truncateUtf8Bytes(String(redirectId).replace(/_/g, ' '), 245),
-          targetId + ( fragment ? '#' + fragment : '' ),
-          { FRONT_ARTICLE: 1 },
-        )
+        // We fake a title, by just removing the underscores
+        const redirectTitle = truncateUtf8Bytes(String(redirectId).replace(/_/g, ' '), 245)
+        if (fragment) {
+          // Should we have a fragment (i.e. we redirect to a section of an article), this is not (yet) supported by libzim
+          // (to have such a redirect with a fragment inside the path), so we create a "fake" entry with only an HTML-based
+          // redirect inside
+          const htmlTemplateString = htmlRedirectTemplateCode()
+            .replace(/__TITLE__/g, redirectTitle)
+            // we have to replace space in fragment with underscores, see https://phabricator.wikimedia.org/T398724
+            .replace(/__TARGET__/g, `${targetId}#${fragment.replace(/ /g, '_')}`)
+            .replace(/__RELATIVE_FILE_PATH__/g, getRelativeFilePath(redirectId, ''))
+          await zimCreatorMutex.runExclusive(() => zimCreator.addItem(new StringItem(redirectId, 'text/html', redirectTitle, { FRONT_ARTICLE: 1 }, htmlTemplateString)))
+        } else {
+          // Otherwise we simply add a "regular" libzim redirect
+          await zimCreatorMutex.runExclusive(() => zimCreator.addRedirection(redirectId, redirectTitle, targetId, { FRONT_ARTICLE: 1 }))
+        }
 
         dump.status.redirects.written += 1
       }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -52,6 +52,7 @@ type FileDetail = {
 type ArticleRedirect = {
   targetId: string
   title: string
+  fragment?: string
 }
 
 // RedisKvs interface
@@ -101,7 +102,11 @@ type QueryCoordinatesRet = Array<{
   globe: string
 }>
 
-type QueryRedirectsRet = PageInfo[]
+type QueryRedirectsRet = Array<
+  PageInfo & {
+    fragment?: string
+  }
+>
 
 type TextDirection = 'ltr' | 'rtl'
 

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -65,7 +65,7 @@ export async function getArticlesByIds(articleIds: string[], log = true): Promis
           if (articleDetail.redirects && articleDetail.redirects.length) {
             await redirectsXId.setMany(
               articleDetail.redirects.reduce((acc, redirect) => {
-                acc[redirect.title] = { targetId: articleId, title: redirect.title }
+                acc[redirect.title] = { title: redirect.title, targetId: articleId, fragment: redirect.fragment || '' }
                 return acc
               }, {}),
             )
@@ -171,6 +171,7 @@ export function getArticlesByNS(ns: number, articleIdsToIgnore?: string[], conti
                 redirects[target.title] = {
                   targetId: articleId,
                   title: target.title,
+                  fragment: target.fragment,
                 }
               }
             }

--- a/test/e2e/bm.e2e.test.ts
+++ b/test/e2e/bm.e2e.test.ts
@@ -68,6 +68,7 @@ await testAllRenders('bm-wikipedia', parameters, async (outFiles) => {
     const redirectFromDump = await zimdump(`show --url Bamakɔ_Monumentsa ${outFiles[0].outFile}`)
     expect(redirectFromDump).toContain('<title>Bamakɔ Monumentsa</title>')
     expect(redirectFromDump).toContain('<meta http-equiv="refresh" content="0;URL=\'./Bamakɔ#Monumentsa_ni_yɔrɔ\'" />')
+    expect(redirectFromDump).toContain('<a href="./Bamakɔ#Monumentsa_ni_yɔrɔ">Bamakɔ Monumentsa</a>')
   })
 
   afterAll(() => {

--- a/test/e2e/en.e2e.test.ts
+++ b/test/e2e/en.e2e.test.ts
@@ -121,6 +121,7 @@ await testAllRenders('en-wikipedia', parameters, async (outFiles) => {
       const redirectFromDump = await zimdump(`show --url Attleboro_Line ${outFiles[0].outFile}`)
       expect(redirectFromDump).toContain('<title>Attleboro Line</title>')
       expect(redirectFromDump).toContain('<meta http-equiv="refresh" content="0;URL=\'./Providence/Stoughton_Line#Ownership_and_financing\'" />')
+      expect(redirectFromDump).toContain('<a href="./Providence/Stoughton_Line#Ownership_and_financing">Attleboro Line</a>')
     })
 
     afterAll(() => {

--- a/test/e2e/en.e2e.test.ts
+++ b/test/e2e/en.e2e.test.ts
@@ -91,6 +91,38 @@ await testAllRenders('en-wikipedia', parameters, async (outFiles) => {
       expect(verifyImgElements(imgFilesArr, imgElements)).toBe(true)
     })
 
+    test(`test redirect without fragment ${outFiles[0]?.renderer} renderer`, async () => {
+      // "Providence_Line" should be a redirect to "Providence/Stoughton_Line"
+      const redirectInfo = await zimdump(`list --details --url Providence_Line ${outFiles[0].outFile}`)
+
+      expect(redirectInfo).toMatch(/path:\s*Providence_Line/)
+      expect(redirectInfo).toMatch(/title:\s*Providence Line/)
+      expect(redirectInfo).toMatch(/type:\s*redirect/)
+      const redirectIndexMatch = redirectInfo.match(/redirect index:\s*(\d+)/)
+      expect(redirectIndexMatch).not.toBe(null)
+      const redirectIndex = redirectIndexMatch ? parseInt(redirectIndexMatch[1], 10) : null
+      expect(redirectIndex).not.toBeNull()
+
+      const redirectTargetInfo = await zimdump(`list --details --idx ${redirectIndex} ${outFiles[0].outFile}`)
+      expect(redirectTargetInfo).toMatch(/path:\s*Providence\/Stoughton_Line/)
+      expect(redirectTargetInfo).toMatch(/title:\s*Providence\/Stoughton Line/)
+      expect(redirectTargetInfo).toMatch(/type:\s*item/)
+    })
+
+    test(`test redirect with fragment ${outFiles[0]?.renderer} renderer`, async () => {
+      // "Attleboro_Line" should be an HTML item which will redirect to "Providence/Stoughton_Line#Ownership_and_financing"
+      // through http-equiv="refresh"
+      const redirectInfo = await zimdump(`list --details --url Attleboro_Line ${outFiles[0].outFile}`)
+
+      expect(redirectInfo).toMatch(/path:\s*Attleboro_Line/)
+      expect(redirectInfo).toMatch(/title:\s*Attleboro Line/)
+      expect(redirectInfo).toMatch(/type:\s*item/)
+
+      const redirectFromDump = await zimdump(`show --url Attleboro_Line ${outFiles[0].outFile}`)
+      expect(redirectFromDump).toContain('<title>Attleboro Line</title>')
+      expect(redirectFromDump).toContain('<meta http-equiv="refresh" content="0;URL=\'./Providence/Stoughton_Line#Ownership_and_financing\'" />')
+    })
+
     afterAll(() => {
       if (!process.env.KEEP_ZIMS) {
         rimraf.sync(`./${outFiles[0].testId}`)


### PR DESCRIPTION
Superseeds #2383 by using a branch from repo instead of fork + rebased + new commit to handle redirect with fragments

Fix #2382
Fixes #938 

This should probably have some tests, but I don't know how to add them. Also libzim itself has no tests for redirects with url fragments in the target path, so I don't know if this actually works as intended.