### PR TITLE
Automatically use mediawiki default skin with fallback template

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -6,6 +6,7 @@ Unreleased:
 * CHANGED: Use subtitle from ActionParse (@Markus-Rost #179)
 * NEW: Add progress logs while writing redirects (@benoit74 #2381)
 * FIX: Keep some HTML tags from parser, since they might be used by CSS (especially for backlinks) (@benoit74 #881)
+* NEW: Automatically detect and use mediawiki default skin (@benoit74 #2358)
 
 1.16.0:
 * CHANGED: ActionParse renderer is now the preferred one when available (@benoit74 #2183)

--- a/Changelog
+++ b/Changelog
@@ -6,7 +6,7 @@ Unreleased:
 * CHANGED: Use subtitle from ActionParse (@Markus-Rost #179)
 * NEW: Add progress logs while writing redirects (@benoit74 #2381)
 * FIX: Keep some HTML tags from parser, since they might be used by CSS (especially for backlinks) (@benoit74 #881)
-* NEW: Automatically detect and use mediawiki default skin (@benoit74 #2358)
+* NEW: Automatically detect and use mediawiki default skin (@benoit74 @Markus-Rost #2213, #2358, #2396)
 
 1.16.0:
 * CHANGED: ActionParse renderer is now the preferred one when available (@benoit74 #2183)

--- a/res/templates/pageFallback.html
+++ b/res/templates/pageFallback.html
@@ -10,14 +10,13 @@
     <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH__mw/site.styles.css" />
     <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH__mw/noscript.css" />
     <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH__footer.css" />
-    <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH__vector.css" />
   </head>
 
-  <body class="__ARTICLE_BODY_CSS_CLASS__">
+  <body class="mwoffliner-fallback __ARTICLE_BODY_CSS_CLASS__">
     <div id="content" class="mw-body" role="main">
       <a id="top"></a>
       <h1 id="firstHeading" class="firstHeading mw-first-heading"><span id="openzim-page-title"></span></h1>
-      <div id="bodyContent" class="vector-body">
+      <div id="bodyContent">
         <div id="contentSub">
           <div id="mw-content-subtitle"></div>
         </div>

--- a/src/Templates.ts
+++ b/src/Templates.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'url'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
-function readTemplate(t: string) {
+function readTemplate(t: string): string {
   return readFileSync(pathParser.resolve(__dirname, '../res', t), 'utf-8')
 }
 
@@ -38,6 +38,10 @@ const htmlVector2022TemplateCode = () => {
   return readTemplate(config.output.templates.pageVector2022)
 }
 
+const htmlFallbackTemplateCode = () => {
+  return readTemplate(config.output.templates.pageFallback)
+}
+
 const htmlRedirectTemplateCode = () => {
   return readTemplate(config.output.templates.htmlRedirect)
 }
@@ -53,6 +57,7 @@ export {
   htmlWikimediaDesktopTemplateCode,
   htmlVectorLegacyTemplateCode,
   htmlVector2022TemplateCode,
+  htmlFallbackTemplateCode,
   htmlRedirectTemplateCode,
   articleListHomeTemplate,
   categoriesTemplate,

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,6 +124,7 @@ const config = {
       pageWikimediaMobile: './templates/pageWikimediaMobile.html',
       pageVectorLegacy: './templates/pageVectorLegacy.html',
       pageVector2022: './templates/pageVector2022.html',
+      pageFallback: './templates/pageFallback.html',
 
       categories: './templates/categories.html',
 

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -100,6 +100,7 @@ async function execute(argv: any) {
     optimisationCacheUrl,
     customFlavour,
     forceRender,
+    forceSkin,
   } = argv
 
   let { articleList, articleListToIgnore } = argv
@@ -194,6 +195,10 @@ async function execute(argv: any) {
   } catch (err) {
     logger.error('FATAL - Failed to get MediaWiki Metadata')
     throw err
+  }
+
+  if (forceSkin) {
+    MediaWiki.skin = forceSkin
   }
 
   const metaDataRequiredKeys = {

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -40,6 +40,7 @@ export const parameterDescriptions = {
   optimisationCacheUrl: 'Object Storage URL (including credentials and bucket name) to cache optimised media files',
   forceRender:
     'Force the usage of a specific API end-point/render, automatically chosen otherwise. Accepted values: [ VisualEditor, WikimediaDesktop. WikimediaMobile, RestApi, ActionParse ]',
+  forceSkin: 'Force the usage of a specific skin, automatically chosen otherwise.',
   insecure: 'Skip HTTPS server authenticity verification step',
 }
 

--- a/src/util/builders/url/api.director.ts
+++ b/src/util/builders/url/api.director.ts
@@ -38,7 +38,10 @@ export default class ApiURLDirector {
   }
 
   buildSiteInfoURL() {
-    return urlBuilder.setDomain(this.baseDomain).setQueryParams({ action: 'query', meta: 'siteinfo', siprop: 'general|rightsinfo', format: 'json', formatversion: '2' }).build()
+    return urlBuilder
+      .setDomain(this.baseDomain)
+      .setQueryParams({ action: 'query', meta: 'siteinfo', siprop: 'general|skins|rightsinfo', format: 'json', formatversion: '2' })
+      .build()
   }
 
   buildVisualEditorURL() {

--- a/test/e2e/articleSubtitle.e2e.test.ts
+++ b/test/e2e/articleSubtitle.e2e.test.ts
@@ -25,7 +25,7 @@ await testRenders(
     test(`test article subtitle for subpage on minecraft.wiki`, async () => {
       const articleSubtitle = articleDoc.querySelector('#contentSub > #mw-content-subtitle')
       expect(articleSubtitle).toBeTruthy()
-      expect(articleSubtitle.innerHTML).toBe('<div class="subpages">&lt; <a href="../Commands" title="Commands">Commands</a></div>')
+      expect(articleSubtitle.innerHTML).toBe('<div class="subpages">&lt; <bdi dir="ltr"><a href="../Commands" title="Commands">Commands</a></bdi></div>')
     })
 
     afterAll(() => {

--- a/test/e2e/forceSkin.e2e.test.ts
+++ b/test/e2e/forceSkin.e2e.test.ts
@@ -1,0 +1,43 @@
+import { testRenders } from '../testRenders.js'
+import domino from 'domino'
+import { zimdump, zimcheck } from '../util.js'
+import 'dotenv/config.js'
+import { jest } from '@jest/globals'
+import { rimraf } from 'rimraf'
+
+jest.setTimeout(60000)
+
+const parameters = {
+  mwUrl: 'https://en.wikipedia.org',
+  articleList: 'Kiwix',
+  adminEmail: 'test@kiwix.org',
+  forceSkin: 'monobook', // Use unsupported skin
+}
+
+await testRenders(
+  'forceSkin',
+  parameters,
+  async (outFiles) => {
+    const articleFromDump = await zimdump(`show --url "${parameters.articleList.replace(' ', '_')}" ${outFiles[0].outFile}`)
+    const articleDoc = domino.createDocument(articleFromDump)
+
+    test(`zimcheck for ${outFiles[0].renderer} renderer`, async () => {
+      await expect(zimcheck(outFiles[0].outFile)).resolves.not.toThrow()
+    })
+
+    test(`test article skin for ${outFiles[0].renderer} renderer`, async () => {
+      expect(articleDoc.body.classList).toContain('skin-monobook')
+    })
+
+    test(`test article template for ${outFiles[0].renderer} renderer`, async () => {
+      expect(articleDoc.body.classList).toContain('mwoffliner-fallback')
+    })
+
+    afterAll(() => {
+      if (!process.env.KEEP_ZIMS) {
+        rimraf.sync(`./${outFiles[0].testId}`)
+      }
+    })
+  },
+  ['ActionParse'],
+)

--- a/test/unit/builders/url/api.director.test.ts
+++ b/test/unit/builders/url/api.director.test.ts
@@ -39,7 +39,7 @@ describe('ApiURLDirector', () => {
     it('should return a string URL with predefined query params for retrieving site info', () => {
       const url = apiUrlDirector.buildSiteInfoURL()
 
-      expect(url).toBe('https://en.wikipedia.org/w/api.php?action=query&meta=siteinfo&siprop=general%7Crightsinfo&format=json&formatversion=2')
+      expect(url).toBe('https://en.wikipedia.org/w/api.php?action=query&meta=siteinfo&siprop=general%7Cskins%7Crightsinfo&format=json&formatversion=2')
     })
   })
 

--- a/test/unit/mwApi.test.ts
+++ b/test/unit/mwApi.test.ts
@@ -1,6 +1,6 @@
 import { startRedis, stopRedis } from './bootstrap.js'
 import Downloader from '../../src/Downloader.js'
-import MediaWiki from '../../src/MediaWiki.js'
+import MediaWiki, { SiteInfoSkin } from '../../src/MediaWiki.js'
 import RedisStore from '../../src/RedisStore.js'
 import { getArticleIds } from '../../src/util/mw-api.js'
 import { getArticlesByNS } from '../../src/util/index.js'
@@ -180,5 +180,42 @@ describe('Test moved page with redirect', () => {
     expect(Vicente_Alejandro_González_y_Robleto).toBeDefined()
     expect(Vicente_Alejandro_González_y_Robleto).toHaveProperty('title')
     expect(Vicente_Alejandro_González_y_Robleto).toHaveProperty('revisionId')
+  })
+})
+
+describe('Mediawiki utils', () => {
+  test.each([
+    [
+      // Standard test case
+      [
+        { code: 'vector', name: 'Vector Legacy' },
+        { code: 'vector-2022', name: 'Vector (2022)', default: true },
+        { code: 'modern', name: 'Modern', unusable: true },
+      ],
+      'vector-2022',
+    ],
+    [
+      // Edge-case where we have two default skin
+      [
+        { code: 'vector-2022', name: 'Vector (2022)', default: true },
+        { code: 'vector', name: 'Vector Legacy', default: true },
+      ],
+      'vector-2022',
+    ],
+  ])('Get skin', (skins: SiteInfoSkin[], defaultSkin: string) => {
+    expect(MediaWiki.getDefaultSkin(skins)).toBe(defaultSkin)
+  })
+
+  test.each([
+    [
+      // No default skin
+      [
+        { code: 'vector', name: 'Vector Legacy' },
+        { code: 'vector-2022', name: 'Vector (2022)' },
+        { code: 'modern', name: 'Modern', unusable: true },
+      ],
+    ],
+  ])('Get skin', (skins: SiteInfoSkin[]) => {
+    expect(() => MediaWiki.getDefaultSkin(skins)).toThrow()
   })
 })


### PR DESCRIPTION
Fix #2213
Fix #2358
Fix #2396

Makes most https://github.com/openzim/mwoffliner/labels/skin issues obsolete

Adds a fallback template based on vector legacy if the specific skin has no template of its own.

Adds a `forceSkin` CLI argument to use a skin supported by the wiki other than the default skin.