### PR TITLE
Always remove redlinks and keep selflinks

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -18,6 +18,8 @@ Unreleased:
 * FIX: Set correct MimeType on ZIM Metadata (@Markus-Rost #2470)
 * FIX: Get files names for wikis using no hashed directory (@Markus-Rost #2465)
 * FIX: Remove TOC from vector-legacy and fallback skin (@Markus-Rost #2449)
+* FIX: Always remove redlinks (@Markus-Rost #2451)
+* FIX: Always keep selflinks (@Markus-Rost #2454)
 
 1.16.0:
 * CHANGED: ActionParse renderer is now the preferred one when available (@benoit74 #2183)

--- a/src/util/rewriteUrls.ts
+++ b/src/util/rewriteUrls.ts
@@ -10,6 +10,17 @@ function rewriteUrlNoArticleCheck(articleId: string, dump: Dump, linkNode: Domin
   let href = linkNode.getAttribute('href') || ''
   let hrefProtocol
 
+  // Always keep selflinks
+  if (linkNode.matches('a.mw-selflink') && !href) {
+    return null
+  }
+  // Always remove redlinks
+  if (linkNode.matches('a.new')) {
+    migrateChildren(linkNode, linkNode.parentNode, linkNode)
+    linkNode.parentNode.removeChild(linkNode)
+    return null
+  }
+
   const extractScheme = function (href: string) {
     const match = href.match(/^([a-zA-Z][a-zA-Z\d+\-.]*):/)
     return match ? match[1] : null

--- a/test/unit/urlRewriting.test.ts
+++ b/test/unit/urlRewriting.test.ts
@@ -44,6 +44,8 @@ describe('Styles', () => {
     const $wikiLink2 = makeLink($doc, '/wiki/British_Museum', '', 'British Museum')
     const $wikiLinkWithSlash = makeLink($doc, '/wiki/Farnborough/Aldershot_built-up_area', '', 'Farnborough/Aldershot built-up Area')
     const $nonScrapedWikiLink = makeLink($doc, '/wiki/this_page_does_not_exist', '', 'fake link')
+    const $redLink = makeLink($doc, '/wiki/this_page_does_not_exist', '', 'red link', '', { class: 'new' })
+    const $selfLink = makeLink($doc, '', '', '', 'self link', { class: 'selflink mw-selflink' })
     const $specialMap = makeLink($doc, '/wiki/Special:Map/9/51.51/-0.08/en', '', 'Interactive map outlining London')
     const $hashLink = makeLink($doc, '#cite_note-LAS-150', '', 'The London Air Ambulance')
     const $resourceLink = makeLink($doc, '//upload.wikimedia.org/wikipedia/commons/c/c6/De-Z%C3%BCrich.ogg', '', 'De-Z%C3%BCrich.ogg', 'Zurich', {
@@ -123,6 +125,16 @@ describe('Styles', () => {
     await rewriteUrl(complexParentArticleId, dump, $nonScrapedWikiLink)
     // nonScrapedWikiLink has been deleted
     expect($nonScrapedWikiLink.parentElement).toBeNull()
+
+    await rewriteUrl(complexParentArticleId, dump, $redLink)
+    // redLink has been deleted
+    expect($redLink.parentElement).toBeNull()
+
+    await rewriteUrl(complexParentArticleId, dump, $selfLink)
+    // selfLink is still a link
+    expect($selfLink.nodeName).toEqual('A')
+    // selfLink still has no href
+    expect($selfLink.getAttribute('href')).toBeFalsy()
 
     await rewriteUrl(complexParentArticleId, dump, $resourceLink)
     // resourceLink is still a link


### PR DESCRIPTION
Fix #2451
Fix #2454

Always remove redlinks, skipping `rewriteUrlNoArticleCheck`. This will remove redlinks even if `mwIndexPhpPath` is set incorrectly or the wiki uses custom [action paths](https://www.mediawiki.org/wiki/Manual:$wgActionPaths).

Keep selflinks as they are, they have bold styling by default but wikis might add different styles targeting them.