### PR TITLE
Automatically guess / retrieve mediawiki paths

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -23,6 +23,9 @@ Unreleased:
 * FIX: Rewrite main page links when main page is at domain root (@Markus-Rost #2461)
 * FIX: Don't encode filenames twice when rewriting CSS files (@Markus-Rost #2473)
 * FIX: Treat absolute URLs to the wiki article path as local links. (@Markus-Rost #2459)
+* CHANGED: Deprecate `mwWikiPath` and `mwIndexPhpPath` CLI parameter, use values from the API instead (@Markus-Rost #2422)
+* CHANGED: Build `mwRestApiPath` and `mwModulePath` CLI parameter default values from the API (@Markus-Rost #2422)
+* NEW: Add `langVariant` CLI parameter for language conversion (@Markus-Rost #2399)
 
 1.16.0:
 * CHANGED: ActionParse renderer is now the preferred one when available (@benoit74 #2183)

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -60,7 +60,6 @@ interface DownloaderOpts {
   s3?: S3
   webp: boolean
   backoffOptions?: BackoffOptions
-  mwWikiPath?: string
   insecure?: boolean
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,9 @@ const argv: any = yargs(hideBin(process.argv))
 Usage: npm run mwoffliner -- --help`,
   )
   .describe(parameterDescriptions)
-  .require(requiredParams as any)
+  .demandOption(requiredParams)
+  .deprecateOption('mwWikiPath')
+  .deprecateOption('mwIndexPhpPath')
   .strict().argv
 
 /* ***********************************/

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -101,6 +101,7 @@ async function execute(argv: any) {
     customFlavour,
     forceRender,
     forceSkin,
+    langVariant,
   } = argv
 
   let { articleList, articleListToIgnore } = argv
@@ -158,11 +159,7 @@ async function execute(argv: any) {
   /* Wikipedia/... URL; Normalize by adding trailing / as necessary */
   MediaWiki.base = mwUrl
   MediaWiki.getCategories = !!argv.getCategories
-  MediaWiki.wikiPath = mwWikiPath
-  MediaWiki.indexPhpPath = mwIndexPhpPath
   MediaWiki.actionApiPath = mwActionApiPath
-  MediaWiki.restApiPath = mwRestApiPath
-  MediaWiki.modulePathOpt = mwModulePath
   MediaWiki.domain = mwDomain
   MediaWiki.password = mwPassword
   MediaWiki.username = mwUsername
@@ -191,14 +188,10 @@ async function execute(argv: any) {
   /* Get MediaWiki Info */
   let mwMetaData
   try {
-    mwMetaData = await MediaWiki.getMwMetaData()
+    mwMetaData = await MediaWiki.getMwMetaData({ mwWikiPath, mwIndexPhpPath, mwRestApiPath, mwModulePath, forceSkin, langVariant })
   } catch (err) {
     logger.error('FATAL - Failed to get MediaWiki Metadata')
     throw err
-  }
-
-  if (forceSkin) {
-    MediaWiki.skin = forceSkin
   }
 
   const metaDataRequiredKeys = {

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -16,11 +16,11 @@ export const parameterDescriptions = {
   format:
     'Flavour for the scraping. If missing, scrape all article contents. Each --format argument will cause a new local file to be created but options can be combined. Supported options are:\n * novid: no video & audio content\n * nopic: no pictures (implies "novid")\n * nopdf: no PDF files\n * nodet: only the first/head paragraph (implies "novid")\nFlavour can be named (and corresponding ZIM metadata will be created) using a ":":\nExample: "--format=nopic,nodet:mini"',
   keepEmptyParagraphs: 'Keep all sections, even empty ones typically used as placeholders in wikis to outline expected article structure.',
-  mwWikiPath: 'MediaWiki article path (by default "/wiki/")',
-  mwIndexPhpPath: 'MediaWiki index.php path (by default "/w/index.php")',
+  mwWikiPath: 'MediaWiki article path (by default fetched from the wiki)',
+  mwIndexPhpPath: 'MediaWiki index.php path (by default fetched from the wiki)',
   mwActionApiPath: 'MediaWiki API path (by default "/w/api.php")',
-  mwRestApiPath: 'MediaWiki REST API path (by default "/w/rest.php")',
-  mwModulePath: 'MediaWiki module load path (by default "/w/load.php")',
+  mwRestApiPath: 'MediaWiki REST API path ($wgRestPath), automatically chosen based on script path otherwise.',
+  mwModulePath: 'MediaWiki module load path ($wgLoadScript), automatically chosen based on script path otherwise.',
   mwDomain: 'MediaWiki user domain (thought for private wikis)',
   mwUsername: 'MediaWiki username (thought for private wikis)',
   mwPassword: 'MediaWiki user password (thought for private wikis)',
@@ -41,6 +41,7 @@ export const parameterDescriptions = {
   forceRender:
     'Force the usage of a specific API end-point/render, automatically chosen otherwise. Accepted values: [ VisualEditor, WikimediaDesktop. WikimediaMobile, RestApi, ActionParse ]',
   forceSkin: 'Force the usage of a specific skin, automatically chosen otherwise.',
+  langVariant: 'Use a specific language variant, only for wikis supporting language conversion.',
   insecure: 'Skip HTTPS server authenticity verification step',
 }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -253,3 +253,12 @@ interface RenderedArticle {
   displayTitle: string
   html: string
 }
+
+interface SiteInfoArgv {
+  mwWikiPath?: string
+  mwIndexPhpPath?: string
+  mwRestApiPath?: string
+  mwModulePath?: string
+  forceSkin?: string
+  langVariant?: string
+}

--- a/test/e2e/apiPathParamsSanitizing.e2e.test.ts
+++ b/test/e2e/apiPathParamsSanitizing.e2e.test.ts
@@ -2,7 +2,7 @@ import { testAllRenders } from '../testRenders.js'
 import 'dotenv/config.js'
 import { jest } from '@jest/globals'
 import { rimraf } from 'rimraf'
-import { sanitizeApiPathParam, sanitizeWikiPath } from '../../src/sanitize-argument.js'
+import { sanitizeApiPathParam } from '../../src/sanitize-argument.js'
 import { zimcheck } from '../util.js'
 
 jest.setTimeout(60000)
@@ -14,8 +14,6 @@ const parameters = {
   mwActionApiPath: sanitizeApiPathParam('/w/api.php'),
   mwRestApiPath: sanitizeApiPathParam('/w/rest.php'),
   mwModulePath: sanitizeApiPathParam('/w/load.php'),
-  mwWikiPath: sanitizeWikiPath('/wiki/'),
-  mwIndexPhpPath: sanitizeApiPathParam('/w/index.php'),
 }
 
 await testAllRenders('api-path-params', parameters, async (outFiles) => {
@@ -26,14 +24,6 @@ await testAllRenders('api-path-params', parameters, async (outFiles) => {
 
     test('Mediawiki restApiPath option sanitized', () => {
       expect(outFiles[0].mwMetaData.restApiPath).toBe('/w/rest.php')
-    })
-
-    test('Mediawiki wikiPath option sanitized', () => {
-      expect(outFiles[0].mwMetaData.wikiPath).toBe('/wiki/')
-    })
-
-    test('Mediawiki wikiPath option sanitized', () => {
-      expect(outFiles[0].mwMetaData.indexPhpPath).toBe('/w/index.php')
     })
 
     test('Mediawiki modulePathOpt option sanitized', () => {

--- a/test/e2e/articleSubtitle.e2e.test.ts
+++ b/test/e2e/articleSubtitle.e2e.test.ts
@@ -14,8 +14,6 @@ await testRenders(
     articleList: 'Commands/summon,Commands',
     adminEmail: 'test@kiwix.org',
     mwActionApiPath: '/api.php',
-    mwModulePath: '/load.php',
-    mwWikiPath: '/w/',
   },
   async (outFiles) => {
     const articleFromDump = await zimdump(`show --url "Commands/summon" ${outFiles[0].outFile}`)

--- a/test/testRenders.ts
+++ b/test/testRenders.ts
@@ -19,7 +19,6 @@ interface Parameters {
   mwActionApiPath?: string
   mwRestApiPath?: string
   mwModulePath?: string
-  mwWikiPath?: string
 }
 
 /*

--- a/test/unit/renderers/article.renderer.test.ts
+++ b/test/unit/renderers/article.renderer.test.ts
@@ -146,13 +146,13 @@ describe('ArticleRenderer', () => {
       Downloader.setUrlsDirectors(actionParseRenderer, actionParseRenderer)
     })
 
-    it('regular paged has content', async () => {
+    it('regular page has content', async () => {
       const articleId = '荷蘭Floriade世界園藝博覽會'
       const downloadRes = await actionParseRenderer.download({ articleId, articleUrl: Downloader.getArticleUrl(articleId), articleDetail: { title: 'foo' } })
       expect(downloadRes.data).toBeDefined()
     })
 
-    it('moved paged has content retrieved from fallback logic', async () => {
+    it('moved page has content retrieved from fallback logic', async () => {
       const articleId = '荷兰Floriade世界園藝博覽會'
       const downloadRes = await actionParseRenderer.download({ articleId, articleUrl: Downloader.getArticleUrl(articleId), articleDetail: { title: 'foo' } })
       expect(downloadRes.data).toBeDefined()


### PR DESCRIPTION
Fix #2422
Fix #2399

- Remove `mwWikiPath` and `mwIndexPhpPath` CLI parameter, use values from the API instead
- Build `mwRestApiPath` and `mwModulePath` CLI parameter default values from the API
- Add `langVariant` CLI parameter for language conversion
  - Medium term fix for #2399, this replaces the temporary fix for #840