### PR TITLE
Fix wrong SVG content type

### DIFF
--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -688,6 +688,10 @@ class Downloader {
 
   private async getImageMimeType(data: any): Promise<string | null> {
     const fileType = await fileTypeFromBuffer(data)
+    if (fileType && fileType.mime === 'application/xml') {
+      // File type is known to be wrong, might be SVG
+      return null
+    }
     return fileType ? fileType.mime : null
   }
 


### PR DESCRIPTION
Fix #2460

Hardcoding `application/xml` as a known wrong file type, relying on the existing fallback instead.