### PR TITLE
Get files names for wikis using no hashed directory

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -16,6 +16,7 @@ Unreleased:
 * FIX: Fix wrong SVG content type (@Markus-Rost #2464)
 * FIX: Fix missing page titles on some mwIndexPhpPath values (@Markus-Rost #2468)
 * FIX: Set correct MimeType on ZIM Metadata (@Markus-Rost #2470)
+* FIX: Get files names for wikis using no hashed directory (@Markus-Rost #2465)
 
 1.16.0:
 * CHANGED: ActionParse renderer is now the preferred one when available (@benoit74 #2183)

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -1,8 +1,8 @@
 export const MAX_CPU_CORES = 8
-export const IMAGE_THUMB_URL_REGEX = /^.*\/[0-9a-fA-F]{1}\/[0-9a-fA-F]{2}\/([^/]+\/)?(\d+px[-]+)?(.+?\.[A-Za-z0-9]{2,6}(\.[A-Za-z0-9]{2,6})?)$/
-export const LATEX_IMAGE_URL_REGEX = /^.*\/math\/render\/svg\/([A-Za-z0-9]+)$/
-export const WIKIHIERO_IMAGE_URL_REGEX = /^.*\/wikihiero\/img\/(.*\.png)(\?.*)?$/
-export const FANDOM_IMAGE_URL_REGEX = /([^/]+)\/revision\//i
+export const IMAGE_THUMB_URL_REGEX =
+  /^(.*?\/)(transcoded\/|thumb\/)?([0-9a-fA-F]{1}\/[0-9a-fA-F]{2}\/)?([^/]+\.[A-Za-z0-9]{2,6}\/)?(\d+px[-]+)?([^/]+?\.[A-Za-z0-9]{2,6}(\.[A-Za-z0-9]{2,6})?)(\?[0-9a-fA-F]+)?$/
+export const LATEX_IMAGE_URL_REGEX = /^(.*\/math\/render\/svg\/)([A-Za-z0-9]+)$/
+export const FANDOM_IMAGE_URL_REGEX = /^(.*\/)[0-9a-fA-F]{1}\/[0-9a-fA-F]{2}\/([^/]+)\/revision\//i
 export const MIN_IMAGE_THRESHOLD_ARTICLELIST_PAGE = 10
 export const CONCURRENCY_LIMIT = 10
 export const IMAGE_MIME_REGEX = /^image+[/-\w.]+$/

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -13,7 +13,6 @@ import * as logger from '../Logger.js'
 import {
   LATEX_IMAGE_URL_REGEX,
   FANDOM_IMAGE_URL_REGEX,
-  WIKIHIERO_IMAGE_URL_REGEX,
   IMAGE_THUMB_URL_REGEX,
   FIND_HTTP_REGEX,
   BITMAP_IMAGE_MIME_REGEX,
@@ -262,36 +261,36 @@ export function getMediaBase(url: string, escape: boolean) {
   const decodedUrl = decodeURI(url)
   let parts
   let filename
+  let filedir = ''
 
   // Image thumbs
   if ((parts = IMAGE_THUMB_URL_REGEX.exec(decodedUrl)) !== null) {
-    // Remove trailing / in parts[1] if possible
-    parts[1] = parts[1] ? parts[1].substring(0, parts[1].length - 1) : ''
+    // Remove trailing / in parts[4] if possible
+    parts[4] = parts[4] ? parts[4].substring(0, parts[4].length - 1) : ''
 
     // Most common case
-    if (!parts[1] || parts[1].length <= parts[3].length) {
-      filename = parts[3]
+    if (!parts[4] || parts[4].length <= parts[6].length) {
+      filename = parts[6]
     }
 
     // To handle /...px-thumbnail.jpg use case
     else {
-      filename = parts[1] + (parts[4] || '')
+      filename = parts[4] + (parts[7] || '')
     }
+
+    filedir = parts[1]
   }
 
   // Latex (equations)
   else if ((parts = LATEX_IMAGE_URL_REGEX.exec(decodedUrl)) !== null) {
-    filename = parts[1] + '.svg'
-  }
-
-  // WikiHiero hieroglyphs (betting there won't be a name conflict with main namespace pictures)
-  else if ((parts = WIKIHIERO_IMAGE_URL_REGEX.exec(decodedUrl)) !== null) {
-    filename = parts[1]
+    filename = parts[2] + '.svg'
+    filedir = parts[1]
   }
 
   // Fandom has even an other URL scheme
   else if ((parts = FANDOM_IMAGE_URL_REGEX.exec(decodedUrl)) !== null) {
-    filename = parts[1]
+    filename = parts[2]
+    filedir = parts[1]
   }
 
   // Default behaviour (make a hash of the URL)
@@ -299,11 +298,15 @@ export function getMediaBase(url: string, escape: boolean) {
     filename = crypto.createHash('md5').update(decodedUrl).digest('hex') + path.extname(new URL(url).pathname)
   }
 
+  if (filedir) {
+    filedir = crypto.createHash('md5').update(filedir).digest('hex') + '/'
+  }
+
   if (escape) {
     filename = encodeURIComponent(filename)
   }
 
-  return `${config.output.dirs.assets}/${filename}`
+  return `${config.output.dirs.assets}/${filedir}${filename}`
 }
 
 /**

--- a/test/e2e/multimediaContent.test.ts
+++ b/test/e2e/multimediaContent.test.ts
@@ -36,13 +36,13 @@ await testRenders(
 
             expect(mediaFiles).toEqual(
               [
-                '_assets_/Kiwix_-_WikiArabia_Cairo_2017.pdf',
-                '_assets_/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.240p.vp9.webm',
-                '_assets_/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.jpg',
-                '_assets_/Kiwix_icon.svg.png',
-                '_assets_/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).mp3.ogg',
-                '_assets_/page1-120px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
-                '_assets_/page1-1500px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
+                '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_-_WikiArabia_Cairo_2017.pdf',
+                '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.240p.vp9.webm',
+                '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.jpg',
+                '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_icon.svg.png',
+                '_assets_/0c70a452f799bfe840676ee341124611/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).mp3.ogg',
+                '_assets_/0c70a452f799bfe840676ee341124611/page1-120px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
+                '_assets_/0c70a452f799bfe840676ee341124611/page1-1500px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
                 '_res_/favicon.png',
               ].sort(),
             )
@@ -68,13 +68,13 @@ await testRenders(
 
             expect(mediaFiles).toEqual(
               [
-                '_assets_/Kiwix_-_WikiArabia_Cairo_2017.pdf',
-                '_assets_/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.240p.vp9.webm',
-                '_assets_/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.jpg',
-                '_assets_/Kiwix_icon.svg.png',
-                '_assets_/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).mp3.ogg',
-                '_assets_/page1-120px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
-                '_assets_/page1-1500px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
+                '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_-_WikiArabia_Cairo_2017.pdf',
+                '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.240p.vp9.webm',
+                '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.jpg',
+                '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_icon.svg.png',
+                '_assets_/0c70a452f799bfe840676ee341124611/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).mp3.ogg',
+                '_assets_/0c70a452f799bfe840676ee341124611/page1-120px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
+                '_assets_/0c70a452f799bfe840676ee341124611/page1-1500px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
                 '_res_/favicon.png',
               ].sort(),
             )
@@ -119,39 +119,39 @@ await testRenders(
               if (dump.nopic) {
                 expect(mediaFiles).toEqual(
                   [
-                    '_assets_/Kiwix_-_WikiArabia_Cairo_2017.pdf',
-                    // '_assets_/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.120p.vp9.webm', // these files were omitted by nopic parameter
-                    // '_assets_/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.jpg',
-                    // '_assets_/Kiwix_icon.svg.png',
-                    // '_assets_/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).mp3.ogg',
-                    // '_assets_/page1-120px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
-                    // '_assets_/page1-1500px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
+                    '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_-_WikiArabia_Cairo_2017.pdf',
+                    // '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.120p.vp9.webm', // these files were omitted by nopic parameter
+                    // '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.jpg',
+                    // '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_icon.svg.png',
+                    // '_assets_/0c70a452f799bfe840676ee341124611/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).mp3.ogg',
+                    // '_assets_/0c70a452f799bfe840676ee341124611/page1-120px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
+                    // '_assets_/0c70a452f799bfe840676ee341124611/page1-1500px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
                     '_res_/favicon.png',
                   ].sort(),
                 )
               } else if (dump.novid) {
                 expect(mediaFiles).toEqual(
                   [
-                    '_assets_/Kiwix_-_WikiArabia_Cairo_2017.pdf',
-                    // '_assets_/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.120p.vp9.webm', // these files were omitted by novid parameter
-                    // '_assets_/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.jpg',
-                    '_assets_/Kiwix_icon.svg.png',
-                    // '_assets_/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).mp3.ogg',
-                    '_assets_/page1-120px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
-                    '_assets_/page1-1500px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
+                    '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_-_WikiArabia_Cairo_2017.pdf',
+                    // '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.120p.vp9.webm', // these files were omitted by novid parameter
+                    // '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.jpg',
+                    '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_icon.svg.png',
+                    // '_assets_/0c70a452f799bfe840676ee341124611/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).mp3.ogg',
+                    '_assets_/0c70a452f799bfe840676ee341124611/page1-120px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
+                    '_assets_/0c70a452f799bfe840676ee341124611/page1-1500px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
                     '_res_/favicon.png',
                   ].sort(),
                 )
               } else if (dump.nopdf) {
                 expect(mediaFiles).toEqual(
                   [
-                    // '_assets_/Kiwix_-_WikiArabia_Cairo_2017.pdf',  // this file was omitted by nopdf parameter
-                    '_assets_/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.240p.vp9.webm',
-                    '_assets_/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.jpg',
-                    '_assets_/Kiwix_icon.svg.png',
-                    '_assets_/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).mp3.ogg',
-                    '_assets_/page1-120px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
-                    '_assets_/page1-1500px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
+                    // '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_-_WikiArabia_Cairo_2017.pdf',  // this file was omitted by nopdf parameter
+                    '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.240p.vp9.webm',
+                    '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.jpg',
+                    '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_icon.svg.png',
+                    '_assets_/0c70a452f799bfe840676ee341124611/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).mp3.ogg',
+                    '_assets_/0c70a452f799bfe840676ee341124611/page1-120px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
+                    '_assets_/0c70a452f799bfe840676ee341124611/page1-1500px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
                     '_res_/favicon.png',
                   ].sort(),
                 )
@@ -185,39 +185,39 @@ await testRenders(
               if (dump.nopic) {
                 expect(mediaFiles).toEqual(
                   [
-                    '_assets_/Kiwix_-_WikiArabia_Cairo_2017.pdf',
-                    // '_assets_/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.120p.vp9.webm', // these files were omitted by nopic parameter
-                    // '_assets_/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.jpg',
-                    // '_assets_/Kiwix_icon.svg.png',
-                    // '_assets_/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).mp3.ogg',
-                    // '_assets_/page1-120px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
-                    // '_assets_/page1-1500px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
+                    '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_-_WikiArabia_Cairo_2017.pdf',
+                    // '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.120p.vp9.webm', // these files were omitted by nopic parameter
+                    // '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.jpg',
+                    // '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_icon.svg.png',
+                    // '_assets_/0c70a452f799bfe840676ee341124611/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).mp3.ogg',
+                    // '_assets_/0c70a452f799bfe840676ee341124611/page1-120px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
+                    // '_assets_/0c70a452f799bfe840676ee341124611/page1-1500px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
                     '_res_/favicon.png',
                   ].sort(),
                 )
               } else if (dump.novid) {
                 expect(mediaFiles).toEqual(
                   [
-                    '_assets_/Kiwix_-_WikiArabia_Cairo_2017.pdf',
-                    // '_assets_/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.120p.vp9.webm', // these files were omitted by novid parameter
-                    // '_assets_/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.jpg',
-                    '_assets_/Kiwix_icon.svg.png',
-                    // '_assets_/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).mp3.ogg',
-                    '_assets_/page1-120px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
-                    '_assets_/page1-1500px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
+                    '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_-_WikiArabia_Cairo_2017.pdf',
+                    // '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.120p.vp9.webm', // these files were omitted by novid parameter
+                    // '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.jpg',
+                    '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_icon.svg.png',
+                    // '_assets_/0c70a452f799bfe840676ee341124611/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).mp3.ogg',
+                    '_assets_/0c70a452f799bfe840676ee341124611/page1-120px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
+                    '_assets_/0c70a452f799bfe840676ee341124611/page1-1500px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
                     '_res_/favicon.png',
                   ].sort(),
                 )
               } else if (dump.nopdf) {
                 expect(mediaFiles).toEqual(
                   [
-                    // '_assets_/Kiwix_-_WikiArabia_Cairo_2017.pdf',  // this file was omitted by nopdf parameter
-                    '_assets_/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.240p.vp9.webm',
-                    '_assets_/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.jpg',
-                    '_assets_/Kiwix_icon.svg.png',
-                    '_assets_/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).mp3.ogg',
-                    '_assets_/page1-120px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
-                    '_assets_/page1-1500px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
+                    // '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_-_WikiArabia_Cairo_2017.pdf',  // this file was omitted by nopdf parameter
+                    '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.240p.vp9.webm',
+                    '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_Hackathon_2017_Florence_WikiFundi.webm.jpg',
+                    '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_icon.svg.png',
+                    '_assets_/0c70a452f799bfe840676ee341124611/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).mp3.ogg',
+                    '_assets_/0c70a452f799bfe840676ee341124611/page1-120px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
+                    '_assets_/0c70a452f799bfe840676ee341124611/page1-1500px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
                     '_res_/favicon.png',
                   ].sort(),
                 )

--- a/test/unit/treatments/media.treatment.test.ts
+++ b/test/unit/treatments/media.treatment.test.ts
@@ -158,15 +158,15 @@ describe('MediaTreatment', () => {
       const sourceUrl = sources[0].getAttribute('src')
 
       // Video poster correctly re-written
-      expect(videoPosterUrl).toEqual('./_assets_/S6-Dendritic_Cells_with_Conidia_in_Collagen.ogv.jpg')
+      expect(videoPosterUrl).toEqual('./_assets_/0c70a452f799bfe840676ee341124611/S6-Dendritic_Cells_with_Conidia_in_Collagen.ogv.jpg')
       // Source src correctly re-written
-      expect(sourceUrl).toEqual('./_assets_/S6-Dendritic_Cells_with_Conidia_in_Collagen.ogv.120p.vp9.webm')
+      expect(sourceUrl).toEqual('./_assets_/0c70a452f799bfe840676ee341124611/S6-Dendritic_Cells_with_Conidia_in_Collagen.ogv.120p.vp9.webm')
 
       const imgEl = ret.doc.querySelector('img')
       const imgSrc = imgEl.getAttribute('src')
 
       // Img src correctly re-written
-      expect(imgSrc).toEqual('./_assets_/Dendritic_cell_revealed.jpg')
+      expect(imgSrc).toEqual('./_assets_/0c70a452f799bfe840676ee341124611/Dendritic_cell_revealed.jpg')
     })
 
     test('treatMedias format="nopic"', async () => {

--- a/test/unit/urlRewriting.test.ts
+++ b/test/unit/urlRewriting.test.ts
@@ -128,13 +128,13 @@ describe('Styles', () => {
     // resourceLink is still a link
     expect($resourceLink.nodeName).toEqual('A')
     // resourceLink has been re-written
-    expect($resourceLink.getAttribute('href')).toEqual('../_assets_/De-Z%C3%BCrich.ogg')
+    expect($resourceLink.getAttribute('href')).toEqual('../_assets_/0c70a452f799bfe840676ee341124611/De-Z%C3%BCrich.ogg')
 
     await rewriteUrl(complexParentArticleId, dump, $ogaResourceLink)
     // ogaResourceLink is still a link
     expect($ogaResourceLink.nodeName).toEqual('A')
     // ogaResourceLink has been re-written
-    expect($ogaResourceLink.getAttribute('href')).toEqual('../_assets_/Fr-Laissez-faire.oga')
+    expect($ogaResourceLink.getAttribute('href')).toEqual('../_assets_/0c70a452f799bfe840676ee341124611/Fr-Laissez-faire.oga')
   })
 
   test('e2e url rewriting', async () => {

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -147,14 +147,22 @@ describe('Utils', () => {
   test('getMediaBase tests', async () => {
     // Thumbs
     // Thumb 1
-    expect(getMediaBase('https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Westminstpalace.jpg/220px-Westminstpalace.jpg', true)).toEqual('_assets_/Westminstpalace.jpg')
+    expect(getMediaBase('https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Westminstpalace.jpg/220px-Westminstpalace.jpg', true)).toEqual(
+      '_assets_/0c70a452f799bfe840676ee341124611/Westminstpalace.jpg',
+    )
+    // Thumb 2 (with cache break)
+    expect(getMediaBase('https://terraria.wiki.gg/images/thumb/c/c3/Achievement_Eye_on_You.png/48px-Achievement_Eye_on_You.png?926e93', true)).toEqual(
+      '_assets_/d8a9a8b9feaff5d65577eb04975bf021/Achievement_Eye_on_You.png',
+    )
     // No thumb
-    expect(getMediaBase('https://upload.wikimedia.org/wikipedia/commons/3/39/Westminstpalace.jpg', true)).toEqual('_assets_/Westminstpalace.jpg')
+    expect(getMediaBase('https://upload.wikimedia.org/wikipedia/commons/3/39/Westminstpalace.jpg', true)).toEqual('_assets_/0c70a452f799bfe840676ee341124611/Westminstpalace.jpg')
     // SVG
-    expect(getMediaBase('https://upload.wikimedia.org/wikipedia/commons/0/0d/VFPt_Solenoid_correct2.svg', true)).toEqual('_assets_/VFPt_Solenoid_correct2.svg')
+    expect(getMediaBase('https://upload.wikimedia.org/wikipedia/commons/0/0d/VFPt_Solenoid_correct2.svg', true)).toEqual(
+      '_assets_/0c70a452f799bfe840676ee341124611/VFPt_Solenoid_correct2.svg',
+    )
     // SVG PNG thumb
     expect(getMediaBase('https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/VFPt_Solenoid_correct2.svg/120px-VFPt_Solenoid_correct2.svg.png', true)).toEqual(
-      '_assets_/VFPt_Solenoid_correct2.svg.png',
+      '_assets_/0c70a452f799bfe840676ee341124611/VFPt_Solenoid_correct2.svg.png',
     )
     // Video poster
     expect(
@@ -162,9 +170,9 @@ describe('Utils', () => {
         'https://upload.wikimedia.org/wikipedia/commons/thumb/b/b7/S6-Dendritic_Cells_with_Conidia_in_Collagen.ogv/120px--S6-Dendritic_Cells_with_Conidia_in_Collagen.ogv.jpg',
         true,
       ),
-    ).toEqual('_assets_/S6-Dendritic_Cells_with_Conidia_in_Collagen.ogv.jpg')
+    ).toEqual('_assets_/0c70a452f799bfe840676ee341124611/S6-Dendritic_Cells_with_Conidia_in_Collagen.ogv.jpg')
     // Escaped UR
-    expect(getMediaBase('https://upload.wikimedia.org/wikipedia/commons/c/c6/De-Z%C3%BCrich.ogg', false)).toEqual('_assets_/De-Zürich.ogg')
+    expect(getMediaBase('https://upload.wikimedia.org/wikipedia/commons/c/c6/De-Z%C3%BCrich.ogg', false)).toEqual('_assets_/0c70a452f799bfe840676ee341124611/De-Zürich.ogg')
     // Long thumb
     expect(
       getMediaBase(
@@ -172,7 +180,7 @@ describe('Utils', () => {
         true,
       ),
     ).toEqual(
-      '_assets_/US_Navy_070406-N-2959L-756_Members_of_USS_Ronald_Reagan_(CVN_76)_First_Class_Association_prepare_and_put_toppings_on_pizzas_in_the_galley_as_part_of_a_special_dinner_prepared_for_the_crew.jpg',
+      '_assets_/0c70a452f799bfe840676ee341124611/US_Navy_070406-N-2959L-756_Members_of_USS_Ronald_Reagan_(CVN_76)_First_Class_Association_prepare_and_put_toppings_on_pizzas_in_the_galley_as_part_of_a_special_dinner_prepared_for_the_crew.jpg',
     )
     // Long thumb with SVG PNG
     expect(
@@ -181,35 +189,56 @@ describe('Utils', () => {
         true,
       ),
     ).toEqual(
-      '_assets_/US_Navy_070406-N-2959L-756_Members_of_USS_Ronald_Reagan_(CVN_76)_First_Class_Association_prepare_and_put_toppings_on_pizzas_in_the_galley_as_part_of_a_special_dinner_prepared_for_the_crew.svg.png',
+      '_assets_/0c70a452f799bfe840676ee341124611/US_Navy_070406-N-2959L-756_Members_of_USS_Ronald_Reagan_(CVN_76)_First_Class_Association_prepare_and_put_toppings_on_pizzas_in_the_galley_as_part_of_a_special_dinner_prepared_for_the_crew.svg.png',
     )
 
-    // Latex (equations)
-    expect(getMediaBase('https://wikimedia.org/api/rest_v1/media/math/render/svg/da47d67ac8dcb0be8b68d7bfdc676d9ce9bf1606', true)).toEqual(
-      '_assets_/da47d67ac8dcb0be8b68d7bfdc676d9ce9bf1606.svg',
+    // No hashed upload directory
+    // Thumb
+    expect(getMediaBase('https://minecraft.wiki/images/thumb/Diamond_Pickaxe_JE3_BE3.png/120px-Diamond_Pickaxe_JE3_BE3.png?7409d', true)).toEqual(
+      '_assets_/5af80496508534f4cdd561aac15bbc50/Diamond_Pickaxe_JE3_BE3.png',
     )
+    // No thumb
+    expect(getMediaBase('https://minecraft.wiki/images/Minecraft_Wiki_header.svg?0d27d', true)).toEqual('_assets_/5af80496508534f4cdd561aac15bbc50/Minecraft_Wiki_header.svg')
 
     // WikiHiero (hieroglyphs)
     // WikiHiero png with URL args
-    expect(getMediaBase('https://en.wikipedia.org/w/extensions/wikihiero/img/hiero_G1.png?4d556', false)).toEqual('_assets_/hiero_G1.png')
+    expect(getMediaBase('https://en.wikipedia.org/w/extensions/wikihiero/img/hiero_G1.png?4d556', false)).toEqual('_assets_/782505031fe338abab4546d8d985b782/hiero_G1.png')
     // WikiHiero png without URL args
-    expect(getMediaBase('https://en.wikipedia.org/w/extensions/wikihiero/img/hiero_G1.png', false)).toEqual('_assets_/hiero_G1.png')
+    expect(getMediaBase('https://en.wikipedia.org/w/extensions/wikihiero/img/hiero_G1.png', false)).toEqual('_assets_/782505031fe338abab4546d8d985b782/hiero_G1.png')
 
-    // Score - is default behaviour
-    expect(getMediaBase('https://upload.wikimedia.org/score/6/c/6clze8fxoo65795idk91426rskovmgp/6clze8fx.png', false)).toEqual('_assets_/012a83318ce8d3a438dbed3127b9e339.png')
+    // Score
+    expect(getMediaBase('https://upload.wikimedia.org/score/6/c/6clze8fxoo65795idk91426rskovmgp/6clze8fx.png', false)).toEqual(
+      '_assets_/a3b45f05ce6fe783907ef96d52c753c0/6clze8fx.png',
+    )
 
-    // Graphoid (charts) - is default behaviour
+    // Graphoid (charts)
     expect(
       getMediaBase('https://en.wikipedia.org/api/rest_v1/page/graph/png/COVID-19_pandemic_in_the_United_Kingdom/0/28fe8c45f73e8cc60d45086655340f49cdfd37d0.png', true),
-    ).toEqual('_assets_/43ffd82a8ffc4755312c22950fde7ac5.png')
+    ).toEqual('_assets_/c54a67d200901809165ee017d0c80e94/28fe8c45f73e8cc60d45086655340f49cdfd37d0.png')
+
+    // Latex (equations)
+    expect(getMediaBase('https://wikimedia.org/api/rest_v1/media/math/render/svg/da47d67ac8dcb0be8b68d7bfdc676d9ce9bf1606', true)).toEqual(
+      '_assets_/eb734a37dd21ce173a46342d1cc64c92/da47d67ac8dcb0be8b68d7bfdc676d9ce9bf1606.svg',
+    )
 
     // Fandom
+    // Thumb
     expect(
       getMediaBase(
         'https://static.wikia.nocookie.net/minecraft_de_gamepedia/images/e/ee/Diamantschwert_%28Dungeons%29.png/revision/latest/scale-to-width-down/60?cb=20200409173531',
         true,
       ),
-    ).toEqual('_assets_/Diamantschwert_(Dungeons).png')
+    ).toEqual('_assets_/28589f4742a95f314ca2e83cca07f2d0/Diamantschwert_(Dungeons).png')
+    // No thumb
+    expect(getMediaBase('https://static.wikia.nocookie.net/minecraft_de_gamepedia/images/e/ee/Diamantschwert_%28Dungeons%29.png/revision/latest?cb=20200409173531', true)).toEqual(
+      '_assets_/28589f4742a95f314ca2e83cca07f2d0/Diamantschwert_(Dungeons).png',
+    )
+
+    // Same filename from different sources
+    // https://commons.wikimedia.org/wiki/File:Example.jpg
+    expect(getMediaBase('https://upload.wikimedia.org/wikipedia/commons/a/a9/Example.jpg', true)).toEqual('_assets_/0c70a452f799bfe840676ee341124611/Example.jpg')
+    // https://en.wikipedia.org/wiki/File:Example.jpg
+    expect(getMediaBase('https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg', true)).toEqual('_assets_/c8f24dc75f9c782269c846c9b17e400f/Example.jpg')
 
     // Default behaviour
     expect(

--- a/test/unit/webpAndRedirection.test.ts
+++ b/test/unit/webpAndRedirection.test.ts
@@ -36,9 +36,9 @@ Real-time computer graphics`
   const zimFile = new Archive(outFiles[0].outFile)
 
   // passed test for png
-  expect(await isWebpPresent('Animexample3edit.png', zimFile)).toBeTruthy()
+  expect(await isWebpPresent('0c70a452f799bfe840676ee341124611/Animexample3edit.png', zimFile)).toBeTruthy()
   // passed test for jpg
-  expect(await isWebpPresent('Claychick.jpg', zimFile)).toBeTruthy()
+  expect(await isWebpPresent('0c70a452f799bfe840676ee341124611/Claychick.jpg', zimFile)).toBeTruthy()
   // redirection check successful
   expect(await isRedirectionPresent('href="Real-time_rendering"', zimFile)).toBeTruthy()
   rimraf.sync(testId)


### PR DESCRIPTION
Fix #2465

Uses a `_assets_` subdirectory based on the hashed file url (without the file name specific parts) to avoid filename conflicts between files from different sources.