### PR TITLE
Also retry `internal_api_error_ThrottledError` errors

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -31,7 +31,7 @@ Unreleased:
 * FIX: Don't reserve space for elements that don't exist (@Markus-Rost #2495)
 * FIX: Get the whole article when the specified section is not available (@Markus-Rost #2480)
 * FIX: Retry ERR_CANCELED errors since this might be a transient problem (@benoit74 #2414)
-* FIX: Also retry `internal_api_error_MWException` errors (@benoit74 #2505)
+* FIX: Also retry `internal_api_error_MWException` and `internal_api_error_ThrottledError` errors (@benoit74 #2505 #2506)
 * FIX: Fix logging + documentation around `RedisKvs.iterateItems` (@benoit74 #2500)
 * FIX: Add redirects from all acceptable namespaces (@benoit74 #2429)
 

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -197,6 +197,7 @@ class Downloader {
         }
         if (
           [
+            'internal_api_error_ThrottledError',
             'internal_api_error_MWException',
             'internal_api_error_ArgumentCountError',
             'internal_api_error_DBConnectionError',


### PR DESCRIPTION
While this is not really a perfect solution to handle throttling since we just use the default backoff strategy, I feel like it might help to workaround light throttling happening every now and then.

For instance in https://farm.openzim.org/pipeline/1d247576-ba6f-4cd1-a548-2eb15a519f40/debug, the scraper achieved to build the whole `maxi` ZIM, and got this error after having retrieved 5.1% of `nodet` ZIM articles. So it does not look at all like we are really retrieving articles way too fast. It looks like for some reason at some point the server asked us to slow down a bit, and this is exactly what will happen with the default backoff.