### PR TITLE
Check API availability at scraper startup instead of raw mwUrl which might not be reachable

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -34,6 +34,7 @@ Unreleased:
 * FIX: Also retry `internal_api_error_MWException` and `internal_api_error_ThrottledError` errors (@benoit74 #2505 #2506)
 * FIX: Fix logging + documentation around `RedisKvs.iterateItems` (@benoit74 #2500)
 * FIX: Add redirects from all acceptable namespaces (@benoit74 #2429)
+* FIX: Check API availability at scraper startup instead of raw mwUrl which might not be reachable (@benoit74 #2447)
 
 1.16.0:
 * CHANGED: ActionParse renderer is now the preferred one when available (@benoit74 #2183)

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -152,6 +152,10 @@ class MediaWiki {
     this.#password = value
   }
 
+  get actionApiPath() {
+    return this.#actionApiPath
+  }
+
   set actionApiPath(value: string) {
     if (value) {
       this.#actionApiPath = value

--- a/src/sanitize-argument.ts
+++ b/src/sanitize-argument.ts
@@ -1,6 +1,6 @@
 import S3 from './S3.js'
 import RedisStore from './RedisStore.js'
-import { fileURLToPath } from 'url'
+import { fileURLToPath, URL } from 'url'
 import pathParser from 'path'
 import * as logger from './Logger.js'
 import fs from 'fs'
@@ -9,6 +9,7 @@ import * as path from 'path'
 import { parameterDescriptions } from './parameterList.js'
 import { RENDERERS_LIST } from './util/const.js'
 import Downloader from './Downloader.js'
+import MediaWiki from './MediaWiki.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -100,10 +101,10 @@ export async function sanitize_all(argv: any) {
 // perform live checks of arguments needing a connection "somewhere"
 export async function check_all(argv: any) {
   // extracting required arguments
-  const { mwUrl, customZimFavicon, optimisationCacheUrl, insecure } = argv
+  const { mwUrl, mwActionApiPath, customZimFavicon, optimisationCacheUrl, insecure } = argv
 
-  // check mwUrl availability
-  await check_mwUrl(mwUrl)
+  // check mediawiki API availability
+  await check_mwApiReachability(mwUrl, mwActionApiPath)
 
   // check s3 availability
   await check_s3(optimisationCacheUrl, insecure)
@@ -180,9 +181,10 @@ export function sanitize_speed(_speed: any) {
   }
 }
 
-export async function check_mwUrl(mwUrl: string) {
-  await Downloader.get(mwUrl).catch((err) => {
-    throw new Error(`mwUrl [${mwUrl}] is not valid:\n${err}`)
+export async function check_mwApiReachability(mwUrl: string, mwActionApiPath: string) {
+  const apiFullUrl = new URL(mwActionApiPath || MediaWiki.actionApiPath, mwUrl).toString()
+  await Downloader.get(apiFullUrl).catch((err) => {
+    throw new Error(`Mediawiki API URL [${apiFullUrl}] is not reachable:\n${err}`)
   })
 }
 


### PR DESCRIPTION
Fix #2447

Changes:
- so far, at scraper startup we've checked the raw `mwUrl` ; this is not really correct because we never use this raw URL
- with this PR, we check the `api.php` API reachability since this is supposed to be correct in all situations and has become the only real required API / setting (with `mwUrl`) since #2456
- changed a bit wording to not speak about validity but reachability ; the URL might be valid but the scraper fails to reach it for whatever reason and this "valid" word was confusing