### PR TITLE
Fix: Ensure homepage includes redirected articles from --articleList (#2206)

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,5 @@
 Unreleased:
+* FIX: Ensure homepage includes redirected articles from --articleList (@ziaddevv #2206)
 * FIX: Support section redirects (@Markus-Rost @benoit74 #2382)
 * FIX: Stop removing links around images (@benoit74 #1214)
 * FIX: Retry more transient errors (@benoit74 #2425)

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -608,7 +608,15 @@ async function execute(argv: any) {
     doc.querySelector('title').innerHTML = sanitizeString(dump.mwMetaData.title) || sanitizeString(dump.opts.customZimTitle)
     const articlesWithImages: ArticleDetail[] = []
     const allArticles: ArticleDetail[] = []
-    for (const articleId of articleListLines) {
+    for (const articleTitle of articleListLines) {
+      let articleId = articleTitle.replace(/ /g, '_')
+
+      // check if this is a redirect
+      const redirect = await redirectsXId.get(articleId)
+      if (redirect) {
+        articleId = redirect.targetId
+      }
+
       const articleDetail = await articleDetailXId.get(articleId)
       if (articleDetail) {
         allArticles.push(articleDetail)


### PR DESCRIPTION
Summary

This PR fixes an issue where articles passed via --articleList were missing from the homepage if they were redirects.


Fix

The loop now uses the canonical titles already stored in Redis (redirectsXId) to resolve redirects before fetching article details. This ensures redirected articles are included on the homepage.

Fixes #2206