### PR TITLE
Rework file downloads to reduce pressure on servers and better handle throttling

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -39,6 +39,8 @@ Unreleased:
 * CHANGED: If vector2022 night mode is enabled, use the preferred color scheme (@Markus-Rost #2086)
 * NEW: Add `maxlag` API parameter to reduce pressure on Mediawiki servers during high load (@benoit74 #2365)
 * FIX: Better handling of audio resources in articles for full ZIMs (@benoit74 #2420)
+* CHANGED: Rework file downloads to reduce pressure on servers and better handle throttling (@benoit74 #2377)
+* FIX: Automatically delete old Redis lists (@benoit74 #1906)
 
 1.16.0:
 * CHANGED: ActionParse renderer is now the preferred one when available (@benoit74 #2183)

--- a/src/mutex.ts
+++ b/src/mutex.ts
@@ -1,5 +1,6 @@
 import { Mutex } from 'async-mutex'
 
 const zimCreatorMutex = new Mutex()
+const fileDownloadMutex = new Mutex()
 
-export { zimCreatorMutex }
+export { zimCreatorMutex, fileDownloadMutex }

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -233,7 +233,7 @@ async function execute(argv: any) {
   await RenderingContext.createRenderers(forceRender, hasWikimediaMobileApi)
 
   await RedisStore.connect()
-  const { articleDetailXId, filesToDownloadXPath, filesToRetryXPath, redirectsXId } = RedisStore
+  const { articleDetailXId, filesToDownloadXPath, redirectsXId } = RedisStore
   // Output directory
   const outputDirectory = path.isAbsolute(_outputDirectory || '') ? _outputDirectory : path.join(process.cwd(), _outputDirectory || 'out')
   await mkdirPromise(outputDirectory)
@@ -455,7 +455,7 @@ async function execute(argv: any) {
       }),
     )
 
-    await downloadFiles(filesToDownloadXPath, filesToRetryXPath, zimCreator, dump)
+    await downloadFiles(filesToDownloadXPath, zimCreator, dump)
 
     logger.log('Writing Article Redirects')
     await writeArticleRedirects(dump, zimCreator)

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -42,6 +42,11 @@ type ArticleDetail = PageInfo & {
   contentmodel?: string
 }
 
+type FileToDownload = FileDetail & {
+  path: string
+  downloadAttempts: number
+}
+
 type FileDetail = {
   url: string
   mult?: number
@@ -76,7 +81,6 @@ interface RKVS<T> {
 interface RS {
   readonly client: any // RedisClientType
   readonly filesToDownloadXPath: RKVS<FileDetail>
-  readonly filesToRetryXPath: RKVS<FileDetail>
   readonly articleDetailXId: RKVS<ArticleDetail>
   readonly redirectsXId: RKVS<ArticleRedirect>
   connect: (populateStores?: boolean) => Promise<void>

--- a/src/util/RedisQueue.ts
+++ b/src/util/RedisQueue.ts
@@ -1,0 +1,70 @@
+import type { RedisClientType } from 'redis'
+
+export default class RedisQueue<T> {
+  private redisClient: RedisClientType
+  private readonly dbName: string
+  private readonly dehydratedKeys?: string[]
+  private readonly hydratedKeys?: string[]
+
+  constructor(redisClient: RedisClientType, dbName: string, keyMapping?: KVS<string>) {
+    this.redisClient = redisClient
+    this.dbName = dbName
+    if (keyMapping) {
+      this.hydratedKeys = Object.values(keyMapping)
+      this.dehydratedKeys = Object.keys(keyMapping)
+    }
+  }
+
+  public async pop(): Promise<T> {
+    const val = await this.redisClient.rPop(this.dbName)
+    return this.hydrateObject(val)
+  }
+
+  public push(val: T): Promise<number> {
+    return this.redisClient.lPush(this.dbName, this.dehydrateObject(val))
+  }
+
+  public len(): Promise<number> {
+    return this.redisClient.hLen(this.dbName)
+  }
+
+  public flush(): Promise<number> {
+    return this.redisClient.del(this.dbName)
+  }
+
+  private hydrateObject(value: string): any {
+    if (!value) {
+      return value
+    }
+    const obj = JSON.parse(value)
+    if (this.hydratedKeys && typeof obj === 'object') {
+      const mappedVal: any = {}
+      for (const key of Object.keys(obj)) {
+        const mapIndex = this.dehydratedKeys.indexOf(key)
+        if (mapIndex !== -1) {
+          mappedVal[this.hydratedKeys[mapIndex]] = obj[key]
+        } else {
+          mappedVal[key] = obj[key]
+        }
+      }
+      return mappedVal
+    }
+    return obj
+  }
+
+  private dehydrateObject(obj: any): string {
+    let mappedVal = obj
+    if (obj && this.dehydratedKeys && typeof obj === 'object') {
+      mappedVal = {}
+      for (const key of Object.keys(obj)) {
+        const mapIndex = this.hydratedKeys.indexOf(key)
+        if (mapIndex !== -1) {
+          mappedVal[this.dehydratedKeys[mapIndex]] = obj[key]
+        } else {
+          mappedVal[key] = obj[key]
+        }
+      }
+    }
+    return typeof mappedVal === 'string' ? mappedVal : JSON.stringify(mappedVal)
+  }
+}

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -4,7 +4,6 @@ export const IMAGE_THUMB_URL_REGEX =
 export const LATEX_IMAGE_URL_REGEX = /^(.*\/math\/render\/svg\/)([A-Za-z0-9]+)$/
 export const FANDOM_IMAGE_URL_REGEX = /^(.*\/)[0-9a-fA-F]{1}\/[0-9a-fA-F]{2}\/([^/]+)\/revision\//i
 export const MIN_IMAGE_THRESHOLD_ARTICLELIST_PAGE = 10
-export const CONCURRENCY_LIMIT = 10
 export const IMAGE_MIME_REGEX = /^image+[/-\w.]+$/
 export const FIND_HTTP_REGEX = /^(?:https?:\/\/)?/i
 export const DB_ERROR = 'internal_api_error_DBQueryError'
@@ -17,6 +16,8 @@ export const DO_PROPAGATION = /mw\.requestIdleCallback\( doPropagation, \{ timeo
 export const LOAD_PHP = /script.src = ".*load\.php.*";/
 export const RULE_TO_REDIRECT = /window\.top !== window\.self/
 export const MAX_FILE_DOWNLOAD_RETRIES = 5
+export const FILES_DOWNLOAD_FAILURE_MINIMUM_FOR_CHECK = 50 // minimum number of files failing download before starting to consider for failing the scrape
+export const FILES_DOWNLOAD_FAILURE_TRESHOLD_PER_TEN_THOUSAND = 10 // 10 = 0.1%
 export const BLACKLISTED_NS = ['Story'] // 'Story' Wikipedia namespace is content, but not indgestable by Parsoid https://github.com/openzim/mwoffliner/issues/1853
 export const RENDERERS_LIST = ['WikimediaDesktop', 'VisualEditor', 'WikimediaMobile', 'RestApi', 'ActionParse']
 export const WIKIMEDIA_REST_API_PATH = '/api/rest_v1/'

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -503,3 +503,31 @@ export function truncateUtf8Bytes(text: string, maxBytes: number) {
 
   return text.slice(0, low - 1)
 }
+
+/**
+ * Parse a Retry-After header into a timestamp (ms since epoch).
+ * @param {string} headerValue The value of the Retry-After header.
+ * @returns {number|null} Epoch time in ms at which you can retry, or null if invalid.
+ */
+export function parseRetryAfterHeader(headerValue: string) {
+  if (!headerValue) return null
+
+  // Trim whitespace just in case
+  const value = headerValue.trim()
+
+  // Case 1: delta-seconds (numeric)
+  if (/^\d+$/.test(value)) {
+    const seconds = parseInt(value, 10)
+    if (isNaN(seconds)) return null
+    return Date.now() + seconds * 1000
+  }
+
+  // Case 2: HTTP-date
+  const date = Date.parse(value)
+  if (!isNaN(date)) {
+    return date
+  }
+
+  // Could not parse
+  return null
+}

--- a/test/unit/bootstrap.ts
+++ b/test/unit/bootstrap.ts
@@ -9,8 +9,8 @@ RedisStore.setOptions(process.env.REDIS || config.defaults.redisPath, { quitOnEr
 
 export const startRedis = async () => {
   await RedisStore.connect()
-  const { articleDetailXId, redirectsXId, filesToDownloadXPath, filesToRetryXPath } = RedisStore
-  await Promise.all([articleDetailXId.flush(), redirectsXId.flush(), filesToDownloadXPath.flush(), filesToRetryXPath.flush()])
+  const { articleDetailXId, redirectsXId, filesToDownloadXPath, filesQueues } = RedisStore
+  await Promise.all([articleDetailXId.flush(), redirectsXId.flush(), filesToDownloadXPath.flush(), ...filesQueues.map((queue) => queue.flush)])
 }
 
 export const stopRedis = async () => {

--- a/test/unit/util/RedisQueue.test.ts
+++ b/test/unit/util/RedisQueue.test.ts
@@ -1,0 +1,49 @@
+import RedisQueue from '../../../src/util/RedisQueue.js'
+import RedisStore from '../../../src/RedisStore.js'
+import { startRedis, stopRedis } from '../bootstrap.js'
+
+describe('Test RedisQueue operations', () => {
+  beforeAll(startRedis)
+  afterAll(stopRedis)
+
+  let queue1: RedisQueue<Value>
+  let queue2: RedisQueue<Value>
+
+  beforeAll(() => {
+    const client = RedisStore.client
+    queue1 = new RedisQueue<Value>(client, 'test-queue1', {
+      v: 'value',
+    })
+    queue1.flush()
+    queue2 = new RedisQueue<Value>(client, 'test-queue2', {
+      v: 'value',
+    })
+    queue2.flush()
+  })
+
+  interface Value {
+    value: string
+  }
+
+  test('simple test', async () => {
+    queue1.push({ value: 'value1' })
+    queue1.push({ value: 'value2' })
+    expect((await queue1.pop()).value).toBe('value1')
+    expect((await queue1.pop()).value).toBe('value2')
+  })
+
+  test('mixed test', async () => {
+    queue1.push({ value: 'value1' })
+    queue2.push({ value: 'value2' })
+    queue1.push({ value: 'value3' })
+    queue2.push({ value: 'value4' })
+    expect((await queue1.pop()).value).toBe('value1')
+    expect((await queue2.pop()).value).toBe('value2')
+    queue1.push({ value: 'value5' })
+    expect((await queue1.pop()).value).toBe('value3')
+    expect((await queue1.pop()).value).toBe('value5')
+    expect((await queue2.pop()).value).toBe('value4')
+    queue2.push({ value: 'value6' })
+    expect((await queue2.pop()).value).toBe('value6')
+  })
+})


### PR DESCRIPTION
Fix #2377
Fix #1906

## Changes
- implement logic described in https://github.com/openzim/mwoffliner/issues/2377#issuecomment-3233125552
  - the only deviation from this comment is that default request interval is 10ms instead of 100ms ; 10ms was going to induce day long download of images for big wikis (e.g. WPFR would have taken about 5 days just to download images) ; does not seem adequate / necessary, especially since we will anyway significantly reduce pressure on servers by not requesting 80 files in parallel but only 1
- I opportunistically fixed #1906 since I jumped into Redis things for the core of this PR
