### PR TITLE
Better handling of audio resources in articles for full ZIMs

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -38,6 +38,7 @@ Unreleased:
 * FIX: Check API availability at scraper startup instead of raw mwUrl which might not be reachable (@benoit74 #2447)
 * CHANGED: If vector2022 night mode is enabled, use the preferred color scheme (@Markus-Rost #2086)
 * NEW: Add `maxlag` API parameter to reduce pressure on Mediawiki servers during high load (@benoit74 #2365)
+* FIX: Better handling of audio resources in articles for full ZIMs (@benoit74 #2420)
 
 1.16.0:
 * CHANGED: ActionParse renderer is now the preferred one when available (@benoit74 #2183)

--- a/test/e2e/wiktionary.e2e.test.ts
+++ b/test/e2e/wiktionary.e2e.test.ts
@@ -1,8 +1,9 @@
 import { testAllRenders } from '../testRenders.js'
-import { zimcheck } from '../util.js'
+import { zimdump, zimcheck } from '../util.js'
 import 'dotenv/config.js'
 import { jest } from '@jest/globals'
 import { rimraf } from 'rimraf'
+import domino from 'domino'
 
 jest.setTimeout(60000)
 
@@ -12,12 +13,62 @@ await testAllRenders(
     mwUrl: 'https://en.wiktionary.org',
     // fetch index article which will cause a conflict with default index page
     // fetch favicon article which will cause a conflict with former favicon illustration
-    articleList: 'index,location,favicon',
+    // fetch maison article to test audio behavior
+    articleList: 'index,location,favicon,maison',
     adminEmail: 'test@kiwix.org',
   },
   async (outFiles) => {
     test(`test ZIM integrity for ${outFiles[0]?.renderer} renderer`, async () => {
       await expect(zimcheck(outFiles[0].outFile)).resolves.not.toThrow()
+      expect(outFiles[0].status.articles.success).toEqual(4)
+      expect(outFiles[0].status.articles.hardFail).toEqual(0)
+      expect(outFiles[0].status.articles.softFail).toEqual(0)
+    })
+
+    test(`test audio files for ${outFiles[0]?.renderer} renderer`, async () => {
+      const allFiles = await zimdump(`list ${outFiles[0].outFile}`)
+      const allFilesArr = allFiles.split('\n')
+      const mediaFiles = allFilesArr.filter((elem) => elem.endsWith('webm') || elem.endsWith('ogg')).sort()
+
+      expect(mediaFiles).toEqual(
+        [
+          '_assets_/0c70a452f799bfe840676ee341124611/Cs-index.ogg',
+          '_assets_/0c70a452f799bfe840676ee341124611/En-au-favicon.ogg',
+          '_assets_/0c70a452f799bfe840676ee341124611/En-us-index.ogg',
+          '_assets_/0c70a452f799bfe840676ee341124611/En-us-location.ogg',
+          '_assets_/0c70a452f799bfe840676ee341124611/Fr-une_maison-fr-ouest.ogg',
+          '_assets_/0c70a452f799bfe840676ee341124611/LL-Q150_(fra)-Jérémy-Günther-Heinz_Jähnick-index.wav.ogg',
+          '_assets_/0c70a452f799bfe840676ee341124611/LL-Q150_(fra)-Jérémy-Günther-Heinz_Jähnick-maison.wav.ogg',
+          '_assets_/0c70a452f799bfe840676ee341124611/LL-Q150_(fra)-Lepticed7-index.wav.ogg',
+          '_assets_/0c70a452f799bfe840676ee341124611/LL-Q150_(fra)-LoquaxFR-index.wav.ogg',
+          '_assets_/0c70a452f799bfe840676ee341124611/LL-Q150_(fra)-LoquaxFR-maison.wav.ogg',
+          '_assets_/0c70a452f799bfe840676ee341124611/LL-Q150_(fra)-Poslovitch-location.wav.ogg',
+          '_assets_/0c70a452f799bfe840676ee341124611/LL-Q150_(fra)-Poslovitch-maison.wav.ogg',
+          '_assets_/0c70a452f799bfe840676ee341124611/LL-Q150_(fra)-WikiLucas00-location.wav.ogg',
+          '_assets_/0c70a452f799bfe840676ee341124611/LL-Q150_(fra)-WikiLucas00-maison.wav.ogg',
+          '_assets_/0c70a452f799bfe840676ee341124611/Nl-index.ogg',
+        ].sort(),
+      )
+    })
+
+    test(`test maison article content for ${outFiles[0]?.renderer} renderer`, async () => {
+      const maisonArticleContent = await zimdump(`show --url maison ${outFiles[0].outFile}`)
+      const maisonArticleDoc = domino.createDocument(maisonArticleContent)
+      const sourcesEl = maisonArticleDoc.querySelectorAll('source')
+      expect(sourcesEl.length).toBe(5)
+      for (const sourceEl of Array.from(sourcesEl)) {
+        expect(sourceEl.getAttribute('src').startsWith('./_assets_/0c70a452f799bfe840676ee341124611/')).toBeTruthy()
+      }
+    })
+
+    test(`test index article content for ${outFiles[0]?.renderer} renderer`, async () => {
+      const indexArticleContent = await zimdump(`show --url index ${outFiles[0].outFile}`)
+      const indexArticleDoc = domino.createDocument(indexArticleContent)
+      const sourcesEl = indexArticleDoc.querySelectorAll('source')
+      expect(sourcesEl.length).toBe(6)
+      for (const sourceEl of Array.from(sourcesEl)) {
+        expect(sourceEl.getAttribute('src').startsWith('./_assets_/0c70a452f799bfe840676ee341124611/')).toBeTruthy()
+      }
     })
 
     afterAll(() => {

--- a/test/unit/renderers/processHtml.test.ts
+++ b/test/unit/renderers/processHtml.test.ts
@@ -1,0 +1,138 @@
+import { Dump } from '../../../src/Dump.js'
+import { DownloadRes, ProcessHtmlOpts, Renderer } from '../../../src/renderers/abstract.renderer.js'
+import MediaWiki from '../../../src/MediaWiki.js'
+import domino from 'domino'
+
+describe('processHtml', () => {
+  class TestRender extends Renderer {
+    download(): Promise<DownloadRes> {
+      throw new Error('Method not implemented.')
+    }
+    render(): Promise<any> {
+      throw new Error('Method not implemented.')
+    }
+  }
+
+  const testRenderer = new TestRender()
+
+  const audioSrc = '//upload.wikimedia.org/wikipedia/commons/9/9f/Local_Forecast_-_Elevator_%28ISRC_USUAN1300012%29.ogg'
+  const expectedAudioPath = '_assets_/0c70a452f799bfe840676ee341124611/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).'
+
+  async function testProcessHtml(html: string) {
+    MediaWiki.webUrl = new URL('https://en.wikipedia.org')
+    MediaWiki.baseUrl = MediaWiki.webUrl
+    MediaWiki.metaData = { mainPage: 'Main_Page' } as any
+    const articleId = 'Test'
+    const articleDetail = { title: articleId, timestamp: '2023-09-10T17:36:04Z' }
+    const opts: ProcessHtmlOpts = {
+      html,
+      dump: new Dump('', {} as any, MediaWiki.metaData),
+      articleId,
+      articleDetail,
+      moduleDependencies: {},
+      callback: () => {
+        return domino.createDocument('<html><head><title></title></head><body><div id="mw-content-text"></div></body></html>')
+      },
+    }
+    return await testRenderer.processHtml(opts)
+  }
+
+  function checkAudioOnly(data) {
+    const { finalHTML, videoDependencies } = data
+    const finalDoc = domino.createDocument(finalHTML)
+    const audioEls = finalDoc.getElementsByTagName('audio')
+    expect(audioEls.length).toBe(1)
+    const audioEl = audioEls[0]
+    expect(audioEl.getAttribute('src')).toContain(`./${expectedAudioPath}`)
+    expect(audioEl.getAttribute('resource')).toBeNull()
+    expect(videoDependencies.length).toBe(1)
+    const videoDependency = videoDependencies[0]
+    expect(videoDependency.path).toContain(expectedAudioPath)
+    expect(videoDependency.url).toContain(`https:${audioSrc.replace('.ogg', '.')}`)
+  }
+
+  it('rewrite audio with src attribute', async () => {
+    checkAudioOnly(await testProcessHtml(`<audio src="${audioSrc}"></audio>`))
+  })
+
+  it('rewrite audio with resource attribute', async () => {
+    checkAudioOnly(await testProcessHtml(`<audio resource="${audioSrc}"></audio>`))
+  })
+
+  it('rewrite audio with both src and resource attribute - order 1', async () => {
+    checkAudioOnly(await testProcessHtml(`<audio src="${audioSrc}" resource="${audioSrc.replace('Elevator', 'Foo')}"></audio>`))
+  })
+
+  it('rewrite audio with both src and resource attribute - order 2', async () => {
+    checkAudioOnly(await testProcessHtml(`<audio resource="${audioSrc.replace('Elevator', 'Foo')}" src="${audioSrc}"></audio>`))
+  })
+
+  function checkAudioWithSource(data) {
+    const { finalHTML, videoDependencies } = data
+    const finalDoc = domino.createDocument(finalHTML)
+    const audioEls = finalDoc.getElementsByTagName('audio')
+    expect(audioEls.length).toBe(1)
+    const audioEl = audioEls[0]
+    expect(audioEl.getAttribute('src')).toBeNull()
+    expect(audioEl.getAttribute('resource')).toBeNull()
+    const sourceEls = finalDoc.getElementsByTagName('source')
+    expect(sourceEls.length).toBe(1)
+    const sourceEl = sourceEls[0]
+    expect(sourceEl.getAttribute('src')).toContain(`./${expectedAudioPath}`)
+    expect(sourceEl.getAttribute('resource')).toBeNull()
+    expect(videoDependencies.length).toBe(1)
+    const videoDependency = videoDependencies[0]
+    expect(videoDependency.path).toContain(expectedAudioPath)
+    expect(videoDependency.url).toContain(`https:${audioSrc.replace('.ogg', '.')}`)
+  }
+
+  it('rewrite audio with src, resource attributes and one source', async () => {
+    checkAudioWithSource(
+      await testProcessHtml(`<audio src="${audioSrc.replace('Elevator', 'Foo')}" resource="${audioSrc.replace('Elevator', 'Bar')}"><source src="${audioSrc}"></audio>`),
+    )
+  })
+
+  it('rewrite audio with src, resource attributes and two sources', async () => {
+    checkAudioWithSource(
+      await testProcessHtml(
+        `<audio src="${audioSrc.replace('Elevator', 'Foo')}" resource="${audioSrc.replace('Elevator', 'Bar')}"><source src="${audioSrc}"><source src="${audioSrc.replace(
+          'Elevator',
+          'Foo',
+        )}"></audio>`,
+      ),
+    )
+  })
+
+  it('rewrite audio with src, resource attributes and two sources, ogg first', async () => {
+    checkAudioWithSource(
+      await testProcessHtml(
+        `<audio src="${audioSrc.replace('Elevator', 'Foo')}" resource="${audioSrc.replace(
+          'Elevator',
+          'Bar',
+        )}"><source src="${audioSrc}" type="audio/ogg"><source src="${audioSrc.replace('Elevator', 'Foo')}"></audio>`,
+      ),
+    )
+  })
+
+  it('rewrite audio with src, resource attributes and two sources, ogg last with type', async () => {
+    checkAudioWithSource(
+      await testProcessHtml(
+        `<audio src="${audioSrc.replace('Elevator', 'Foo')}" resource="${audioSrc.replace('Elevator', 'Bar')}"><source src="${audioSrc.replace(
+          '.ogg',
+          '.mp3',
+        )}"><source src="${audioSrc.replace('.ogg', '.foo')}" type="audio/ogg"></audio>`,
+      ),
+    )
+  })
+
+  it('rewrite audio with src, resource attributes and two sources, ogg last without type', async () => {
+    checkAudioWithSource(
+      await testProcessHtml(
+        `<audio src="${audioSrc.replace('Elevator', 'Foo')}" resource="${audioSrc.replace('Elevator', 'Bar')}"><source src="${audioSrc.replace(
+          '.ogg',
+          '.mp3',
+        )}"><source src="${audioSrc}"><source src="${audioSrc.replace('Elevator', 'Foo')}"></audio>`,
+      ),
+    )
+  })
+})

--- a/test/unit/treatments/media.treatment.test.ts
+++ b/test/unit/treatments/media.treatment.test.ts
@@ -13,7 +13,7 @@ describe('MediaTreatment', () => {
       return null
     }
     public async testTreatVideo(dump: Dump, srcCache: KVS<boolean>, articleId: string, videoEl: DominoElement) {
-      return this.treatVideo(dump, srcCache, articleId, videoEl)
+      return this.treatAudioVideo(dump, srcCache, articleId, videoEl)
     }
     public async testTreatSubtitle(trackEle: DominoElement, articleId: string) {
       return this.treatSubtitle(trackEle, articleId)


### PR DESCRIPTION
Fix #2420

## Changes

- Differentiate handling of audio from video resources
- For both, take into account the (probably rare) situations where:
  - we have only an `src` attribute and no children `<source>`
  - we have an `src` attribute and children `<source>`
- For audio, implement a basic selection logic:
  - prefer the first ogg source if available
  - otherwise use the first source