### PR TITLE
Add `maxlag` API parameter to reduce pressure on Mediawiki servers during high load

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -37,6 +37,7 @@ Unreleased:
 * FIX: Add redirects from all acceptable namespaces (@benoit74 #2429)
 * FIX: Check API availability at scraper startup instead of raw mwUrl which might not be reachable (@benoit74 #2447)
 * CHANGED: If vector2022 night mode is enabled, use the preferred color scheme (@Markus-Rost #2086)
+* NEW: Add `maxlag` API parameter to reduce pressure on Mediawiki servers during high load (@benoit74 #2365)
 
 1.16.0:
 * CHANGED: ActionParse renderer is now the preferred one when available (@benoit74 #2183)

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -190,6 +190,10 @@ class Downloader {
           logger.log(`Retrying ${requestedUrl} URL due to ${err.code} error`)
           return true // retry all connection issues
         }
+        if (err.responseData?.error?.code == 'maxlag') {
+          logger.log(`Mediawiki server is lagging ${err.responseData?.error?.lag}s; retrying in few seconds`)
+          return true // note that we do not honor Retry-After header value because it is not possible in current code architecture
+        }
         const httpReturnCode = err.response?.status || err.httpReturnCode
         if ([429, 500, 502, 503, 504].includes(httpReturnCode)) {
           logger.log(`Retrying ${requestedUrl} URL due to HTTP ${httpReturnCode} error`)

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -15,6 +15,7 @@ import RestApiURLDirector from './util/builders/url/rest-api.director.js'
 import ActionParseURLDirector from './util/builders/url/action-parse.director.js'
 import { checkApiAvailability } from './util/mw-api.js'
 import { BLACKLISTED_NS } from './util/const.js'
+import { config } from './config.js'
 
 export interface QueryOpts {
   action: string
@@ -25,6 +26,7 @@ export interface QueryOpts {
   rdprop: string
   redirects?: boolean
   formatversion: string
+  maxlag: string
 }
 
 export interface SiteInfoResponse {
@@ -241,6 +243,7 @@ class MediaWiki {
       rdprop: 'title|fragment',
       redirects: false,
       formatversion: '2',
+      maxlag: config.defaults.maxlag,
     }
 
     this.#hasWikimediaDesktopApi = null
@@ -373,7 +376,7 @@ class MediaWiki {
       }
 
       // Getting token to login.
-      const { content } = await Downloader.downloadContent(url + 'action=query&meta=tokens&type=login&format=json&formatversion=2', 'data')
+      const { content } = await Downloader.downloadContent(url + 'action=query&meta=tokens&type=login&format=json&formatversion=2&maxlag=' + config.defaults.maxlag, 'data')
 
       // Logging in
       await Downloader.request({

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ const config = {
     publisher: 'openZIM',
     redisPath: 'redis://127.0.0.1:6379',
     requestTimeout: 120 * 1000,
+    maxlag: '5',
   },
 
   candidateIndexPath: ['index', 'welcome', 'home', 'Main_Page'],

--- a/src/sanitize-argument.ts
+++ b/src/sanitize-argument.ts
@@ -10,6 +10,7 @@ import { parameterDescriptions } from './parameterList.js'
 import { RENDERERS_LIST } from './util/const.js'
 import Downloader from './Downloader.js'
 import MediaWiki from './MediaWiki.js'
+import { config } from './config.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -183,7 +184,7 @@ export function sanitize_speed(_speed: any) {
 
 export async function check_mwApiReachability(mwUrl: string, mwActionApiPath: string) {
   // We are building an API query "by-hand" because we've not yet initialized the whole URL director / URL builder stack
-  const apiQueryUrl = `${new URL(mwActionApiPath || MediaWiki.actionApiPath, mwUrl).toString()}?action=query&format=json&formatversion=2`
+  const apiQueryUrl = `${new URL(mwActionApiPath || MediaWiki.actionApiPath, mwUrl).toString()}?action=query&format=json&formatversion=2&maxlag=${config.defaults.maxlag}`
   const value = await Downloader.get(apiQueryUrl).catch((err) => {
     throw new Error(`Mediawiki API is not reachable with ${apiQueryUrl}\n${err}`)
   })

--- a/src/util/builders/url/action-parse.director.ts
+++ b/src/util/builders/url/action-parse.director.ts
@@ -1,3 +1,4 @@
+import { config } from '../../../config.js'
 import urlBuilder from './url.builder.js'
 
 /**
@@ -33,6 +34,7 @@ export default class ActionParseURLDirector {
           redirects: '1',
           formatversion: '2',
           section: sectionId,
+          maxlag: config.defaults.maxlag,
         },
         '?',
         true,

--- a/src/util/builders/url/api.director.ts
+++ b/src/util/builders/url/api.director.ts
@@ -1,3 +1,4 @@
+import { config } from '../../../config.js'
 import urlBuilder from './url.builder.js'
 
 /**
@@ -22,6 +23,7 @@ export default class ApiURLDirector {
         formatversion: '2',
         cmtitle: articleId,
         cmcontinue: continueStr,
+        maxlag: config.defaults.maxlag,
       })
       .build()
   }
@@ -45,6 +47,7 @@ export default class ApiURLDirector {
         gaenabledonly: '1',
         format: 'json',
         formatversion: '2',
+        maxlag: config.defaults.maxlag,
       })
       .build()
   }
@@ -54,13 +57,16 @@ export default class ApiURLDirector {
   }
 
   buildLogEventsQuery(letype: string, articleId: string) {
-    return urlBuilder.setDomain(this.baseDomain).setQueryParams({ action: 'query', list: 'logevents', letype: letype, letitle: articleId, format: 'json' }).build()
+    return urlBuilder
+      .setDomain(this.baseDomain)
+      .setQueryParams({ action: 'query', list: 'logevents', letype: letype, letitle: articleId, format: 'json', maxlag: config.defaults.maxlag })
+      .build()
   }
 
   buildArticleApiURL(articleId: string) {
     return urlBuilder
       .setDomain(this.baseDomain)
-      .setQueryParams({ action: 'parse', format: 'json', prop: 'modules|jsconfigvars|headhtml', formatversion: '2', page: articleId })
+      .setQueryParams({ action: 'parse', format: 'json', prop: 'modules|jsconfigvars|headhtml', formatversion: '2', page: articleId, maxlag: config.defaults.maxlag })
       .build()
   }
 }

--- a/test/unit/builders/url/api.director.test.ts
+++ b/test/unit/builders/url/api.director.test.ts
@@ -7,7 +7,9 @@ describe('ApiURLDirector', () => {
     it('should return a string URL to get article sub categories', () => {
       const url = apiUrlDirector.buildSubCategoriesURL('article-123')
 
-      expect(url).toBe('https://en.wikipedia.org/w/api.php?action=query&list=categorymembers&cmtype=subcat&cmlimit=max&format=json&formatversion=2&cmtitle=article-123&cmcontinue=')
+      expect(url).toBe(
+        'https://en.wikipedia.org/w/api.php?action=query&list=categorymembers&cmtype=subcat&cmlimit=max&format=json&formatversion=2&cmtitle=article-123&cmcontinue=&maxlag=5',
+      )
     })
   })
 
@@ -23,7 +25,7 @@ describe('ApiURLDirector', () => {
     it('should return a string URL with predefined query params and provided page for retrieving article', () => {
       const url = apiUrlDirector.buildArticleApiURL('article-123')
 
-      expect(url).toBe('https://en.wikipedia.org/w/api.php?action=parse&format=json&prop=modules%7Cjsconfigvars%7Cheadhtml&formatversion=2&page=article-123')
+      expect(url).toBe('https://en.wikipedia.org/w/api.php?action=parse&format=json&prop=modules%7Cjsconfigvars%7Cheadhtml&formatversion=2&page=article-123&maxlag=5')
     })
   })
 
@@ -32,7 +34,7 @@ describe('ApiURLDirector', () => {
       const url = apiUrlDirector.buildSiteInfoURL()
 
       expect(url).toBe(
-        'https://en.wikipedia.org/w/api.php?action=query&meta=siteinfo%7Callmessages&siprop=general%7Cskins%7Crightsinfo%7Cnamespaces%7Cnamespacealiases&ammessages=tagline&amenableparser=1&list=gadgets&gaprop=id%7Cmetadata&gaallowedonly=1&gaenabledonly=1&format=json&formatversion=2',
+        'https://en.wikipedia.org/w/api.php?action=query&meta=siteinfo%7Callmessages&siprop=general%7Cskins%7Crightsinfo%7Cnamespaces%7Cnamespacealiases&ammessages=tagline&amenableparser=1&list=gadgets&gaprop=id%7Cmetadata&gaallowedonly=1&gaenabledonly=1&format=json&formatversion=2&maxlag=5',
       )
     })
   })


### PR DESCRIPTION
Fix #2365

Note: as indicated in the code, we currently do not respect the `Retry-After` header value since this is not possible with current code architecture and it is probably acceptable (exponential backoff is maybe even better since if the lag situation continues a bit, then it will give even more time for server to recover compared to the constant `Retry-After` value usually returned by Mediawiki servers).