### PR TITLE
Remove custom ZIM footer background to automatically adapt to skin colors

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -36,7 +36,7 @@ Unreleased:
 * FIX: Fix logging + documentation around `RedisKvs.iterateItems` (@benoit74 #2500)
 * FIX: Add redirects from all acceptable namespaces (@benoit74 #2429)
 * FIX: Check API availability at scraper startup instead of raw mwUrl which might not be reachable (@benoit74 #2447)
-* CHANGED: If vector2022 night mode is enabled, use the preferred color scheme (@Markus-Rost #2086)
+* CHANGED: If vector2022 night mode is enabled, use the preferred color scheme (@Markus-Rost #2086, @benoit74 #2540)
 * NEW: Add `maxlag` API parameter to reduce pressure on Mediawiki servers during high load (@benoit74 #2365)
 * FIX: Better handling of audio resources in articles for full ZIMs (@benoit74 #2420)
 * CHANGED: Rework file downloads to reduce pressure on servers and better handle throttling (@benoit74 #2377)

--- a/res/footer.css
+++ b/res/footer.css
@@ -1,15 +1,14 @@
 .zim-footer {
-    clear:both; 
-    background-image:linear-gradient(180deg, #E8E8E8, white); 
-    border-top: dashed 2px #AAAAAA; 
-    padding: 0.5em 0.5em 0.5em 0.5em; 
-    margin-top: 1em;
+  clear: both;
+  border-top: dashed 2px #aaaaaa;
+  padding: 0.5em 0.5em 0.5em 0.5em;
+  margin-top: 1em;
 }
 
 .zim-footer a {
-    background-image: url(./external-link.svg);
-    background-position: center right;
-    background-repeat: no-repeat;
-    background-size: 0.857em;
-    padding-right: 1em;
+  background-image: url(./external-link.svg);
+  background-position: center right;
+  background-repeat: no-repeat;
+  background-size: 0.857em;
+  padding-right: 1em;
 }


### PR DESCRIPTION
Having a background in custom ZIM footer is not a really good idea because it does not adapt at all to ~~dark~~night mode (for instance), while the text color does.

<img width="975" height="88" alt="image" src="https://github.com/user-attachments/assets/c3ba3163-bc64-44eb-a464-c120bb61cfb6" />

This PR removes the background to use the one from article content, so that it has highest chances text color and background colors are aligned with the ones of the rest of the article. This is deemed to work well for ~~dark~~night  mode, but also any wiki specific color schemes (wiki might have chosen to display text in blue and background in orange, footer will automatically adapt accordingly)