### PR TITLE
Fix backoff and slow down issues

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,6 @@
 Unreleased:
 * CHANGED: pass `pageid` in `rdprop` for proper mdwiki API operation (@benoit74 #2557)
+* FIX: Fix backoff and slow down issues (@benoit74 #2574)
 
 1.17.2:
 * FIX: Fix parsing of potentially missing retry-after header (@benoit74 #2556)

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -824,6 +824,7 @@ class Downloader {
   }
 
   private backoffCall(handler: (...args: any[]) => void, url: string, kind: DonwloadKind, callback: (...args: any[]) => void | Promise<void>): void {
+    this.backoffOptions.strategy.reset() // reset delay to initial one at each call
     const call = backoff.call(handler, url, kind, callback)
     call.setStrategy(this.backoffOptions.strategy)
     call.retryIf(this.backoffOptions.retryIf)

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -161,7 +161,8 @@ export async function downloadFiles(fileStore: RKVS<FileDetail>, zimCreator: Cre
               }
             }
           }
-          if (err.response && [429, 503, 524].includes(err.response.status)) {
+          // slow down except for wikimedia thumbnails whose server is known to be lying (see https://github.com/openzim/mwoffliner/issues/2572)
+          if (err.response && [429, 503, 524].includes(err.response.status) && !fileToDownload.url.match(/^https?:\/\/upload\.wikimedia\.org\/.*\/thumb\//)) {
             hostData.requestInterval = hostData.requestInterval * 1.2 // 1.2 is arbitrary value to progressively slow requests to host down
             logger.log(`Received a [status=${err.response.status}], slowing down ${hostname} to ${hostData.requestInterval}ms interval`)
           }


### PR DESCRIPTION
This is a containment PR for issue #2572 

Changes:
- do not slow down file downloads when the 429, 503 or 524 comes from wikimedia thumbnails (a bit hackish tbh, but not real other alternative ATM)
- reset backoff interval between queries: this is mostly unrelated, but discovered this issue while looking into the code, without the reset backoff always restarts at previous value