### PR TITLE
Ask for pageid in rdprop for proper mdwiki API operation

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,5 @@
 Unreleased:
+* CHANGED: pass `pageid` in `rdprop` for proper mdwiki API operation (@benoit74 #2557)
 
 1.17.2:
 * FIX: Fix parsing of potentially missing retry-after header (@benoit74 #2556)

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -240,7 +240,9 @@ class MediaWiki {
       prop: 'info|redirects|revisions',
       rdlimit: 'max',
       rdnamespace: '0',
-      rdprop: 'title|fragment',
+      // pageid in rdprop is not mandatory in general, but required for proper
+      // mdwiki API operation
+      rdprop: 'pageid|title|fragment',
       redirects: false,
       formatversion: '2',
       maxlag: config.defaults.maxlag,


### PR DESCRIPTION
When retrieving article details including their redirects with `action=query`, we need `title` and `fragment` of each redirect. `pageid` is not required by mwoffliner because we do not manipulate IDs but titles.

However, mdwiki.org API needed a special `action=query` API implementation to retrieve redirects of mirrored articles.

And this special API implementation does not work ATM when it comes to have continuation of redirects (`rdcontinue`) if `pageid` is not asked for (and hence present in the `rdcontinue` value).

Since this is expected to have negligible impact in most cases, I propose we include the `pageid` in `rdprop` by default in mwoffliner. We could implement something special for mdwiki.org, but I do not feel like this is worth the additional complexity.