### PR TITLE
Fix/2609 retry when malformed json

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,7 @@ Unreleased:
 * NEW: Add support for ResourceLoader based JavaScript (@Markus-Rost #2310)
 * CHANGED: Keep only ActionParse renderer (@benoit74 #2210)
 * CHANGED: Keep inline scripts if all JS is allowed (@Markus-Rost #2555)
+* FIX: retry malformed JSON API responses (@kunalsiyag #2609)
 
 1.17.5:
 * FIX: Ignore articles returning permissiondenied error code (@kunalsiyag #2604)

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -71,6 +71,18 @@ interface CompressionData {
   data: any
 }
 
+function isMalformedJsonResponseError(err: unknown): boolean {
+  if (err instanceof SyntaxError) {
+    return true
+  }
+
+  if (!axios.isAxiosError(err) || err.code !== AxiosError.ERR_BAD_RESPONSE) {
+    return false
+  }
+
+  return err.cause instanceof SyntaxError
+}
+
 export class DownloadError extends Error {
   urlCalled: string | null
   httpReturnCode: number | null
@@ -179,6 +191,11 @@ class Downloader {
       failAfter: 10,
       retryIf: (err: any) => {
         const requestedUrl = err.urlCalled || err.config?.url || 'unknown'
+        if (isMalformedJsonResponseError(err)) {
+          logger.log(`Retrying ${requestedUrl} due to malformed JSON response`)
+          return true
+        }
+
         if (err instanceof AxiosError && err.code && !['ERR_BAD_REQUEST', 'ERR_BAD_RESPONSE'].includes(err.code)) {
           logger.log(`Retrying ${requestedUrl} URL due to ${err.code} error`)
           return true // retry all connection issues
@@ -247,6 +264,11 @@ class Downloader {
         'accept-encoding': 'gzip, deflate',
       },
       responseType: 'json',
+      transitional: {
+        // Parse failures must throw so backoff retries can be triggered.
+        silentJSONParsing: false,
+        forcedJSONParsing: true,
+      },
       method: 'GET',
     }
 
@@ -659,7 +681,12 @@ class Downloader {
           handler(null, val.data)
         }
       })
-      .catch((err) => handler(err))
+      .catch((err) => {
+        if (isMalformedJsonResponseError(err)) {
+          logger.warn(`Malformed JSON from [${url}] → ${err.message}`)
+        }
+        handler(err)
+      })
   }
 
   private async getImageMimeType(data: any): Promise<string | null> {

--- a/test/unit/downloader.retry.test.ts
+++ b/test/unit/downloader.retry.test.ts
@@ -1,0 +1,97 @@
+import { AxiosError } from 'axios'
+import { jest } from '@jest/globals'
+
+import { DownloaderClass } from '../../src/Downloader.js'
+import MediaWiki from '../../src/MediaWiki.js'
+
+const createDownloader = () => {
+  MediaWiki.reset()
+  MediaWiki.base = 'https://example.org'
+
+  const downloader = new DownloaderClass()
+  downloader.init = {
+    uaString: 'mwoffliner-test-agent',
+    speed: 1,
+    reqTimeout: 1000,
+    optimisationCacheUrl: '',
+    webp: false,
+  }
+
+  return downloader
+}
+
+describe('Downloader malformed JSON retry strategy', () => {
+  test('enables strict JSON parsing', () => {
+    const downloader = createDownloader()
+    expect((downloader as any).jsonRequestOptions.transitional).toEqual({
+      silentJSONParsing: false,
+      forcedJSONParsing: true,
+    })
+  })
+
+  test('retries plain SyntaxError parse failures', () => {
+    const downloader = createDownloader()
+    const retryIf = (downloader as any).backoffOptions.retryIf as (error?: any) => boolean
+    const err = new SyntaxError('Unexpected end of JSON input')
+
+    expect(retryIf(err)).toBe(true)
+  })
+
+  test('retries malformed JSON parse failures when wrapped in cause', () => {
+    const downloader = createDownloader()
+    const retryIf = (downloader as any).backoffOptions.retryIf as (error?: any) => boolean
+    const err = new AxiosError('Failed to parse API response', AxiosError.ERR_BAD_RESPONSE)
+    ;(err as any).cause = new SyntaxError('Unexpected end of JSON input')
+
+    expect(retryIf(err)).toBe(true)
+  })
+
+  test('does not treat generic ERR_BAD_RESPONSE as malformed JSON', () => {
+    const downloader = createDownloader()
+    const retryIf = (downloader as any).backoffOptions.retryIf as (error?: any) => boolean
+    const err = new AxiosError('Request failed while handling response', AxiosError.ERR_BAD_RESPONSE)
+
+    expect(retryIf(err)).toBe(false)
+  })
+
+  test('does not retry non-transient bad responses', () => {
+    const downloader = createDownloader()
+    const retryIf = (downloader as any).backoffOptions.retryIf as (error?: any) => boolean
+    const err = new AxiosError('Request failed with status code 418', AxiosError.ERR_BAD_RESPONSE)
+    ;(err as any).response = { status: 418 }
+
+    expect(retryIf(err)).toBe(false)
+  })
+
+  test('getJSON retries once and succeeds after malformed JSON', async () => {
+    const downloader = createDownloader()
+    const malformed = new AxiosError('Failed to parse API response', AxiosError.ERR_BAD_RESPONSE)
+    ;(malformed as any).cause = new SyntaxError('Unexpected end of JSON input')
+    ;(downloader as any).request = jest
+      .fn()
+      .mockRejectedValueOnce(malformed)
+      .mockResolvedValueOnce({
+        data: { ok: true },
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    ;(downloader as any).backoffCall = (handler: any, url: string, kind: any, cb: any) => {
+      const retryIf = (downloader as any).backoffOptions.retryIf as (error?: any) => boolean
+      let attempts = 0
+      const run = () => {
+        attempts += 1
+        handler(url, kind, (err: any, val: any) => {
+          if (err && attempts < 3 && retryIf(err)) {
+            run()
+            return
+          }
+          cb(err, val)
+        })
+      }
+      run()
+    }
+
+    await expect(downloader.getJSON('https://example.org/api')).resolves.toEqual({ ok: true })
+    expect((downloader as any).request).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
Fixes #2609

## Changes

What changed:
- JSON requests are parsed strictly, so truncated/invalid JSON throws.
- Retry detection is limited to real parse failures:
  - direct SyntaxError
  - Axios ERR_BAD_RESPONSE with SyntaxError in cause
- Generic ERR_BAD_RESPONSE is not treated as malformed JSON.

Validation:
- Unit tests pass in test/unit/downloader.retry.test.ts.
- Real run against [dwarffortresswiki.org_en_all](https://farm.openzim.org/recipes/dwarffortresswiki.org_en_all) succeeded locally.
- Logs show malformed JSON warnings and immediate retries, then full completion with exit code 0 and no article/file failures.

