### PR TITLE
Issue-2481-support-third-party-youtube-videos

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,5 @@
 Unreleased:
+* UPDATE: Replace iFrame with a placeholder card instead of deleting them (@kunalsiyag #2481)
 * NEW: Scrape only wikitext contentmodel articles by default (@triemerge #2445)
 * FIX: In nopic mode, fixed layout issues by preserving image layout using SVG placeholders (@kunalsiyag #1004)
 * NEW: Add support for ResourceLoader based JavaScript (@Markus-Rost #2310)

--- a/res/style.css
+++ b/res/style.css
@@ -115,3 +115,10 @@ summary.section-heading {
 body[data-useragent*='KAIOS'] h1 {
     display: none !important;
 }
+
+.mwo-external-video-card {
+    display: block;
+    margin: 1em 0;
+    border: 1px solid #a2a9b1;
+    background-color: #f8f9fa;
+}

--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -608,6 +608,9 @@ export abstract class Renderer {
           return { url, path }
         }),
     )
+    // applyOtherTreatments must run before treatMedias so that iframe
+    // placeholders (e.g. YouTube thumbnails) are already in the DOM
+    // when treatMedias processes <img> tags for download into the ZIM.
     doc = this.applyOtherTreatments(doc, dump, articleId)
 
     const tmRet = await this.treatMedias(doc, dump, articleId)
@@ -785,12 +788,89 @@ export abstract class Renderer {
     element.parentElement.innerHTML = `${slices[0]}<!--htdig_noindex-->${element.outerHTML}<!--/htdig_noindex-->${slices[1]}`
   }
 
-  private removeIframeTags(parsoidDoc: DominoElement) {
-    // Remove all <iframe> tags
+  // Rewrite iframe tags into external placeholders
+  private processIframeTags(parsoidDoc: DominoElement) {
     const iframes: DominoElement[] = Array.from(parsoidDoc.getElementsByTagName('iframe'))
+
     for (const iframe of iframes) {
-      DU.deleteNode(iframe)
+      const src = iframe.getAttribute('src')
+      if (!src) {
+        DU.deleteNode(iframe)
+        continue
+      }
+
+      let fullSrc = src
+      try {
+        fullSrc = getFullUrl(src, MediaWiki.baseUrl)
+      } catch {
+        // Keep original src when URL parsing fails
+      }
+
+      const placeholder = this.isYouTubeIframeUrl(fullSrc)
+        ? this.createYouTubePlaceholder(parsoidDoc, iframe, fullSrc, this.extractYouTubeVideoId(fullSrc))
+        : this.createExternalIframePlaceholder(parsoidDoc, iframe, fullSrc)
+      if (iframe.parentNode) {
+        iframe.parentNode.replaceChild(placeholder, iframe)
+      } else {
+        DU.deleteNode(iframe)
+      }
     }
+  }
+  private isYouTubeIframeUrl(url: string) {
+    const lowerUrl = url.toLowerCase()
+    return lowerUrl.includes('youtube.com/embed/') || lowerUrl.includes('youtube-nocookie.com/embed/') || lowerUrl.includes('youtu.be/') || lowerUrl.includes('youtube.com/watch')
+  }
+
+  private extractYouTubeVideoId(url: string): string | null {
+    const match = url.match(/(?:embed\/|v=|\.be\/)([a-zA-Z0-9_-]+)/)
+    return match ? match[1] : null
+  }
+
+  private createExternalIframePlaceholder(parsoidDoc: DominoElement, iframe: DominoElement, originalUrl: string): DominoElement {
+    const card = parsoidDoc.createElement('div')
+    this.copyNodeAttributes(iframe, card)
+    const iframeClass = card.getAttribute('class')
+    card.setAttribute('class', iframeClass ? `${iframeClass} mwo-external-video-card` : 'mwo-external-video-card')
+
+    const link = parsoidDoc.createElement('a')
+    link.setAttribute('class', 'external')
+    link.setAttribute('href', originalUrl)
+    link.textContent = 'Open embedded content (external)'
+    card.appendChild(link)
+    return card
+  }
+
+  private copyNodeAttributes(sourceNode: DominoElement, targetNode: DominoElement) {
+    for (let attributeIndex = 0; attributeIndex < sourceNode.attributes.length; attributeIndex++) {
+      const attribute = sourceNode.attributes.item(attributeIndex)
+      if (!attribute) {
+        continue
+      }
+      targetNode.setAttribute(attribute.name, attribute.value)
+    }
+  }
+
+  private createYouTubePlaceholder(parsoidDoc: DominoElement, iframe: DominoElement, originalUrl: string, videoId: string | null): DominoElement {
+    const link = parsoidDoc.createElement('a')
+    link.setAttribute('class', 'external')
+    link.setAttribute('href', videoId ? `https://www.youtube.com/watch?v=${videoId}` : originalUrl)
+
+    if (!videoId) {
+      link.textContent = 'View this content externally'
+      link.setAttribute('aria-label', 'View this content externally')
+      return link
+    }
+
+    const thumbnail = parsoidDoc.createElement('img')
+    this.copyNodeAttributes(iframe, thumbnail)
+    // Set the online thumbnail URL here; treatMedias will process this
+    // <img> tag later to download the image and rewrite src to a local path in the ZIM.
+    thumbnail.setAttribute('src', `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`)
+    thumbnail.setAttribute('alt', 'Video thumbnail')
+    thumbnail.setAttribute('loading', 'lazy')
+
+    link.appendChild(thumbnail)
+    return link
   }
 
   private removeCitations(parsoidDoc: DominoElement) {
@@ -917,7 +997,7 @@ export abstract class Renderer {
   }
 
   private applyOtherTreatments(parsoidDoc: DominoElement, dump: Dump, articleId: string) {
-    this.removeIframeTags(parsoidDoc)
+    this.processIframeTags(parsoidDoc)
 
     if (dump.nodet) {
       this.removeCitations(parsoidDoc)

--- a/test/unit/renderers/processHtml.test.ts
+++ b/test/unit/renderers/processHtml.test.ts
@@ -143,23 +143,37 @@ describe('processHtml', () => {
       const { finalHTML } = await testProcessHtml(`<div id="foo"><iframe></iframe></div>`)
       expect(finalHTML).toContain('<div id="foo"></div>')
     })
-    it('remove full iframe', async () => {
+    it('replace full non-youtube iframe with external placeholder', async () => {
       const { finalHTML } = await testProcessHtml(
         `<div id="foo">` +
-          `<iframe id="inlineFrameExample" title="Inline Frame Example" width="300" height="200" ` +
+          `<iframe id="inlineFrameExample" class="sample-frame" title="Inline Frame Example" width="300" height="200" style="border:0;" ` +
           `src="https://www.openstreetmap.org/export/embed.html"></iframe></div>`,
       )
-      expect(finalHTML).toContain('<div id="foo"></div>')
+      const finalDoc = domino.createDocument(finalHTML)
+      expect(finalDoc.querySelector('#foo iframe') == null).toBe(true)
+      const placeholder = finalDoc.querySelector('#foo .mwo-external-video-card') as DominoElement
+      expect(placeholder).toBeDefined()
+      expect(placeholder.getAttribute('id')).toBe('inlineFrameExample')
+      expect(placeholder.getAttribute('width')).toBe('300')
+      expect(placeholder.getAttribute('height')).toBe('200')
+      expect(placeholder.getAttribute('style')).toContain('border')
+      expect(placeholder.className).toContain('sample-frame')
+      const link = finalDoc.querySelector('#foo a.external')
+      expect(link?.getAttribute('href')).toBe('https://www.openstreetmap.org/export/embed.html')
+      expect(link?.getAttribute('class')).toContain('external')
+      expect(link?.textContent).toContain('Open embedded content (external)')
     })
-    it('remove iframe "with content"', async () => {
+    it('replace iframe "with content" with external placeholder', async () => {
       const { finalHTML } = await testProcessHtml(
         `<div id="foo">` +
           `<iframe id="inlineFrameExample" title="Inline Frame Example" width="300" height="200" ` +
           `src="https://www.openstreetmap.org/export/embed.html"><span>bar</span></iframe></div>`,
       )
-      expect(finalHTML).toContain('<div id="foo"></div>')
+      const finalDoc = domino.createDocument(finalHTML)
+      expect(finalDoc.querySelector('#foo iframe') == null).toBe(true)
+      expect(finalDoc.querySelector('#foo .mwo-external-video-card')).not.toBeNull()
     })
-    it('remove multiple iframes', async () => {
+    it('replace multiple iframes', async () => {
       const { finalHTML } = await testProcessHtml(
         `<div id="foo">` +
           `<iframe id="inlineFrameExample1" title="Inline Frame Example 1" width="300" height="200" ` +
@@ -168,7 +182,64 @@ describe('processHtml', () => {
           `<iframe id="inlineFrameExample2" title="Inline Frame Example 2" width="300" height="200" ` +
           `src="https://www.openstreetmap.org/export/embed.html"></iframe></div>`,
       )
-      expect(finalHTML).toContain('<div id="foo"></div><div id="bar"></div>')
+      const finalDoc = domino.createDocument(finalHTML)
+      expect(finalDoc.querySelectorAll('.mwo-external-video-card').length).toBe(2)
+    })
+
+    it('rewrites youtube.com embed iframe', async () => {
+      const { finalHTML, imageDependencies } = await testProcessHtml(`<div id="foo"><iframe src="https://www.youtube.com/embed/VIDEO_ID"></iframe></div>`)
+      const finalDoc = domino.createDocument(finalHTML)
+      expect(finalDoc.querySelector('#foo iframe') == null).toBe(true)
+      const link = finalDoc.querySelector('#foo a.external')
+      expect(link).not.toBeNull()
+      expect(link?.getAttribute('href')).toBe('https://www.youtube.com/watch?v=VIDEO_ID')
+      expect(link?.getAttribute('class')).toContain('external')
+      expect(finalDoc.querySelector('#foo a.external img')?.getAttribute('src')).toContain('_assets_')
+      // No overlay
+      expect(finalDoc.querySelector('#foo .mwo-external-video-overlay') == null).toBe(true)
+      // Thumbnail URL tracked for local download
+      expect(imageDependencies.some((dep) => dep.url.includes('img.youtube.com/vi/VIDEO_ID'))).toBe(true)
+    })
+
+    it('copies iframe dimensions to thumbnail img', async () => {
+      const { finalHTML } = await testProcessHtml(`<div id="foo"><iframe width="560" height="315" src="https://www.youtube.com/embed/DIM_ID"></iframe></div>`)
+      const finalDoc = domino.createDocument(finalHTML)
+      const img = finalDoc.querySelector('#foo a.external img')
+      expect(img).not.toBeNull()
+      expect(img?.getAttribute('width')).toBe('560')
+      expect(img?.getAttribute('height')).toBe('315')
+    })
+
+    it('rewrites youtube-nocookie embed iframe', async () => {
+      const { finalHTML } = await testProcessHtml(`<div id="foo"><iframe src="https://www.youtube-nocookie.com/embed/NOC_ID"></iframe></div>`)
+      const finalDoc = domino.createDocument(finalHTML)
+      expect(finalDoc.querySelector('#foo iframe') == null).toBe(true)
+      expect(finalDoc.querySelector('#foo a.external')?.getAttribute('href')).toBe('https://www.youtube.com/watch?v=NOC_ID')
+    })
+
+    it('rewrites youtu.be iframe', async () => {
+      const { finalHTML } = await testProcessHtml(`<div id="foo"><iframe src="https://youtu.be/SHORT_ID"></iframe></div>`)
+      const finalDoc = domino.createDocument(finalHTML)
+      expect(finalDoc.querySelector('#foo iframe') == null).toBe(true)
+      expect(finalDoc.querySelector('#foo a.external')?.getAttribute('href')).toBe('https://www.youtube.com/watch?v=SHORT_ID')
+    })
+
+    it('rewrites youtube watch iframe', async () => {
+      const { finalHTML } = await testProcessHtml(`<div id="foo"><iframe src="https://www.youtube.com/watch?v=WATCH_ID&t=20"></iframe></div>`)
+      const finalDoc = domino.createDocument(finalHTML)
+      expect(finalDoc.querySelector('#foo iframe') == null).toBe(true)
+      expect(finalDoc.querySelector('#foo a.external')?.getAttribute('href')).toBe('https://www.youtube.com/watch?v=WATCH_ID')
+    })
+
+    it('falls back to text link when youtube id extraction fails', async () => {
+      const { finalHTML } = await testProcessHtml(`<div id="foo"><iframe src="https://www.youtube.com/watch?feature=share"></iframe></div>`)
+      const finalDoc = domino.createDocument(finalHTML)
+      const link = finalDoc.querySelector('#foo a.external')
+      expect(finalDoc.querySelector('#foo iframe') == null).toBe(true)
+      expect(finalDoc.querySelector('#foo a.external img') == null).toBe(true)
+      expect(link?.getAttribute('href')).toBe('https://www.youtube.com/watch?feature=share')
+      expect(link?.textContent).toContain('View this content externally')
+      expect(link?.getAttribute('aria-label')).toBe('View this content externally')
     })
   })
 })


### PR DESCRIPTION
Fixes #2481

Improves handling of YouTube videos embedded via <iframe> elements and other iframe elements.

Behavior

- Previously, all iframes were removed, causing YouTube embeds to disappear in ZIM output.
- Detects YouTube-specific iframe URLs (youtube.com, youtube-nocookie.com, youtu.be).
- Replaces YouTube iframes with a responsive external-video placeholder.
- Extracts the video ID to link to the canonical https://www.youtube.com/watch?v=<ID> and display the video thumbnail.
- If the video ID cannot be extracted, renders a generic external link instead of producing a broken embed.
- The rewrite occurs before media processing so thumbnails are handled by the existing asset pipeline.