### PR TITLE
add --customCss CLI option for injecting static CSS files

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -9,6 +9,7 @@ Unreleased:
 * FIX: Handle categorylockdown error with placeholder instead of crashing (@triemerge #2150)
 * FIX: Improve mwUrl and adminEmail input validation and expanding test coverage for input sanitation (@RishabhThakur-19 #2657)
 * DEL: Remove deprecated CLI parameters `mwWikiPath`, `mwIndexPhpPath`, `keepEmptyParagraphs` (@Markus-Rost #2489)
+* NEW: Add `--customCss` CLI option to inject custom stylesheets
 
 1.17.5:
 * FIX: Ignore articles returning permissiondenied error code (@kunalsiyag #2604)

--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -281,6 +281,12 @@
       "title": "Additional modules",
       "description": "Add additional ResourceLoader modules for dynamic loading (comma separated list)",
       "required": false
+    },
+    "customCss": {
+      "type": "string",
+      "required": false,
+      "title": "Custom CSS",
+      "description": "Comma-separated list of CSS URLs to inject into all rendered pages. Alternatively, a path to a local file containing one URL per line."
     }
   }
 }

--- a/res/templates/pageFallback.html
+++ b/res/templates/pageFallback.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH____MW_DIR__/site.styles.css" />
     __ARTICLE_CSS_NOSCRIPT__
     <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH____RES_DIR__/footer.css" />
+    __CUSTOM_CSS__
   </head>
 
   <body class="mwoffliner-fallback __ARTICLE_BODY_CSS_CLASS__">

--- a/res/templates/pageVector2022.html
+++ b/res/templates/pageVector2022.html
@@ -14,6 +14,7 @@
     __ARTICLE_CSS_NOSCRIPT__
     <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH____RES_DIR__/footer.css" />
     <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH____RES_DIR__/vector-2022.css" />
+    __CUSTOM_CSS__
   </head>
   <body class="__ARTICLE_BODY_CSS_CLASS__">
     <div class="mw-page-container">

--- a/res/templates/pageVectorLegacy.html
+++ b/res/templates/pageVectorLegacy.html
@@ -14,6 +14,7 @@
     __ARTICLE_CSS_NOSCRIPT__
     <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH____RES_DIR__/footer.css" />
     <link rel="stylesheet" type="text/css" href="__RELATIVE_FILE_PATH____RES_DIR__/vector.css" />
+    __CUSTOM_CSS__
   </head>
 
   <body class="__ARTICLE_BODY_CSS_CLASS__">

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -153,6 +153,7 @@ class Downloader {
   private _jsonRequestOptions: AxiosRequestConfig
   private _streamRequestOptions: AxiosRequestConfig
   public trustedJs: string[] = []
+  public customCssUrls: string[] = []
 
   private uaString: string
   private backoffOptions: BackoffOptions

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -25,6 +25,7 @@ import {
   downloadAndSaveModule,
   downloadAndSaveStartupModule,
   getModuleDependencies,
+  downloadAndSaveCustomCss,
   genCanonicalLink,
   genHeaderCSSLink,
   genHeaderScript,
@@ -56,6 +57,7 @@ import { articleListHomeTemplate, htmlRedirectTemplateCode } from './Templates.j
 import { downloadFiles, saveArticles } from './util/saveArticles.js'
 import { getCategoriesForArticles, trimUnmirroredPages } from './util/categories.js'
 import urlHelper from './util/url.helper.js'
+import { parseCustomCssUrls, customCssUrlToFilename } from './util/customCss.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -103,6 +105,7 @@ async function execute(argv: any) {
     forceRender,
     forceSkin,
     langVariant,
+    customCss,
   } = argv
 
   let { articleList, articleListToIgnore } = argv
@@ -114,6 +117,14 @@ async function execute(argv: any) {
   // TODO: Move it to sanitaze method
   if (articleList) articleList = String(articleList)
   if (articleListToIgnore) articleListToIgnore = String(articleListToIgnore)
+
+  // Parse --customCss and populate Downloader so renderers can use the list
+  if (customCss) {
+    Downloader.customCssUrls = parseCustomCssUrls(String(customCss))
+    if (Downloader.customCssUrls.length > 0) {
+      logger.log(`Custom CSS URLs configured: ${Downloader.customCssUrls.join(', ')}`)
+    }
+  }
   const publisher = _publisher || config.defaults.publisher
 
   // TODO: Move it to sanitaze method
@@ -435,6 +446,23 @@ async function execute(argv: any) {
     if (!mainPage) {
       logger.log('Checking Main Page rendering')
       await createIndexPage(dump, zimCreator, true)
+    }
+
+    // Download and save custom CSS files
+    if (Downloader.customCssUrls.length > 0) {
+      logger.log(`Downloading ${Downloader.customCssUrls.length} custom CSS file(s)`)
+      const cssErrors: string[] = []
+      for (const cssUrl of Downloader.customCssUrls) {
+        try {
+          const filename = customCssUrlToFilename(cssUrl)
+          await downloadAndSaveCustomCss(zimCreator, cssUrl, filename)
+        } catch (err) {
+          cssErrors.push(`  - Failed to download [${cssUrl}]: ${err}`)
+        }
+      }
+      if (cssErrors.length > 0) {
+        throw new Error(`Failed to download custom CSS file(s):\n${cssErrors.join('\n')}`)
+      }
     }
 
     logger.log('Getting articles')

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -43,6 +43,7 @@ export const parameterDescriptions = {
   forceSkin: 'Force the usage of a specific skin, automatically chosen otherwise.',
   langVariant: 'Use a specific language variant, only for wikis supporting language conversion.',
   insecure: 'Skip HTTPS server authenticity verification step',
+  customCss: 'Comma-separated list of CSS URLs to inject into all rendered pages',
 }
 
 // TODO: Add an interface based on the object above

--- a/src/renderers/action-parse.renderer.ts
+++ b/src/renderers/action-parse.renderer.ts
@@ -7,6 +7,7 @@ import { genCanonicalLink, genHeaderScript, genHeaderCSSLink, getStaticFiles, ge
 import MediaWiki from '../MediaWiki.js'
 import { htmlVectorLegacyTemplateCode, htmlVector2022TemplateCode, htmlFallbackTemplateCode, javaScriptTemplateCode } from '../Templates.js'
 import Downloader, { DownloadError } from '../Downloader.js'
+import { customCssUrlToFilename } from '../util/customCss.js'
 import Gadgets from '../Gadgets.js'
 import { extractJsConfigVars, extractBodyCssClass, extractHtmlCssClass, getMainpageTitle } from '../util/articles.js'
 
@@ -85,6 +86,14 @@ export class ActionParseRenderer extends Renderer {
       .replace('__ARTICLE_JS_MODULES__', jsonStringify(jsDependenciesList))
       .replace('__ARTICLE_CSS_STATE__', jsonStringify(articleCssState))
 
+    // Generate custom CSS links from --customCss option
+    const customCssLinks = (Downloader.customCssUrls || [])
+      .map((cssUrl: string) => {
+        const filename = customCssUrlToFilename(cssUrl)
+        return genHeaderCSSLink(config, filename, articleId, config.output.dirs.res)
+      })
+      .join('\n    ')
+
     const htmlTemplateString = this.#htmlTemplateCode()
       .replace(/__ARTICLE_LANG_DIR__/g, articleLangDir)
       .replace('__ARTICLE_CANONICAL_LINK__', genCanonicalLink(config, MediaWiki.webUrl.href, articleId))
@@ -94,6 +103,7 @@ export class ActionParseRenderer extends Renderer {
       .replace('__ARTICLE_JS_STARTUP__', articleJsStartup)
       .replace('__ARTICLE_CSS_AFTER_META__', articleCssAfterMeta)
       .replace('__ARTICLE_CSS_NOSCRIPT__', articleCssNoscript)
+      .replace('__CUSTOM_CSS__', customCssLinks)
       .replace(/__ASSETS_DIR__/g, config.output.dirs.assets)
       .replace(/__RES_DIR__/g, config.output.dirs.res)
       .replace(/__MW_DIR__/g, config.output.dirs.mediawiki)

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -260,4 +260,5 @@ interface SiteInfoArgv {
   mwModulePath?: string
   forceSkin?: string
   langVariant?: string
+  customCss?: string
 }

--- a/src/util/customCss.ts
+++ b/src/util/customCss.ts
@@ -1,0 +1,66 @@
+import * as fs from 'fs'
+import crypto from 'crypto'
+
+export function parseCustomCssUrls(rawValue: string): string[] {
+  if (!rawValue) {
+    return []
+  }
+
+  const result: string[] = []
+  const errors: string[] = []
+
+  const parts = String(rawValue)
+    .split(',')
+    .filter((n) => n)
+    .map((part) => {
+      let item: string | string[] = part.trim()
+      if (fs.existsSync(item)) {
+        item = fs
+          .readFileSync(item, 'utf-8')
+          .split(/[\n,]/)
+          .map((a) => a.replace(/\r/gm, '').trim())
+          .filter((a) => a)
+      }
+      return item
+    })
+    .flat(1)
+
+  for (const part of parts) {
+    const trimmed = part.trim()
+    if (!trimmed) {
+      continue
+    }
+
+    try {
+      const url = new URL(trimmed)
+      if (!['http:', 'https:'].includes(url.protocol)) {
+        errors.push(`Invalid CSS URL [${trimmed}]: unsupported protocol [${url.protocol}]`)
+        continue
+      }
+    } catch {
+      errors.push(`Invalid CSS URL [${trimmed}]: not a valid URL`)
+      continue
+    }
+
+    if (result.includes(trimmed)) {
+      errors.push(`Duplicate CSS URL [${trimmed}]`)
+      continue
+    }
+
+    result.push(trimmed)
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`--customCss has invalid entries:\n${errors.map((e) => `  - ${e}`).join('\n')}`)
+  }
+
+  return result
+}
+
+export function customCssUrlToFilename(url: string): string {
+  const pathname = new URL(url).pathname
+  const basename = pathname.split('/').pop() || 'custom_style'
+  const stem = basename.replace(/\.css$/, '').replace(/[^a-zA-Z0-9._-]/g, '_')
+  const hash = crypto.createHash('md5').update(url).digest('hex').slice(0, 8)
+  return `${hash}_${stem}.css`
+}

--- a/src/util/dump.ts
+++ b/src/util/dump.ts
@@ -208,6 +208,16 @@ export function getModuleDependencies(oneModule: ResourceLoaderModule, allModule
   return allDeps
 }
 
+// Download a custom CSS file and save it into the ZIM.
+export async function downloadAndSaveCustomCss(zimCreator: Creator, cssUrl: string, filename: string): Promise<void> {
+  logger.log(`Downloading custom CSS [${cssUrl}]`)
+  const { content: cssBody } = await Downloader.downloadContent(cssUrl, 'css')
+  const processedCss = processStylesheetContent(cssUrl, '', cssBody.toString())
+  const zimPath = cssPath(filename, config.output.dirs.res)
+  await zimCreatorMutex.runExclusive(() => zimCreator.addItem(new StringItem(zimPath, 'text/css', null, { FRONT_ARTICLE: 0 }, processedCss)))
+  logger.log(`Saved custom CSS [${cssUrl}] at ${zimPath}`)
+}
+
 // URLs should be kept the same as Kiwix JS relies on it.
 export async function addWebpJsScripts(zimCreator: Creator) {
   ;[

--- a/test/unit/customCss.test.ts
+++ b/test/unit/customCss.test.ts
@@ -1,0 +1,105 @@
+import { parseCustomCssUrls, customCssUrlToFilename } from '../../src/util/customCss.js'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+
+describe('parseCustomCssUrls', () => {
+  let tempFilePath: string
+  let tempMixedFilePath: string
+
+  beforeAll(() => {
+    tempFilePath = path.join(os.tmpdir(), `test-custom-css-${Date.now()}.csv`)
+    fs.writeFileSync(tempFilePath, 'https://example.com/file1.css\nhttps://example.com/file2.css\nhttps://example.com/file3.css\n  \n')
+
+    tempMixedFilePath = path.join(os.tmpdir(), `test-custom-css-mixed-${Date.now()}.csv`)
+    // mix  of lines, spaces, trailing and commas
+    fs.writeFileSync(tempMixedFilePath, 'https://example.com/a.css\n\n  https://example.com/b.css  , https://example.com/c.css ,\nhttps://example.com/d.css\n\n')
+  })
+
+  afterAll(() => {
+    if (fs.existsSync(tempFilePath)) {
+      fs.unlinkSync(tempFilePath)
+    }
+    if (fs.existsSync(tempMixedFilePath)) {
+      fs.unlinkSync(tempMixedFilePath)
+    }
+  })
+
+  test('reads URLs from local file', () => {
+    const result = parseCustomCssUrls(tempFilePath)
+    expect(result).toEqual(['https://example.com/file1.css', 'https://example.com/file2.css', 'https://example.com/file3.css'])
+  })
+
+  test('reads heavily mixed formats from local file', () => {
+    const result = parseCustomCssUrls(tempMixedFilePath)
+    expect(result).toEqual(['https://example.com/a.css', 'https://example.com/b.css', 'https://example.com/c.css', 'https://example.com/d.css'])
+  })
+
+  test('parses comma-separated URLs', () => {
+    const result = parseCustomCssUrls('https://example.com/a.css,https://example.com/b.css')
+    expect(result).toEqual(['https://example.com/a.css', 'https://example.com/b.css'])
+  })
+
+  test('trims whitespace from URLs', () => {
+    const result = parseCustomCssUrls('  https://example.com/a.css , https://example.com/b.css  ')
+    expect(result).toEqual(['https://example.com/a.css', 'https://example.com/b.css'])
+  })
+
+  test('throws on duplicate URLs', () => {
+    expect(() => parseCustomCssUrls('https://example.com/a.css,https://example.com/a.css')).toThrow(/Duplicate CSS URL/)
+  })
+
+  test('throws on invalid URLs and lists all errors', () => {
+    expect(() => parseCustomCssUrls('invalid-url,also-invalid,https://example.com/valid.css')).toThrow(/Invalid CSS URL.*Invalid CSS URL/s)
+  })
+
+  test('throws on non-http(s) protocols', () => {
+    expect(() => parseCustomCssUrls('ftp://example.com/style.css')).toThrow(/unsupported protocol/)
+  })
+
+  test('ignores empty values', () => {
+    const result = parseCustomCssUrls('https://example.com/a.css,,https://example.com/b.css,')
+    expect(result).toEqual(['https://example.com/a.css', 'https://example.com/b.css'])
+  })
+
+  test('returns empty array for empty string', () => {
+    expect(parseCustomCssUrls('')).toEqual([])
+  })
+
+  test('returns empty array for null/undefined', () => {
+    expect(parseCustomCssUrls(null as any)).toEqual([])
+    expect(parseCustomCssUrls(undefined as any)).toEqual([])
+  })
+})
+
+describe('customCssUrlToFilename', () => {
+  test('extracts filename from URL with hash prefix', () => {
+    expect(customCssUrlToFilename('https://example.com/path/bootstrap.min.css')).toBe('3ab65b35_bootstrap.min.css')
+  })
+
+  test('add .css suffix even when original has one', () => {
+    expect(customCssUrlToFilename('https://example.com/style.css')).toBe('8d1c8eb9_style.css')
+  })
+
+  test('add .css suffix when original has no extension', () => {
+    expect(customCssUrlToFilename('https://example.com/stylesheet')).toBe('92361343_stylesheet.css')
+  })
+
+  test('sanitizes special characters', () => {
+    expect(customCssUrlToFilename('https://example.com/my%20style.css')).toBe('8c0df9dc_my_20style.css')
+  })
+
+  test('handles URLs with no meaningful path using fallback stem', () => {
+    expect(customCssUrlToFilename('https://example.com/')).toBe('182ccedb_custom_style.css')
+  })
+
+  test('handles deeply nested paths', () => {
+    expect(customCssUrlToFilename('https://cdn.example.com/assets/css/v2/theme.css')).toBe('faf87e3a_theme.css')
+  })
+
+  test('returns unique filenames for different URLs with same basename', () => {
+    const a = customCssUrlToFilename('https://cdn1.example.com/style.css')
+    const b = customCssUrlToFilename('https://cdn2.example.com/style.css')
+    expect(a).not.toEqual(b)
+  })
+})


### PR DESCRIPTION
fixes #2448

**What this PR does**
Adds a --customCss option to let users include their own CSS files when generating a ZIM. This fixes pages that look broken because some wikis use external CSS not captured by default

**How it works**
You just pass a comma-separated list of URLs:
`mwoffliner --customCss=cssUrl,cssURL2`
