### PR TITLE
fix: resize images to HTML-defined display width (#2192)

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,7 @@ Unreleased:
 * UPDATE: Replace iFrame with a placeholder card instead of deleting them (@kunalsiyag #2481)
 * NEW: Scrape only wikitext contentmodel articles by default (@triemerge #2445)
 * FIX: In nopic mode, fixed layout issues by preserving image layout using SVG placeholders (@kunalsiyag #1004)
+* NEW: Detect image size from HTML attribute instead of URL regex and recompress (@kunalsiyag #2192)
 * NEW: Add support for ResourceLoader based JavaScript (@Markus-Rost #2310)
 * CHANGED: Keep only ActionParse renderer (@benoit74 #2210)
 * CHANGED: Keep inline scripts if all JS is allowed (@Markus-Rost #2555)
@@ -12,6 +13,7 @@ Unreleased:
 * FIX: Recursively resolve CSS @import statements (@triemerge #2649)
 * DEL: Remove deprecated CLI parameters `mwWikiPath`, `mwIndexPhpPath`, `keepEmptyParagraphs` (@Markus-Rost #2489)
 * NEW: Add `--customCss` CLI option to inject custom stylesheets
+
 
 1.17.5:
 * FIX: Ignore articles returning permissiondenied error code (@kunalsiyag #2604)

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -586,7 +586,7 @@ class Downloader {
   public async getJSON<T>(_url: string): Promise<T> {
     const url = urlHelper.deserializeUrl(_url)
     return new Promise<T>((resolve, reject) => {
-      this.backoffCall(this.getJSONCb, url, 'json', (err: any, val: any) => {
+      this.backoffCall(this.getJSONCb, url, 'json', undefined, (err: any, val: any) => {
         if (err) {
           const httpStatus = (err.response && err.response.status) || err.httpReturnCode
           logger.info(`Failed to get [${url}] [status=${httpStatus}]`)
@@ -618,7 +618,12 @@ class Downloader {
     return this.request({ url, data, method: 'POST', ...config })
   }
 
-  public async downloadContent(_url: string, kind: DonwloadKind, retry = true): Promise<{ content: Buffer | string; contentType: string; setCookie: string | null }> {
+  public async downloadContent(
+    _url: string,
+    kind: DonwloadKind,
+    retry = true,
+    requestedWidth?: number,
+  ): Promise<{ content: Buffer | string; contentType: string; setCookie: string | null }> {
     if (!_url) {
       throw new Error(`Parameter [${_url}] is not a valid url`)
     }
@@ -638,9 +643,9 @@ class Downloader {
           }
         }
         if (retry) {
-          this.backoffCall(this.getContentCb, url, kind, cb)
+          this.backoffCall(this.getContentCb, url, kind, requestedWidth, cb)
         } else {
-          this.getContentCb(url, kind, cb)
+          this.getContentCb(url, kind, requestedWidth, cb)
         }
       })
     } catch (err) {
@@ -687,7 +692,7 @@ class Downloader {
     return articleDetails
   }
 
-  private getJSONCb = <T>(url: string, kind: DonwloadKind, handler: (...args: any[]) => any): void => {
+  private getJSONCb = <T>(url: string, kind: DonwloadKind, _requestedWidth: number | undefined, handler: (...args: any[]) => any): void => {
     logger.info(`Getting JSON from [${url}]`)
     this.request<T>({ url, method: 'GET', ...this.jsonRequestOptions })
       .then((val) => {
@@ -717,26 +722,40 @@ class Downloader {
     return fileType ? fileType.mime : null
   }
 
-  private async getCompressedBody(input: CompressionData): Promise<CompressionData> {
+  private async getCompressedBody(input: CompressionData, requestedWidth?: number): Promise<CompressionData> {
     const contentType = await this.getImageMimeType(input.data)
     if (isBitmapImageMimeType(contentType)) {
+      // Resize down with sharp before compression when the source is wider
+      // than the requested display width. Skip GIFs to avoid breaking animations.
+      let dataToCompress = input.data
+      if (requestedWidth && contentType !== 'image/gif') {
+        try {
+          const metadata = await sharp(input.data).metadata()
+          if (metadata.width && metadata.width > requestedWidth) {
+            dataToCompress = await sharp(input.data).resize({ width: requestedWidth, withoutEnlargement: true }).toBuffer()
+          }
+        } catch (err) {
+          logger.warn(`Failed to resize image to ${requestedWidth}px, proceeding without resize: ${err.message}`)
+        }
+      }
+
       if (this.webp && isWebpCandidateImageMimeType(contentType)) {
         return {
           data: await (imagemin as any)
-            .buffer(input.data, imageminOptions.get('webp').get(contentType))
+            .buffer(dataToCompress, imageminOptions.get('webp').get(contentType))
             .catch(async (err) => {
               if (/Unsupported color conversion request/.test(err.stderr)) {
                 return (imagemin as any)
-                  .buffer(await sharp(input.data).toColorspace('srgb').toBuffer(), imageminOptions.get('webp').get(contentType))
+                  .buffer(await sharp(dataToCompress).toColorspace('srgb').toBuffer(), imageminOptions.get('webp').get(contentType))
                   .catch(() => {
-                    return input.data
+                    return dataToCompress
                   })
                   .then((data) => {
                     return data
                   })
               } else {
-                return (imagemin as any).buffer(input.data, imageminOptions.get('default').get(contentType)).catch(() => {
-                  return input.data
+                return (imagemin as any).buffer(dataToCompress, imageminOptions.get('default').get(contentType)).catch(() => {
+                  return dataToCompress
                 })
               }
             })
@@ -746,8 +765,8 @@ class Downloader {
         }
       } else {
         return {
-          data: await (imagemin as any).buffer(input.data, imageminOptions.get('default').get(contentType)).catch(() => {
-            return input.data
+          data: await (imagemin as any).buffer(dataToCompress, imageminOptions.get('default').get(contentType)).catch(() => {
+            return dataToCompress
           }),
         }
       }
@@ -757,15 +776,15 @@ class Downloader {
     }
   }
 
-  private getContentCb = async (url: string, kind: DonwloadKind, handler: any): Promise<void> => {
+  private getContentCb = async (url: string, kind: DonwloadKind, requestedWidth: number | undefined, handler: any): Promise<void> => {
     logger.info(`Downloading [${url}]`)
     try {
       if (this.optimisationCacheUrl && kind === 'image') {
-        this.downloadImage(url, handler)
+        this.downloadImage(url, handler, requestedWidth)
       } else {
         const resp = await this.request({ url, method: 'GET', ...this.arrayBufferRequestOptions })
         // If content is an image, we might benefit from compressing it
-        const content = kind === 'image' ? (await this.getCompressedBody({ data: resp.data })).data : resp.data
+        const content = kind === 'image' ? (await this.getCompressedBody({ data: resp.data }, requestedWidth)).data : resp.data
         // compute content-type from content, since getCompressedBody might have modified it
         const contentType = kind === 'image' ? (await this.getImageMimeType(content)) || resp.headers['content-type'] : resp.headers['content-type']
         handler(null, {
@@ -782,12 +801,16 @@ class Downloader {
     }
   }
 
-  private async downloadImage(url: string, handler: any) {
+  private async downloadImage(url: string, handler: any, requestedWidth?: number) {
+    // Build a width-aware cache version token so the same URL at different
+    // requested widths does not reuse an undersized cached image.
+    const cacheVersion = this.webp ? (requestedWidth ? `webp-w${requestedWidth}` : 'webp') : requestedWidth ? `1-w${requestedWidth}` : '1'
+
     try {
       this.s3
 
         // Check first if we have an entry in the (object storage) cache for this URL
-        .downloadBlob(stripHttpFromUrl(url), this.webp ? 'webp' : '1')
+        .downloadBlob(stripHttpFromUrl(url), cacheVersion)
 
         // Handle the cache response and act accordingly
         .then(async (s3Resp) => {
@@ -824,12 +847,12 @@ class Downloader {
           }
 
           // Compress content because image blob comes from upstream MediaWiki
-          const compressedData = (await this.getCompressedBody({ data: mwResp.data })).data
+          const compressedData = (await this.getCompressedBody({ data: mwResp.data }, requestedWidth)).data
 
           // Check for the ETag and upload to cache
           const etag = this.removeEtagWeakPrefix(mwResp.headers.etag)
           if (etag) {
-            await this.s3.uploadBlob(stripHttpFromUrl(url), compressedData, etag, this.webp ? 'webp' : '1')
+            await this.s3.uploadBlob(stripHttpFromUrl(url), compressedData, etag, cacheVersion)
           }
 
           // get contentType from image, with fallback to response headers should the image be unsupported at all (e.g. SVG)
@@ -873,9 +896,15 @@ class Downloader {
     }
   }
 
-  private backoffCall(handler: (...args: any[]) => void, url: string, kind: DonwloadKind, callback: (...args: any[]) => void | Promise<void>): void {
+  private backoffCall(
+    handler: (...args: any[]) => void,
+    url: string,
+    kind: DonwloadKind,
+    requestedWidth: number | undefined,
+    callback: (...args: any[]) => void | Promise<void>,
+  ): void {
     this.backoffOptions.strategy.reset() // reset delay to initial one at each call
-    const call = backoff.call(handler, url, kind, callback)
+    const call = backoff.call(handler, url, kind, requestedWidth, callback)
     call.setStrategy(this.backoffOptions.strategy)
     call.retryIf(this.backoffOptions.retryIf)
     call.failAfter(this.backoffOptions.failAfter)

--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -588,11 +588,52 @@ export abstract class Renderer {
     return thumbDiv
   }
 
+  private getPositiveIntegerAttribute(node: DominoElement, attribute: string): number | undefined {
+    const val = Number.parseInt(node.getAttribute(attribute), 10)
+    return Number.isFinite(val) && val > 0 ? val : undefined
+  }
+
+  private getRequestedImageWidths(doc: DominoElement): KVS<number> {
+    const requestedWidths: KVS<number> = {}
+    const setRequestedWidth = (url: string, width: number) => {
+      const prevWidth = requestedWidths[url] || 0
+      requestedWidths[url] = Math.max(prevWidth, width)
+    }
+
+    for (const image of Array.from<HTMLImageElement>(doc.getElementsByTagName('img'))) {
+      const imageSrc = image.getAttribute('src')
+      const width = this.getPositiveIntegerAttribute(image, 'width') || this.getPositiveIntegerAttribute(image, 'data-width')
+      if (!imageSrc || !width) {
+        continue
+      }
+      try {
+        setRequestedWidth(getFullUrl(imageSrc, MediaWiki.baseUrl), width)
+      } catch {
+        continue
+      }
+    }
+
+    for (const video of Array.from<HTMLVideoElement>(doc.getElementsByTagName('video'))) {
+      const posterSrc = video.getAttribute('poster')
+      const width = this.getPositiveIntegerAttribute(video, 'width')
+      if (!posterSrc || !width) {
+        continue
+      }
+      try {
+        setRequestedWidth(getFullUrl(posterSrc, MediaWiki.baseUrl), width)
+      } catch {
+        continue
+      }
+    }
+
+    return requestedWidths
+  }
+
   // TODO: The first part of this method is common for all renders
   public async processHtml(processHtmlOpts: ProcessHtmlOpts) {
     const { html, dump, articleId, articleDetail, displayTitle, moduleDependencies, callback } = processHtmlOpts
     let { articleSubtitle } = processHtmlOpts
-    let imageDependencies: Array<{ url: string; path: string }> = []
+    let imageDependencies: Array<{ url: string; path: string; width?: number }> = []
     let videoDependencies: Array<{ url: string; path: string }> = []
     let mediaDependencies: Array<{ url: string; path: string }> = []
     let subtitles: Array<{ url: string; path: string }> = []
@@ -612,6 +653,7 @@ export abstract class Renderer {
     // placeholders (e.g. YouTube thumbnails) are already in the DOM
     // when treatMedias processes <img> tags for download into the ZIM.
     doc = await this.applyOtherTreatments(doc, dump, articleId)
+    const imageRequestedWidths = this.getRequestedImageWidths(doc)
 
     const tmRet = await this.treatMedias(doc, dump, articleId)
 
@@ -630,7 +672,8 @@ export abstract class Renderer {
         .filter((a) => a)
         .map((url) => {
           const path = getMediaBase(url, false)
-          return { url, path }
+          const width = imageRequestedWidths[url]
+          return width ? { url, path, width } : { url, path }
         }),
     )
 
@@ -639,7 +682,8 @@ export abstract class Renderer {
         .filter((a) => a)
         .map((url) => {
           const path = getMediaBase(url, false)
-          return { url, path }
+          const width = imageRequestedWidths[url]
+          return width ? { url, path, width } : { url, path }
         }),
     )
 

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -153,7 +153,7 @@ export async function downloadFiles(fileStore: RKVS<FileDetail>, zimCreator: Cre
 
     fileToDownload.downloadAttempts += 1
     logger.info(`Worker ${workerId} downloading ${urlHelper.deserializeUrl(fileToDownload.url)} (${fileToDownload.kind})`)
-    await Downloader.downloadContent(fileToDownload.url, fileToDownload.kind, false)
+    await Downloader.downloadContent(fileToDownload.url, fileToDownload.kind, false, fileToDownload.width)
       .then(async (resp) => {
         if (resp && resp.content && resp.contentType) {
           // { FRONT_ARTICLE: 0 } is here very important, should we retrieve HTML we want to be sure the libzim will
@@ -309,7 +309,9 @@ async function saveArticle(
       const existingVals = await RedisStore.filesToDownloadXPath.getMany(imageDependencies.map((dep) => dep.path))
 
       for (const dep of imageDependencies) {
-        const { mult, width } = getSizeFromUrl(dep.url)
+        const urlSize = getSizeFromUrl(dep.url)
+        const width = dep.width || urlSize.width
+        const mult = urlSize.mult
         const existingVal = existingVals[dep.path]
         const currentDepIsHigherRes = !existingVal || existingVal.width < (width || 10e6) || existingVal.mult < (mult || 1)
         if (currentDepIsHigherRes) {

--- a/test/unit/downloader.retry.test.ts
+++ b/test/unit/downloader.retry.test.ts
@@ -21,12 +21,12 @@ const createDownloader = () => {
 }
 
 const stubImmediateBackoff = (downloader: DownloaderClass) => {
-  ;(downloader as any).backoffCall = (handler: any, url: string, kind: any, cb: any) => {
+  ;(downloader as any).backoffCall = (handler: any, url: string, kind: any, requestedWidth: any, cb: any) => {
     const retryIf = (downloader as any).backoffOptions.retryIf as (error?: any) => boolean
     let attempts = 0
     const run = () => {
       attempts += 1
-      handler(url, kind, (err: any, val: any) => {
+      handler(url, kind, requestedWidth, (err: any, val: any) => {
         if (err && attempts < 3 && retryIf(err)) {
           run()
           return

--- a/test/unit/renderers/processHtml.test.ts
+++ b/test/unit/renderers/processHtml.test.ts
@@ -138,6 +138,36 @@ describe('processHtml', () => {
     })
   })
 
+  describe('image tags', () => {
+    const imageSrc = '//upload.wikimedia.org/wikipedia/commons/thumb/f/fa/Dendritic_cell_revealed.jpg/250px-Dendritic_cell_revealed.jpg'
+
+    it('captures requested width from the img width attribute', async () => {
+      const { imageDependencies } = await testProcessHtml(`<img src="${imageSrc}" width="180" height="135">`)
+      // console.log('debug imageDependencies single', imageDependencies)
+
+      expect(imageDependencies).toHaveLength(1)
+      expect(imageDependencies[0].url).toEqual(`https:${imageSrc}`)
+      expect(imageDependencies[0].width).toEqual(180)
+    })
+
+    it('keeps the maximum requested width for duplicate image URLs', async () => {
+      const { imageDependencies } = await testProcessHtml(`<img src="${imageSrc}" width="180"><img src="${imageSrc}" width="320">`)
+      // console.log('debug imageDependencies dup', imageDependencies)
+
+      expect(imageDependencies).toHaveLength(1)
+      expect(imageDependencies[0].url).toEqual(`https:${imageSrc}`)
+      expect(imageDependencies[0].width).toEqual(320)
+    })
+
+    it('missing width attribute still produces dependency without width (URL fallback)', async () => {
+      const { imageDependencies } = await testProcessHtml(`<img src="${imageSrc}">`)
+
+      expect(imageDependencies).toHaveLength(1)
+      expect(imageDependencies[0].url).toEqual(`https:${imageSrc}`)
+      expect(imageDependencies[0].width).toBeUndefined()
+    })
+  })
+
   describe('iframe', () => {
     it('remove empty iframe', async () => {
       const { finalHTML } = await testProcessHtml(`<div id="foo"><iframe></iframe></div>`)


### PR DESCRIPTION
Fixes #2192

Images are resized to their actual display width (from HTML `width` attributes) before compression instead of being stored at full resolution. This reduces ZIM size without visible quality loss.

### Changes

- **`abstract.renderer.ts`**
  - Attach `width` from `getRequestedImageWidths` to `imageDependencies`

- **`saveArticles.ts`**
  - Prefer HTML-derived `dep.width` for deduplication
  - Pass `width` to `downloadContent`

- **`Downloader.ts`**
  - Accept `requestedWidth`
  - Resize via `sharp` prior to `imagemin`
  - Introduce width-aware S3 cache keys (`webp-w300`)
  - Prevent cache collisions across resize variants

- **`processHtml.test.ts`**
  - Regression test for images missing `width`

### Design Decisions

- Skip GIF resizing (sharp removes animation frames)
- `withoutEnlargement: true` (downscale only)
- Graceful fallback on resize failure
- Width-aware S3 cache versioning