### PR TITLE
docs: improve README local setup guide and add troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,10 @@
 # MWoffliner
 
-MWoffliner is a tool for making a local offline HTML snapshot of any
-online [MediaWiki](https://mediawiki.org) instance. It goes through
-all online articles (or a selection if specified) and create the
-corresponding [ZIM](https://openzim.org) file. It has mainly been
-tested against Wikimedia projects like
-[Wikipedia](https://wikipedia.org) and
-[Wiktionary](https://wiktionary.org) --- but it should also work for
-any recent MediaWiki.
+MWoffliner is a tool for creating a local offline HTML snapshot of any online [MediaWiki](https://mediawiki.org) instance. It scrapes all articles (or a selection if specified) and creates the corresponding [ZIM](https://openzim.org) file. While primarily targeted for Wikimedia projects like [Wikipedia](https://wikipedia.org) and [Wiktionary](https://wiktionary.org), MWoffliner also supports any recent MediaWiki instance (version 1.27+), though instances with custom skins or highly unusual configurations may have limitations.
 
-Read [CONTRIBUTING.md](./CONTRIBUTING.md) to know more about
-MWoffliner development.
+Read [CONTRIBUTING.md](./CONTRIBUTING.md) to learn more about MWoffliner development.
 
-User Help is available in the for a a
-[FAQ](https://github.com/openzim/mwoffliner/wiki/Frequently-Asked-Questions).
+User help is available in the [FAQ](https://github.com/openzim/mwoffliner/wiki/Frequently-Asked-Questions).
 
 [![NPM](https://nodei.co/npm/mwoffliner.png)](https://www.npmjs.com/package/mwoffliner)
 
@@ -28,14 +19,14 @@ User Help is available in the for a a
 
 ## Features
 
-- Scrape with or without image thumbnail
+- Scrape with or without image thumbnails
 - Scrape with or without audio/video multimedia content
 - S3 cache (optional)
-- Image size optimiser / Webp converter
+- Image size optimization and WebP conversion
 - Scrape all articles in namespaces or title list based
 - Specify additional/non-main namespaces to scrape
 
-Run `mwoffliner --help` to get all the possible options.
+Run `mwoffliner --help` to see all available options.
 
 ## Prerequisites
 
@@ -55,15 +46,20 @@ docker pull ghcr.io/openzim/mwoffliner
 
 ### Prerequisites for local execution
 
-- *NIX Operating System (GNU/Linux, macOS, ...)
-- [Redis](https://redis.io/)
-- [NodeJS](https://nodejs.org/en/) version 24 (we support only one single Node.JS version, other versions might work or not)
-- [Libzim](https://github.com/openzim/libzim) (On GNU/Linux & macOS we automatically download it)
-- Various build tools which are probably already installed on your
-  machine (packages `libjpeg-dev`, `libglu1`, `autoconf`, `automake`, `gcc` on
-  Debian/Ubuntu)
+- *NIX Operating System (GNU/Linux, macOS, etc.)
+- [Redis](https://redis.io/) — in-memory data store
+- [Node.js](https://nodejs.org/en/) version 24 (we support only one single Node.js version; other versions might work or might not)
+- [Libzim](https://github.com/openzim/libzim) — C++ library for creating ZIM files (automatically downloaded on GNU/Linux & macOS)
+- Various build tools which are probably already installed on your machine:
+  - `libjpeg-dev` — JPEG image processing
+  - `libglu1` — OpenGL utility library
+  - `autoconf` — automatic configuration system
+  - `automake` — Makefile generator
+  - `gcc` — C compiler
 
-... and an online MediaWiki with its API available.
+  (These packages are for Debian/Ubuntu systems)
+
+An online [MediaWiki](https://mediawiki.org) instance with its API available.
 
 ### Installation methods
 
@@ -86,16 +82,88 @@ docker pull ghcr.io/openzim/mwoffliner
 > [!WARNING]
 > Local installation requires several system dependencies (see above). Using the Docker image is strongly recommended to avoid setup issues.
 
-1. Install latest released MWoffliner version from NPM (use `-g` to install globally):
+Setting up MWoffliner locally for development can be tricky due to several dependencies and version requirements. Follow these steps carefully to avoid common errors.
 
+##### 1. Node.js Version
+
+MWoffliner requires Node.js 24 (other versions may fail).
+
+Compatible Node 24 ranges: `>=24 <24.6` or `>=24.7 <25`.
+
+Check your version:
+
+```sh
+node -v
+```
+
+If your version does not match, use [nvm](https://github.com/nvm-sh/nvm) to install the correct Node.js version.
+
+##### 2. libzim Dependency
+
+MWoffliner depends on [`@openzim/libzim`](https://github.com/openzim/libzim), which requires the C++ libzim library.
+
+- On Linux/macOS, MWoffliner can download libzim automatically.
+- On Windows, you must install libzim manually because there are no prebuilt binaries. See the [libzim installation guide](https://github.com/openzim/libzim) for details.
+
+##### 3. Compiler Requirements (Windows)
+
+Node 24 on Windows officially supports [Visual Studio 2019 (v16)](https://visualstudio.microsoft.com/vs/older-downloads/) or [Visual Studio 2022 (v17)](https://visualstudio.microsoft.com/downloads/).
+
+Ensure C++ build tools are installed and environment variables are set correctly. See [Windows Setup for node-gyp](https://github.com/nodejs/node-gyp#on-windows) for detailed instructions.
+
+##### 4. Node-gyp
+
+MWoffliner uses [node-gyp](https://github.com/nodejs/node-gyp), which enforces strict checks for Node and compiler versions. Make sure you have:
+
+- Proper Visual Studio version (Windows) — see [Visual Studio versions](https://visualstudio.microsoft.com/downloads/)
+- Required C++ headers, e.g., `zim/archive.h` — see [libzim documentation](https://github.com/openzim/libzim)
+- [Python 3.10+](https://www.python.org/downloads/) (required by node-gyp; a recent version is preferred for compatibility)
+
+##### Additional troubleshooting steps if errors persist:
+
+1. **Clear npm cache** — a corrupted cache can cause cryptic install failures:
    ```sh
-   npm i -g mwoffliner
+   npm cache clean --force
    ```
 
-   > [!WARNING] 
-   > Note that you might need to run this command with the `sudo` command, depending
-   how your `npm` / OS is configured. `npm` permission checking can be a bit annoying for a
-   newcomer. Please read the documentation carefully if you hit problems: https://docs.npmjs.com/cli/v7/using-npm/scripts#user
+2. **Delete node_modules and reinstall** — stale or partially installed dependencies are a common source of errors:
+   ```sh
+   rm -rf node_modules package-lock.json
+   npm install
+   ```
+
+3. **Check that all environment variables are set** — especially on Windows, `PATH`, `INCLUDE`, and `LIB` must point to the correct Visual Studio and libzim directories. Reopen your terminal after installing new tools.
+
+4. **Verify Redis is running before starting MWoffliner** — MWoffliner will fail immediately if it cannot connect to Redis:
+   ```sh
+   redis-cli ping   # expected output: PONG
+   ```
+
+5. **Run npm install with verbose logging** to see exactly where it fails:
+   ```sh
+   npm install --verbose
+   ```
+
+##### 5. Common Errors & Troubleshooting
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| Node.js version error | Node.js version incompatible | Install [Node 24 with nvm](https://github.com/nvm-sh/nvm) |
+| Cannot find module @openzim/libzim | libzim not installed | Follow [libzim installation guide](https://github.com/openzim/libzim); Windows users must install manually |
+| node-gyp rebuild failed | Wrong Node or compiler version | Check [Node.js version](https://nodejs.org/en/), [Visual Studio version](https://visualstudio.microsoft.com/downloads/), [Python 3.x](https://www.python.org/downloads/) |
+| zim/archive.h not found | C++ headers missing | Install [libzim](https://github.com/openzim/libzim) system-wide, verify include paths |
+
+> [!NOTE]
+> Even with these steps, other setup errors may occur. Using Docker is strongly recommended for a smoother experience.
+
+##### Installation via NPM
+
+```sh
+npm i -g mwoffliner
+```
+
+> [!WARNING]
+> You might need to run this command with the `sudo` command, depending on how your `npm` / OS is configured. `npm` permission checking can be a bit annoying for newcomers. Please read the [npm script documentation](https://docs.npmjs.com/cli/v7/using-npm/scripts#user) if you encounter issues.
 
 </details>
 
@@ -129,15 +197,15 @@ mwoffliner --mwUrl=https://bm.wikipedia.org --adminEmail=foo@bar.net
 
 </details>
 
-To use MWoffliner with a S3 cache, you should provide a S3 URL like
-this:
+To use MWoffliner with an S3 cache, provide an S3 URL:
+
 ```sh
 --optimisationCacheUrl="https://wasabisys.com/?bucketName=my-bucket&keyId=my-key-id&secretAccessKey=my-sac"
 ```
 
 ## Contribute
 
-If you've retrieved mwoffliner source code (e.g. with a git clone of our repo), you can then install and run it locally (including with your local modifications):
+If you've retrieved the MWoffliner source code (e.g., via a git clone), you can install and run it locally with your modifications:
 
 ```bash
 npm i
@@ -148,18 +216,19 @@ Detailed [contribution documentation and guidelines](CONTRIBUTING.md) are availa
 
 ## API
 
-MWoffliner provides also an API and therefore can be used as a NodeJS
-library. Here a stub example that could go in your index.mjs file:
+MWoffliner provides an API and can be used as a Node.js library. Here's a stub example for your `index.mjs` file:
+
 ```javascript
 import * as mwoffliner from 'mwoffliner';
 
 const parameters = {
-    mwUrl: "https://es.wikipedia.org",
-    adminEmail: "foo@bar.net",
-    verbose: true,
-    format: "nopic",
-    articleList: "./articleList"
+  mwUrl: "https://es.wikipedia.org",
+  adminEmail: "foo@bar.net",
+  verbose: true,
+  format: "nopic",
+  articleList: "./articleList"
 };
+
 mwoffliner.execute(parameters); // returns a Promise
 ```
 
@@ -167,22 +236,17 @@ mwoffliner.execute(parameters); // returns a Promise
 
 Complementary information about MWoffliner:
 
-* MediaWiki software is used by thousands of wikis, the most
-  famous ones being the Wikimedia ones, including [Wikipedia](https://wikipedia.org).
-* MediaWiki is a PHP wiki runtime engine.
-* Wikitext is the name of the markup language that MediaWiki uses.
-* MediaWiki includes a parser for WikiText into HTML, and this
-  parser creates the HTML pages displayed in your browser.
-* Have a look at the scraper [functional architecture](docs/functional_architecture.md)
+- **MediaWiki software** is used by thousands of wikis, the most famous ones being the Wikimedia ones, including [Wikipedia](https://wikipedia.org).
+- **MediaWiki** is a PHP wiki runtime engine.
+- **Wikitext** is the markup language that MediaWiki uses.
+- **MediaWiki parser** converts Wikitext to HTML, which displays in your browser.
+- Read the [scraper functional architecture](docs/functional_architecture.md) for more details.
 
-License
--------
+## License
 
-[GPLv3](https://www.gnu.org/licenses/gpl-3.0) or later, see
-[LICENSE](LICENSE) for more details.
+[GPLv3](https://www.gnu.org/licenses/gpl-3.0) or later, see [LICENSE](LICENSE) for more details.
 
-Acknowledgements
---------
+## Acknowledgements
 
 This project received funding through [NGI Zero Core](https://nlnet.nl/core), a fund established by [NLnet](https://nlnet.nl/) with financial support from the European Commission's [Next Generation Internet](https://ngi.eu/) program. Learn more at the [NLnet project page](https://nlnet.nl/project/MWOffliner).
 


### PR DESCRIPTION
## Summary

Improves the local setup documentation in README.md to make it easier for new contributors to set up MWoffliner.

## Changes

- Clarified Node.js v24 version requirements
- Added detailed libzim explanation
- Added Windows-specific compiler requirements
- Documented node-gyp requirements
- Added Redis verification step
- Added troubleshooting section with common errors and fixes
- Solved minor Grammatical and indentation Errors of the original README.md