### PR TITLE
Scrape only wikitext contentmodel articles by default

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,5 @@
 Unreleased:
+* NEW: Scrape only wikitext contentmodel articles by default (@triemerge #2445)
 * NEW: Add support for ResourceLoader based JavaScript (@Markus-Rost #2310)
 * CHANGED: Keep only ActionParse renderer (@benoit74 #2210)
 * CHANGED: Keep inline scripts if all JS is allowed (@Markus-Rost #2555)

--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -134,6 +134,12 @@
       "title": "Add Namespaces",
       "description": "Include addional namespaces (comma separated numbers)"
     },
+    "addContentModels": {
+      "type": "string",
+      "required": false,
+      "title": "Add Content Models",
+      "description": "Include additional content models besides wikitext (comma separated). By default, only wikitext articles are scraped."
+    },
     "getCategories": {
       "type": "boolean",
       "required": false,

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -94,6 +94,7 @@ async function execute(argv: any) {
     publisher: _publisher,
     outputDirectory: _outputDirectory,
     addNamespaces: _addNamespaces,
+    addContentModels: _addContentModels,
     javaScript: _javaScript,
     addModules: _addModules,
     customZimFavicon,
@@ -194,6 +195,12 @@ async function execute(argv: any) {
     ? String(_addNamespaces)
         .split(',')
         .map((a: string) => Number(a))
+    : []
+
+  const addContentModels = _addContentModels
+    ? String(_addContentModels)
+        .split(',')
+        .map((a: string) => a.trim())
     : []
 
   /* Get MediaWiki Info */
@@ -297,9 +304,11 @@ async function execute(argv: any) {
     }
   }
 
+  const allowedContentModels = ['wikitext', ...addContentModels]
+
   logger.info('Getting article ids')
   let stime = Date.now()
-  await getArticleIds(mainPage, articleList ? articleListLines : null, articleListToIgnore ? articleListToIgnoreLines : null)
+  await getArticleIds(mainPage, articleList ? articleListLines : null, articleListToIgnore ? articleListToIgnoreLines : null, allowedContentModels)
   logger.log(`Got ArticleIDs in ${(Date.now() - stime) / 1000} seconds`)
 
   if (MediaWiki.getCategories) {

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -33,6 +33,8 @@ export const parameterDescriptions = {
   withoutZimFullTextIndex: "Don't include a fulltext search index to the ZIM",
   webp: 'Convert all jpeg, png and gif images to webp format',
   addNamespaces: 'Force additional namespace (comma separated numbers)',
+  addContentModels: 'Include additional content models besides wikitext (comma separated, e.g. "Scribunto,json"). By default, only wikitext articles are scraped.',
+
   javaScript: 'Amount of JavaScript being allowed in pages, one of the following values can be given: "none", "trusted" or "all" (default being "trusted").',
   addModules: 'Add additional ResourceLoader modules for dynamic loading (comma separated list)',
   osTmpDir: 'Override default operating system temporary directory path environment variable',

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -96,7 +96,7 @@ async function saveToStore(
   }
 }
 
-export function getArticlesByNS(ns: number, articleIdsToIgnore?: string[], continueLimit?: number): Promise<void> {
+export function getArticlesByNS(ns: number, articleIdsToIgnore?: string[], allowedContentModels: string[] = ['wikitext'], continueLimit?: number): Promise<void> {
   // eslint-disable-next-line no-async-promise-executor
   return new Promise(async (resolve, reject) => {
     let totalArticles = 0
@@ -139,6 +139,20 @@ export function getArticlesByNS(ns: number, articleIdsToIgnore?: string[], conti
             articleIdsToIgnore = []
           }
           articleIdsToIgnore.push(...newArticlesToIgnore)
+        }
+
+        // Filter articles by content model (#2445)
+        if (allowedContentModels) {
+          const articlesWithWrongModel = Object.values(chunk.articleDetails)
+            .filter((a) => !allowedContentModels.includes(a.contentmodel))
+            .map((article) => article.title)
+          if (articlesWithWrongModel.length > 0) {
+            logger.info(`Skipping articles with non-matching content model: ${articlesWithWrongModel.join(', ')}`)
+            if (!articleIdsToIgnore) {
+              articleIdsToIgnore = []
+            }
+            articleIdsToIgnore.push(...articlesWithWrongModel)
+          }
         }
 
         if (articleIdsToIgnore) {
@@ -340,7 +354,7 @@ export async function checkApiAvailability(url: string, allowedMimeTypes = null)
   }
 }
 
-export async function getArticleIds(mainPage?: string, articleIds?: string[], articleIdsToIgnore?: string[]) {
+export async function getArticleIds(mainPage?: string, articleIds?: string[], articleIdsToIgnore?: string[], allowedContentModels: string[] = ['wikitext']) {
   if (mainPage) {
     await getArticlesByIds([mainPage])
   }
@@ -351,7 +365,7 @@ export async function getArticleIds(mainPage?: string, articleIds?: string[], ar
     await pmap(
       MediaWiki.namespacesToMirror,
       (namespace: string) => {
-        return getArticlesByNS(MediaWiki.namespaces[namespace].num, articleIdsToIgnore)
+        return getArticlesByNS(MediaWiki.namespaces[namespace].num, articleIdsToIgnore, allowedContentModels)
       },
       { concurrency: Downloader.speed },
     )

--- a/test/unit/mwApi.test.ts
+++ b/test/unit/mwApi.test.ts
@@ -62,7 +62,7 @@ describe('mwApi', () => {
   })
 
   test('MWApi NS', async () => {
-    await getArticlesByNS(0, undefined, 5) // Get 5 continues/pages of NSes
+    await getArticlesByNS(0, undefined, ['wikitext'], 5) // Get 5 continues/pages of NSes
     const interestingAIds = ['"...And_Ladies_of_the_Club"', '"Khan_gizi"_spring']
     const articles = await RedisStore.articleDetailXId.getMany(interestingAIds)
     const ArticleWithRevisionsAndCategory = articles['"...And_Ladies_of_the_Club"']


### PR DESCRIPTION
Fix #2445

- Filter articles by contentmodel during scraping, keeping only wikitext articles by default
- Add `--addContentModels` option to include additional content models (comma separated)
- Add `--scrapeAllContentModels` option to scrape all content models regardless
- Log skipped articles with their content model for transparency
- Add Changelog entry