### PR TITLE
Text overlaps on other other text or even images

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,6 @@
 Unreleased:
 * NEW: Scrape only wikitext contentmodel articles by default (@triemerge #2445)
+* FIX: In nopic mode, fixed layout issues by preserving image layout using SVG placeholders (@kunalsiyag #1004)
 * NEW: Add support for ResourceLoader based JavaScript (@Markus-Rost #2310)
 * CHANGED: Keep only ActionParse renderer (@benoit74 #2210)
 * CHANGED: Keep inline scripts if all JS is allowed (@Markus-Rost #2555)

--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -339,7 +339,7 @@ export abstract class Renderer {
   private treatImageFrames(dump: Dump, parsoidDoc: DominoElement, imageNode: DominoElement) {
     const image = imageNode.getElementsByTagName('img')[0] || imageNode.getElementsByTagName('video')[0]
 
-    if (!this.shouldKeepNode(dump, imageNode, image)) {
+    if (!this.shouldKeepNode(imageNode, image)) {
       DOMUtils.deleteNode(imageNode)
       return
     }
@@ -376,8 +376,13 @@ export abstract class Renderer {
   private async treatImage(dump: Dump, srcCache: KVS<boolean>, articleId: string, img: DominoElement): Promise<{ imageDependencies: string[] }> {
     const imageDependencies: string[] = []
 
-    if (!this.shouldKeepImage(dump, img)) {
+    if (!this.shouldKeepImage(img)) {
       DOMUtils.deleteNode(img)
+      return { imageDependencies }
+    }
+
+    if (dump.nopic && !this.isMathFallbackImage(img)) {
+      this.convertImageToPlaceholder(img)
       return { imageDependencies }
     }
 
@@ -413,14 +418,113 @@ export abstract class Renderer {
     return { imageDependencies }
   }
 
-  private shouldKeepImage(dump: Dump, img: DominoElement) {
+  private convertImageToPlaceholder(img: DominoElement) {
+    const width = this.getImageDimension(img, 'width')
+    const height = this.getImageDimension(img, 'height')
+    const meaningfulAlt = this.getMeaningfulAltText(img)
+    const svgPayload = this.getPlaceholderSvgPayload(width, height, meaningfulAlt, this.shouldRenderVisibleAlt(width, height))
+
+    if (!img.getAttribute('width') && width) {
+      img.setAttribute('width', `${width}`)
+    }
+    if (!img.getAttribute('height') && height) {
+      img.setAttribute('height', `${height}`)
+    }
+
+    img.setAttribute('src', `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svgPayload)}`)
+    img.removeAttribute('resource')
+    img.removeAttribute('srcset')
+    img.setAttribute('loading', 'lazy')
+  }
+
+  private getImageDimension(img: DominoElement, attrName: 'width' | 'height'): number | null {
+    const attrValue = Number(img.getAttribute(attrName))
+    if (Number.isFinite(attrValue) && attrValue > 0) {
+      return attrValue
+    }
+
+    const styleValue = this.getImageDimensionFromStyle(img, attrName)
+    if (styleValue) {
+      return styleValue
+    }
+
+    const dataAttrName = attrName === 'width' ? 'data-file-width' : 'data-file-height'
+    const dataAttrValue = Number(img.getAttribute(dataAttrName))
+    if (Number.isFinite(dataAttrValue) && dataAttrValue > 0) {
+      return dataAttrValue
+    }
+
+    return null
+  }
+
+  private getImageDimensionFromStyle(img: DominoElement, attrName: 'width' | 'height'): number | null {
+    const style = img.getAttribute('style')
+    if (!style) {
+      return null
+    }
+
+    const regex = new RegExp(`(?:^|;)\\s*${attrName}\\s*:\\s*([0-9]+(?:\\.[0-9]+)?)\\s*(?:px)?\\s*(?:;|$)`, 'i')
+    const match = style.match(regex)
+    if (!match) {
+      return null
+    }
+
+    const value = Math.round(Number(match[1]))
+    return Number.isFinite(value) && value > 0 ? value : null
+  }
+
+  private shouldRenderVisibleAlt(width: number | null, height: number | null) {
+    return !!width && !!height && width >= 48 && height >= 24
+  }
+
+  private getPlaceholderSvgPayload(width: number | null, height: number | null, meaningfulAlt: string | null, shouldRenderVisibleAlt: boolean) {
+    const safeWidth = width || 1
+    const safeHeight = height || 1
+    const title = meaningfulAlt ? `<title>${this.escapeXml(meaningfulAlt)}</title>` : ''
+    const defs = shouldRenderVisibleAlt ? '<defs><clipPath id="alt-text-clip"><rect x="0" y="0" width="100%" height="100%" /></clipPath></defs>' : ''
+    let text = ''
+
+    if (meaningfulAlt && shouldRenderVisibleAlt) {
+      const fontSize = Math.max(10, Math.min(16, Math.floor(safeHeight / 3)))
+      text =
+        `<g clip-path="url(#alt-text-clip)">` +
+        `<text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" fill="#54595d" font-size="${fontSize}" font-family="sans-serif">${this.escapeXml(meaningfulAlt)}</text>` +
+        '</g>'
+    }
+
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="${safeWidth}" height="${safeHeight}" viewBox="0 0 ${safeWidth} ${safeHeight}" preserveAspectRatio="none">${title}${defs}<rect width="100%" height="100%" fill="transparent"/>${text}</svg>`
+  }
+
+  private getMeaningfulAltText(img: DominoElement) {
+    const alt = img.getAttribute('alt')
+    if (!alt) {
+      return null
+    }
+    const compactAlt = alt.replace(/\u00a0/g, ' ').trim()
+    return compactAlt.length > 0 ? compactAlt : null
+  }
+
+  private escapeXml(input: string) {
+    return input.replace(/[<>&"']/g, (char) => {
+      const entities: KVS<string> = {
+        '<': '&lt;',
+        '>': '&gt;',
+        '&': '&amp;',
+        '"': '&quot;',
+        "'": '&apos;',
+      }
+      return entities[char]
+    })
+  }
+
+  private isMathFallbackImage(img: DominoElement) {
     const imageNodeClass = img.getAttribute('class') || ''
+    return imageNodeClass.includes('mwe-math-fallback-image-inline') || img.getAttribute('typeof') === 'mw:Extension/math'
+  }
+
+  private shouldKeepImage(img: DominoElement) {
     const src = img.getAttribute('src')
-    return (
-      (!dump.nopic || imageNodeClass.includes('mwe-math-fallback-image-inline') || img.getAttribute('typeof') === 'mw:Extension/math') &&
-      src &&
-      !src.includes('./Special:FilePath/')
-    )
+    return !!src && !src.includes('./Special:FilePath/')
   }
 
   protected async treatMedias(parsoidDoc: DominoElement, dump: Dump, articleId: string) {
@@ -460,8 +564,8 @@ export abstract class Renderer {
     return image && image.parentNode && image.parentNode.tagName === 'A'
   }
 
-  private shouldKeepNode(dump: Dump, imageNode: DominoElement, image: DominoElement) {
-    return !dump.nopic && imageNode && image
+  private shouldKeepNode(imageNode: DominoElement, image: DominoElement) {
+    return !!(imageNode && image)
   }
 
   private makeThumbDiv(dump: Dump, parsoidDoc: DominoElement, imageNode: DominoElement) {

--- a/test/e2e/formatParams.test.ts
+++ b/test/e2e/formatParams.test.ts
@@ -22,8 +22,15 @@ await testAllRenders('format-params-nopic', { ...parameters, format: 'nopic', ar
       const articleDoc = domino.createDocument(articleFromDump)
 
       const imgElements = Array.from(articleDoc.querySelectorAll('img'))
+      const nonMathImages = imgElements.filter((img) => {
+        const className = img.getAttribute('class') || ''
+        return !className.includes('mwe-math-fallback-image-inline') && img.getAttribute('typeof') !== 'mw:Extension/math'
+      })
 
-      expect(imgElements).toHaveLength(0)
+      expect(imgElements.length).toBeGreaterThan(0)
+      expect(nonMathImages.length).toBeGreaterThan(0)
+      expect(nonMathImages.every((img) => (img.getAttribute('src') || '').startsWith('data:image/svg+xml'))).toBe(true)
+      expect(nonMathImages.every((img) => !(img.getAttribute('src') || '').includes('_assets_/'))).toBe(true)
       if (!process.env.KEEP_ZIMS) {
         rimraf.sync(`./${outFiles[0].testId}`)
       }

--- a/test/unit/treatments/media.treatment.test.ts
+++ b/test/unit/treatments/media.treatment.test.ts
@@ -181,8 +181,10 @@ describe('MediaTreatment', () => {
 
       // Video element removed in nopic
       expect(videoEl).toBeUndefined()
-      // Img element removed in nopic
-      expect(imgEl).toBeUndefined()
+      // Img element replaced by placeholder in nopic
+      expect(imgEl).toBeDefined()
+      expect(imgEl.getAttribute('src')).toMatch(/^data:image\/svg\+xml/)
+      expect(ret.imageDependencies).toHaveLength(0)
     })
 
     test('treatMedias format="novid"', async () => {
@@ -199,6 +201,93 @@ describe('MediaTreatment', () => {
       expect(videoEl).toBeUndefined()
       // Img element not removed in novid
       expect(imgEl).toBeDefined()
+    })
+
+    test('treatMedias format="nopic" preserves filename-like alt text as-is in placeholder title', async () => {
+      const { dump } = await setupScrapeClasses({ format: 'nopic' }) // en wikipedia
+      const doc = domino.createDocument('<img src="//upload.wikimedia.org/fake.png" width="250" height="25" alt="Heavyrespawns.png">')
+
+      const ret = await testableRenderer.testTreatMedias(doc, dump, 'Mechanical_energy')
+      const imgEl = ret.doc.querySelector('img')
+      const imgSrc = imgEl.getAttribute('src')
+      const encodedSvg = imgSrc.split(',')[1]
+      const svg = decodeURIComponent(encodedSvg)
+
+      expect(imgSrc).toMatch(/^data:image\/svg\+xml/)
+      expect(svg).toContain('<title>Heavyrespawns.png</title>')
+      expect(svg).toContain('>Heavyrespawns.png</text>')
+      expect(ret.imageDependencies).toHaveLength(0)
+    })
+
+    test('treatMedias format="nopic" uses style-only image dimensions in placeholder', async () => {
+      const { dump } = await setupScrapeClasses({ format: 'nopic' }) // en wikipedia
+      const doc = domino.createDocument('<img src="//upload.wikimedia.org/fake.png" style="width:100px;height:80px">')
+
+      const ret = await testableRenderer.testTreatMedias(doc, dump, 'style_dimensions')
+      const imgEl = ret.doc.querySelector('img')
+      const imgSrc = imgEl.getAttribute('src')
+      const encodedSvg = imgSrc.split(',')[1]
+      const svg = decodeURIComponent(encodedSvg)
+
+      expect(imgEl.getAttribute('width')).toEqual('100')
+      expect(imgEl.getAttribute('height')).toEqual('80')
+      expect(svg).toContain('width="100"')
+      expect(svg).toContain('height="80"')
+      expect(svg).toContain('viewBox="0 0 100 80"')
+      expect(ret.imageDependencies).toHaveLength(0)
+    })
+
+    test('treatMedias format="nopic" hides visible text for small placeholders but keeps title metadata', async () => {
+      const { dump } = await setupScrapeClasses({ format: 'nopic' }) // en wikipedia
+      const doc = domino.createDocument('<img src="//upload.wikimedia.org/fake.png" width="16" height="16" alt="Heavyrespawns.png">')
+
+      const ret = await testableRenderer.testTreatMedias(doc, dump, 'small_placeholder')
+      const imgEl = ret.doc.querySelector('img')
+      const imgSrc = imgEl.getAttribute('src')
+      const encodedSvg = imgSrc.split(',')[1]
+      const svg = decodeURIComponent(encodedSvg)
+
+      expect(svg).toContain('<title>Heavyrespawns.png</title>')
+      expect(svg).not.toContain('<text ')
+      expect(svg).not.toContain('<clipPath')
+      expect(ret.imageDependencies).toHaveLength(0)
+    })
+
+    test('treatMedias format="nopic" clips long visible alt text inside the placeholder box', async () => {
+      const { dump } = await setupScrapeClasses({ format: 'nopic' }) // en wikipedia
+      const doc = domino.createDocument('<img src="//upload.wikimedia.org/fake.png" width="250" height="25" alt="Lecture demonstrating conservation of mechanical energy">')
+
+      const ret = await testableRenderer.testTreatMedias(doc, dump, 'long_alt')
+      const imgEl = ret.doc.querySelector('img')
+      const imgSrc = imgEl.getAttribute('src')
+      const encodedSvg = imgSrc.split(',')[1]
+      const svg = decodeURIComponent(encodedSvg)
+
+      expect(svg).toContain('<title>Lecture demonstrating conservation of mechanical energy</title>')
+      expect(svg).toContain('<clipPath id="alt-text-clip">')
+      expect(svg).toContain('<g clip-path="url(#alt-text-clip)">')
+      expect(svg).toContain('>Lecture demonstrating conservation of mechanical energy</text>')
+      expect(ret.imageDependencies).toHaveLength(0)
+    })
+
+    test('treatMedias format="nopic" uses 1x1 fallback when dimensions are missing', async () => {
+      const { dump } = await setupScrapeClasses({ format: 'nopic' }) // en wikipedia
+      const doc = domino.createDocument('<img src="//upload.wikimedia.org/fake.png" alt="No dimensions">')
+
+      const ret = await testableRenderer.testTreatMedias(doc, dump, 'missing_dimensions')
+      const imgEl = ret.doc.querySelector('img')
+      const imgSrc = imgEl.getAttribute('src')
+      const encodedSvg = imgSrc.split(',')[1]
+      const svg = decodeURIComponent(encodedSvg)
+
+      expect(imgEl.getAttribute('width')).toBeNull()
+      expect(imgEl.getAttribute('height')).toBeNull()
+      expect(svg).toContain('width="1"')
+      expect(svg).toContain('height="1"')
+      expect(svg).toContain('viewBox="0 0 1 1"')
+      expect(svg).toContain('<title>No dimensions</title>')
+      expect(svg).not.toContain('<text ')
+      expect(ret.imageDependencies).toHaveLength(0)
     })
   })
 })


### PR DESCRIPTION
Fix #1004 by preserving image layout in nopic mode using SVG placeholders

- Update treatImage() to replace img src with inline SVG placeholders instead of removing images
- Preserve img elements and dimensions in nopic
- Prevent image wrappers (figure/span) from being removed when dump.nopic is true
- Render meaningful alt text inside placeholder SVG, otherwise use transparent placeholder
- Do not add placeholder images to imageDependencies
- Keep existing math fallback and novid/nodet behavior unchanged
- Parsing of dimensions from inline style
- Reducing the fallback svg to 1*1 to handle images with no size metadata

Tests:
- Update media.treatment tests to expect img with data:image/svg+xml src and empty imageDependencies
- Update e2e nopic assertion to expect images without downloaded assets

Validation:

Made a zim file of https://it.wikiversity.org/wiki/Pagina_principale#/