### PR TITLE
Remove deprecated CLI parameters

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -4,6 +4,7 @@ Unreleased:
 * CHANGED: Keep inline scripts if all JS is allowed (@Markus-Rost #2555)
 * FIX: retry malformed JSON API responses (@kunalsiyag #2609)
 * FIX: Make processStylesheetContent use getMediaBase (@Markus-Rost #2647)
+* DEL: Remove deprecated CLI parameters `mwWikiPath`, `mwIndexPhpPath`, `keepEmptyParagraphs` (@Markus-Rost #2489)
 
 1.17.5:
 * FIX: Ignore articles returning permissiondenied error code (@kunalsiyag #2604)

--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -140,23 +140,17 @@
       "title": "Add categories",
       "description": "[WIP] Download category pages"
     },
-    "keepEmptyParagraphs": {
+    "keepEmptySections": {
       "type": "boolean",
       "required": false,
-      "title": "Keep empty paragraphs",
-      "description": "Keep all paragraphs, even empty ones."
+      "title": "Keep empty sections",
+      "description": "Keep all sections, even empty ones."
     },
     "minifyHtml": {
       "type": "boolean",
       "required": false,
       "title": "Minify HTML",
       "description": "Try to reduce the size of the HTML"
-    },
-    "mwWikiPath": {
-      "type": "string",
-      "required": false,
-      "title": "Wiki Path",
-      "description": "Mediawiki wiki base path. Otherwise `/wiki/`."
     },
     "mwActionApiPath": {
       "type": "string",
@@ -169,12 +163,6 @@
       "required": false,
       "title": "Module Path",
       "description": "Mediawiki module load path. Otherwise `/w/load.php`."
-    },
-    "mwIndexPhpPath": {
-      "type": "string",
-      "required": false,
-      "title": "index.php Path",
-      "description": "Path to Mediawiki index.php. Otherwise `/w/index.php`."
     },
     "mwDomain": {
       "type": "string",

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -419,7 +419,7 @@ class MediaWiki {
     return defaultSkins[0]
   }
 
-  public async getSiteInfo({ mwWikiPath, mwIndexPhpPath, addNamespaces, mwModulePath, forceSkin, langVariant }: SiteInfoArgv = {}) {
+  public async getSiteInfo({ addNamespaces, mwModulePath, forceSkin, langVariant }: SiteInfoArgv = {}) {
     logger.log('Getting site info...')
     const body = await Downloader.querySiteInfo()
 
@@ -470,21 +470,12 @@ class MediaWiki {
     })
 
     // Use CLI parameter and set MediaWiki config
-    if (mwWikiPath) {
-      mwWikiPath = mwWikiPath + '$1'
-      if (mwWikiPath !== generalEntries.articlepath) {
-        logger.warn(`mwWikiPath [${mwWikiPath}] does not match the path [${generalEntries.articlepath}] returned by the wiki.`)
-      }
-    }
-    const articlepath = mwWikiPath || generalEntries.articlepath
+    const articlepath = generalEntries.articlepath
     if (articlepath.includes('?') || !articlepath.endsWith('$1')) {
       throw new Error(`Article path [${articlepath}] is not supported`)
     }
     this.wikiPath = articlepath.replace('$1', '')
-    if (mwIndexPhpPath && mwIndexPhpPath !== generalEntries.script) {
-      logger.warn(`mwIndexPhpPath [${mwIndexPhpPath}] does not match the path [${generalEntries.script}] returned by the wiki.`)
-    }
-    this.indexPhpPath = mwIndexPhpPath || generalEntries.script
+    this.indexPhpPath = generalEntries.script
     this.modulePathOpt = mwModulePath || generalEntries.scriptpath + '/load.php'
 
     const skins: SiteInfoSkin[] = body.query.skins.filter((skin) => !skin.unusable)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,9 +23,6 @@ Usage: npm run mwoffliner -- --help`,
   )
   .describe(parameterDescriptions)
   .demandOption(requiredParams)
-  .deprecateOption('mwWikiPath')
-  .deprecateOption('mwIndexPhpPath')
-  .deprecateOption('keepEmptyParagraphs', 'use --keepEmptySections instead')
   .strict().argv
 
 /* ***********************************/

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -74,8 +74,6 @@ async function execute(argv: any) {
     minifyHtml,
     keepEmptySections,
     mwUrl,
-    mwWikiPath,
-    mwIndexPhpPath,
     mwActionApiPath,
     mwModulePath,
     mwDomain,
@@ -201,7 +199,7 @@ async function execute(argv: any) {
   /* Get MediaWiki Info */
   let mwMetaData
   try {
-    mwMetaData = await MediaWiki.getMwMetaData({ mwWikiPath, mwIndexPhpPath, addNamespaces, mwModulePath, forceSkin, langVariant })
+    mwMetaData = await MediaWiki.getMwMetaData({ addNamespaces, mwModulePath, forceSkin, langVariant })
   } catch (err) {
     logger.error('FATAL - Failed to get MediaWiki Metadata')
     throw err
@@ -345,7 +343,7 @@ async function execute(argv: any) {
         withoutZimFullTextIndex,
         resume,
         minifyHtml,
-        keepEmptySections: keepEmptySections ?? argv.keepEmptyParagraphs,
+        keepEmptySections,
         tags: customZimTags,
         filenameDate,
       },

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -15,10 +15,7 @@ export const parameterDescriptions = {
   filenamePrefix: 'Part of the ZIM filename which is before the format & date parts.',
   format:
     'Flavour for the scraping. If missing, scrape all article contents. Each --format argument will cause a new local file to be created but options can be combined. Supported options are:\n * novid: no video & audio content\n * nopic: no pictures (implies "novid")\n * nopdf: no PDF files\n * nodet: only the first/head paragraph (implies "novid")\nFlavour can be named (and corresponding ZIM metadata will be created) using a ":":\nExample: "--format=nopic,nodet:mini"',
-  keepEmptyParagraphs: 'Keep all sections, even empty ones typically used as placeholders in wikis to outline expected article structure.',
   keepEmptySections: 'Keep all sections, even empty ones typically used as placeholders in wikis to outline expected article structure.',
-  mwWikiPath: 'MediaWiki article path (by default fetched from the wiki)',
-  mwIndexPhpPath: 'MediaWiki index.php path (by default fetched from the wiki)',
   mwActionApiPath: 'MediaWiki API path (by default "/w/api.php")',
   mwModulePath: 'MediaWiki module load path ($wgLoadScript), automatically chosen based on script path otherwise.',
   mwDomain: 'MediaWiki user domain (thought for private wikis)',

--- a/src/sanitize-argument.ts
+++ b/src/sanitize-argument.ts
@@ -31,8 +31,6 @@ export async function sanitize_all(argv: any) {
     forceRender,
     javaScript,
     addModules,
-    mwWikiPath,
-    mwIndexPhpPath,
     mwActionApiPath,
     mwModulePath,
   } = argv
@@ -63,16 +61,6 @@ export async function sanitize_all(argv: any) {
 
   // sanitizing javaScript
   sanitize_javaScript_addModules(javaScript, addModules)
-
-  // sanitizing mwWikiPath
-  if (mwWikiPath) {
-    argv.mwWikiPath = sanitizeWikiPath(mwWikiPath)
-  }
-
-  // sanitizing mwIndexPhpPath
-  if (mwIndexPhpPath) {
-    argv.mwIndexPhpPath = sanitizeApiPathParam(mwIndexPhpPath)
-  }
 
   // sanitizing mwActionApiPath
   if (mwActionApiPath) {
@@ -117,22 +105,6 @@ export async function check_all(argv: any) {
   if (customZimFavicon) {
     await check_customZimFavicon(customZimFavicon)
   }
-}
-
-export function sanitizeWikiPath(mwWikiPath = '') {
-  mwWikiPath = sanitizeApiPathParam(mwWikiPath)
-
-  // Remove trailing $1 since we don't need it
-  if (mwWikiPath?.endsWith('$1')) {
-    mwWikiPath = mwWikiPath.substring(0, mwWikiPath.length - 3)
-  }
-
-  // Make sure wikiPath always has forward slash at the end for the correct URL building
-  if (!mwWikiPath?.endsWith('/')) {
-    mwWikiPath += '/'
-  }
-
-  return mwWikiPath
 }
 
 export function sanitizeApiPathParam(apiPathParam: string) {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -256,8 +256,6 @@ interface RenderedArticle {
 }
 
 interface SiteInfoArgv {
-  mwWikiPath?: string
-  mwIndexPhpPath?: string
   addNamespaces?: number[]
   mwModulePath?: string
   forceSkin?: string

--- a/test/e2e/mainPageIsDomainRoot.e2e.test.ts
+++ b/test/e2e/mainPageIsDomainRoot.e2e.test.ts
@@ -15,7 +15,6 @@ await testRenders(
     adminEmail: 'test@kiwix.org',
     mwActionApiPath: '/api.php',
     mwModulePath: '/load.php',
-    mwWikiPath: '/w/',
   },
   async (outFiles) => {
     const mainPageFromDump = await zimdump(`show --url "Minecraft_Wiki" ${outFiles[0].outFile}`)


### PR DESCRIPTION
Remove deprecated CLI parameters `mwWikiPath`, `mwIndexPhpPath`, `keepEmptyParagraphs`

Fix #2489