### PR TITLE
Recursively resolve CSS @import statements

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -9,6 +9,7 @@ Unreleased:
 * FIX: Make processStylesheetContent use getMediaBase (@Markus-Rost #2647)
 * FIX: Handle categorylockdown error with placeholder instead of crashing (@triemerge #2150)
 * FIX: Improve mwUrl and adminEmail input validation and expanding test coverage for input sanitation (@RishabhThakur-19 #2657)
+* FIX: Recursively resolve CSS @import statements (@triemerge #2649)
 * DEL: Remove deprecated CLI parameters `mwWikiPath`, `mwIndexPhpPath`, `keepEmptyParagraphs` (@Markus-Rost #2489)
 * NEW: Add `--customCss` CLI option to inject custom stylesheets
 

--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -611,7 +611,7 @@ export abstract class Renderer {
     // applyOtherTreatments must run before treatMedias so that iframe
     // placeholders (e.g. YouTube thumbnails) are already in the DOM
     // when treatMedias processes <img> tags for download into the ZIM.
-    doc = this.applyOtherTreatments(doc, dump, articleId)
+    doc = await this.applyOtherTreatments(doc, dump, articleId)
 
     const tmRet = await this.treatMedias(doc, dump, articleId)
 
@@ -996,7 +996,7 @@ export abstract class Renderer {
     }
   }
 
-  private applyOtherTreatments(parsoidDoc: DominoElement, dump: Dump, articleId: string) {
+  private async applyOtherTreatments(parsoidDoc: DominoElement, dump: Dump, articleId: string) {
     this.processIframeTags(parsoidDoc)
 
     if (dump.nodet) {
@@ -1031,7 +1031,7 @@ export abstract class Renderer {
       // We use MediaWiki.baseUrl which is an approximation but it is deemed sufficient because
       // all non-absolute URL found in inline CSS are expected to be relative to the root, not to
       // current web URL which is "moving" (could use something like /w/index.php?title=... or /wiki/...)
-      style.textContent = processStylesheetContent(MediaWiki.baseUrl.toString(), '', style.textContent, articleId)
+      style.textContent = await processStylesheetContent(MediaWiki.baseUrl.toString(), '', style.textContent, articleId)
     }
 
     /* Remove element with id in the blacklist */

--- a/src/util/dump.ts
+++ b/src/util/dump.ts
@@ -15,44 +15,147 @@ import { zimCreatorMutex } from '../mutex.js'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
-export function processStylesheetContent(cssUrl: string, linkMedia: string, body: string, articleId?: string, isJs?: boolean) {
+export async function processStylesheetContent(cssUrl: string, linkMedia: string, body: string, articleId?: string, isJs?: boolean) {
   // articleId is supposed to be passed only when we rewrite inline CSS for a given article and we hence have
   // to compute relative path to assets
 
   const { filesToDownloadXPath } = RedisStore
+  const importRegexp = /@import\s+(?:url\(\s*(['"]?)(.*?)\1\s*\)|(['"])(.*?)\3)\s*([^;]*);/gi
   const cssUrlRegexp = new RegExp('url\\([\'"]{0,1}(.*?)[\'"]{0,1}\\)', 'gi')
 
-  let rewrittenCss = `\n/* start ${cssUrl} */\n\n`
-  rewrittenCss += linkMedia ? `@media ${linkMedia}  {\n` : '\n'
-  rewrittenCss += `${body}\n`
-  rewrittenCss += linkMedia ? `} /* @media ${linkMedia} */\n` : '\n'
-  rewrittenCss += `\n/* end   ${cssUrl} */\n`
+  type CssPart = { type: 'css'; text: string }
+  type ImportPart = { type: 'import'; url: string; conditions: string }
+  type StylesheetParts = Array<CssPart | ImportPart>
 
-  /* Downloading CSS dependencies */
-  let match: any
-  // tslint:disable-next-line:no-conditional-assignment
-  while ((match = cssUrlRegexp.exec(body))) {
-    const url = match[1]
+  const wrapStylesheetContent = (css: string, url: string, conditions: string) => {
+    let wrappedCss = css
+    const rawConditions = conditions.trim()
 
-    /* Avoid 'data', so no URL dependency */
-    if (url && !url.match('^data')) {
-      const fullurl = getFullUrl(url, cssUrl)
-      const filepath = getMediaBase(fullurl, true)
+    if (rawConditions) {
+      const supportsMatch = rawConditions.match(/supports\s*\((.*?)\)/i)
+      const supportsCondition = supportsMatch?.[1]?.trim()
+      const mediaCondition = rawConditions.replace(/supports\s*\((.*?)\)/i, '').trim()
 
-      /* Rewrite the CSS */
-      const relativePath = articleId ? getRelativeFilePath(articleId, filepath) : isJs ? `__RELATIVE_FILE_PATH__${filepath}` : `../${filepath}`
-      rewrittenCss = rewrittenCss.replace(url, relativePath.replace(/'/g, '%27').replace(/\(/g, '%28').replace(/\)/g, '%29'))
-
-      /* Download CSS dependency, but avoid duplicate calls */
-      // eslint-disable-next-line no-prototype-builtins
-      if (!Downloader.cssDependenceUrls.hasOwnProperty(fullurl) && filepath) {
-        Downloader.cssDependenceUrls[fullurl] = true
-        filesToDownloadXPath.set(filepath, { url: urlHelper.serializeUrl(fullurl), kind: 'media' })
+      if (supportsCondition) {
+        wrappedCss = `@supports (${supportsCondition}) {\n${wrappedCss}\n}\n`
+      }
+      if (mediaCondition) {
+        wrappedCss = `@media ${mediaCondition} {\n${wrappedCss}\n}\n`
       }
     }
+
+    return `\n/* start ${url} */\n\n${wrappedCss}\n/* end   ${url} */\n`
   }
 
-  return rewrittenCss
+  const rewriteCssDependencies = (sourceCss: string, sourceUrl: string) => {
+    let rewrittenCss = sourceCss
+    let match: any
+
+    while ((match = cssUrlRegexp.exec(sourceCss))) {
+      const url = match[1]
+
+      /* Avoid 'data', so no URL dependency */
+      if (url && !url.match('^data')) {
+        const fullurl = getFullUrl(url, sourceUrl)
+        const filepath = getMediaBase(fullurl, true)
+
+        /* Rewrite the CSS */
+        const relativePath = articleId ? getRelativeFilePath(articleId, filepath) : isJs ? `__RELATIVE_FILE_PATH__${filepath}` : `../${filepath}`
+        rewrittenCss = rewrittenCss.replace(url, relativePath.replace(/'/g, '%27').replace(/\(/g, '%28').replace(/\)/g, '%29'))
+
+        /* Download CSS dependency, but avoid duplicate calls */
+        if (!Object.prototype.hasOwnProperty.call(Downloader.cssDependenceUrls, fullurl) && filepath) {
+          Downloader.cssDependenceUrls[fullurl] = true
+          filesToDownloadXPath.set(filepath, { url: urlHelper.serializeUrl(fullurl), kind: 'media' })
+        }
+      }
+    }
+
+    cssUrlRegexp.lastIndex = 0
+    return rewrittenCss
+  }
+
+  // Iterative worklist to resolve @import statements (no depth limit).
+  // Each entry carries its own URL so that url() references are resolved relative to each stylesheet.
+  const processedImportUrls = new Set<string>()
+  const worklist: Array<{ url: string; body: string }> = [{ url: cssUrl, body }]
+  const stylesheetParts = new Map<string, StylesheetParts>()
+
+  while (worklist.length > 0) {
+    const current = worklist.shift()!
+    const currentBody = current.body
+
+    const parts: StylesheetParts = []
+    let startIdx = 0
+
+    /* Find and queue @import URLs */
+    let importMatch: RegExpExecArray | null
+    const importRe = new RegExp(importRegexp.source, importRegexp.flags)
+    while ((importMatch = importRe.exec(currentBody)) !== null) {
+      if (importMatch.index > startIdx) {
+        parts.push({ type: 'css', text: currentBody.substring(startIdx, importMatch.index) })
+      }
+
+      const importUrl = importMatch[2] || importMatch[4]
+      const importConditions = (importMatch[5] || '').trim()
+
+      if (importUrl) {
+        const fullUrl = getFullUrl(importUrl, current.url)
+        parts.push({ type: 'import', url: fullUrl, conditions: importConditions })
+
+        if (!processedImportUrls.has(fullUrl)) {
+          processedImportUrls.add(fullUrl)
+          try {
+            const { content } = await Downloader.downloadContent(fullUrl, 'css')
+            worklist.push({ url: fullUrl, body: content.toString() })
+          } catch {
+            logger.warn(`Failed to download imported CSS: ${fullUrl}`)
+          }
+        }
+      }
+
+      startIdx = importRe.lastIndex
+    }
+
+    if (startIdx < currentBody.length) {
+      parts.push({ type: 'css', text: currentBody.substring(startIdx) })
+    }
+
+    stylesheetParts.set(current.url, parts)
+  }
+
+  const renderedImportedUrls = new Set<string>()
+  const renderStack = new Set<string>()
+
+  const renderStylesheet = (url: string, conditions = ''): string => {
+    if (renderedImportedUrls.has(url)) {
+      return ''
+    }
+    if (renderStack.has(url)) {
+      return ''
+    }
+
+    const parts = stylesheetParts.get(url)
+    if (!parts) {
+      return ''
+    }
+
+    renderedImportedUrls.add(url)
+    renderStack.add(url)
+    let currentBody = ''
+    for (const part of parts) {
+      if (part.type === 'css') {
+        currentBody += rewriteCssDependencies(part.text, url)
+      } else {
+        currentBody += renderStylesheet(part.url, part.conditions)
+      }
+    }
+    renderStack.delete(url)
+
+    return wrapStylesheetContent(currentBody, url, conditions)
+  }
+
+  return renderStylesheet(cssUrl, linkMedia)
 }
 
 export async function downloadModule(module: string, type: 'js' | 'css') {
@@ -141,9 +244,11 @@ export async function downloadModule(module: string, type: 'js' | 'css') {
       try {
         const cssParts: string[] = JSON.parse(embeddedCss[1])
         const processedCss = JSON.stringify(
-          cssParts.map((cssPart) => {
-            return processStylesheetContent(moduleApiUrl, '', cssPart, '', true)
-          }),
+          await Promise.all(
+            cssParts.map((cssPart) => {
+              return processStylesheetContent(moduleApiUrl, '', cssPart, '', true)
+            }),
+          ),
         ).replace(/__RELATIVE_FILE_PATH__/g, '"+RLCONF.zimRelativeFilePath+"')
         text = text.replace(embeddedCss[0], `,{"css":${processedCss}}`)
       } catch (e) {
@@ -153,7 +258,7 @@ export async function downloadModule(module: string, type: 'js' | 'css') {
   }
 
   if (type === 'css') {
-    text = processStylesheetContent(moduleApiUrl, '', text, '')
+    text = await processStylesheetContent(moduleApiUrl, '', text, '')
   }
 
   // Zimcheck complains about empty files, and it is too late to decide to not create this file
@@ -212,7 +317,7 @@ export function getModuleDependencies(oneModule: ResourceLoaderModule, allModule
 export async function downloadAndSaveCustomCss(zimCreator: Creator, cssUrl: string, filename: string): Promise<void> {
   logger.log(`Downloading custom CSS [${cssUrl}]`)
   const { content: cssBody } = await Downloader.downloadContent(cssUrl, 'css')
-  const processedCss = processStylesheetContent(cssUrl, '', cssBody.toString())
+  const processedCss = await processStylesheetContent(cssUrl, '', cssBody.toString())
   const zimPath = cssPath(filename, config.output.dirs.res)
   await zimCreatorMutex.runExclusive(() => zimCreator.addItem(new StringItem(zimPath, 'text/css', null, { FRONT_ARTICLE: 0 }, processedCss)))
   logger.log(`Saved custom CSS [${cssUrl}] at ${zimPath}`)

--- a/test/unit/bootstrap.ts
+++ b/test/unit/bootstrap.ts
@@ -10,7 +10,7 @@ RedisStore.setOptions(process.env.REDIS || config.defaults.redisPath, { quitOnEr
 export const startRedis = async () => {
   await RedisStore.connect()
   const { articleDetailXId, redirectsXId, filesToDownloadXPath, filesQueues } = RedisStore
-  await Promise.all([articleDetailXId.flush(), redirectsXId.flush(), filesToDownloadXPath.flush(), ...filesQueues.map((queue) => queue.flush)])
+  await Promise.all([articleDetailXId.flush(), redirectsXId.flush(), filesToDownloadXPath.flush(), ...filesQueues.map((queue) => queue.flush())])
 }
 
 export const stopRedis = async () => {

--- a/test/unit/util/dump.test.ts
+++ b/test/unit/util/dump.test.ts
@@ -5,6 +5,7 @@ import { config } from '../../../src/config.js'
 import { downloadModule, processStylesheetContent } from '../../../src/util/dump.js'
 import RedisStore from '../../../src/RedisStore.js'
 import urlHelper from '../../../src/util/url.helper.js'
+import { jest } from '@jest/globals'
 
 describe('Download CSS or JS Module', () => {
   beforeAll(startRedis)
@@ -33,7 +34,7 @@ describe('Download CSS or JS Module', () => {
   })
 
   test('rewrite standalone CSS', async () => {
-    const rewrittenCSS = processStylesheetContent(
+    const rewrittenCSS = await processStylesheetContent(
       'https://en.wikipedia.org/w/load.php?lang=en&modules=skins.vector.styles&only=styles&skin=vector',
       '',
       'a.external { background-image: url(/w/skins/Vector/resources/skins.vector.styles/images/link-external-small-ltr-progressive.svg?fb64d); }',
@@ -48,7 +49,7 @@ describe('Download CSS or JS Module', () => {
   })
 
   test('rewrite inline CSS with relative path', async () => {
-    const rewrittenCSS = processStylesheetContent(
+    const rewrittenCSS = await processStylesheetContent(
       'https://en.wikipedia.org/w/load.php?lang=en&modules=skins.vector.styles&only=styles&skin=vector',
       '',
       'a.external { background-image: url(/w/skins/Vector/resources/skins.vector.styles/images/link-external-small-ltr-progressive.svg?fb64d); }',
@@ -63,7 +64,7 @@ describe('Download CSS or JS Module', () => {
   })
 
   test('rewrite inline CSS with absolute path', async () => {
-    const rewrittenCSS = processStylesheetContent(
+    const rewrittenCSS = await processStylesheetContent(
       'https://en.wikipedia.org/w/load.php?lang=en&modules=skins.vector.styles&only=styles&skin=vector',
       '',
       'a.external { background-image: url(//upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Commons-logo.svg/64px-Commons-logo.svg.png); }',
@@ -76,7 +77,7 @@ describe('Download CSS or JS Module', () => {
   })
 
   test('rewrite CSS with encoded image', async () => {
-    const rewrittenCSS = processStylesheetContent(
+    const rewrittenCSS = await processStylesheetContent(
       'https://minecraft.wiki/load.php?lang=en&modules=ext.gadget.site-styles&only=styles&skin=vector',
       '',
       '.mcui-arrow { background: url(/images/Grid_layout_Arrow_%28small%29.png?a4894) no-repeat; }',
@@ -86,5 +87,130 @@ describe('Download CSS or JS Module', () => {
     expect(await RedisStore.filesToDownloadXPath.keys()).toStrictEqual(['_assets_/5af80496508534f4cdd561aac15bbc50/Grid_layout_Arrow_(small).png'])
     const redisValue = await RedisStore.filesToDownloadXPath.get('_assets_/5af80496508534f4cdd561aac15bbc50/Grid_layout_Arrow_(small).png')
     expect(urlHelper.deserializeUrl(redisValue.url)).toBe('https://minecraft.wiki/images/Grid_layout_Arrow_%28small%29.png?a4894')
+  })
+
+  test('resolve single @import statement', async () => {
+    const downloadSpy = jest.spyOn(Downloader, 'downloadContent').mockImplementation(async (url: string) => {
+      if (url === 'https://example.wiki/customizations/custom.css') {
+        return { content: Buffer.from('.imported { color: red; }'), contentType: 'text/css', setCookie: null }
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const rewrittenCSS = await processStylesheetContent(
+      'https://example.wiki/load.php?modules=site.styles',
+      '',
+      '@import url("/customizations/custom.css");\n.main { color: blue; }',
+      '',
+    )
+
+    expect(rewrittenCSS).toContain('.main { color: blue; }')
+    expect(rewrittenCSS).toContain('.imported { color: red; }')
+    expect(rewrittenCSS).not.toContain('@import')
+    expect(downloadSpy).toHaveBeenCalledWith('https://example.wiki/customizations/custom.css', 'css')
+
+    downloadSpy.mockRestore()
+  })
+
+  test('resolve nested @import statements', async () => {
+    const downloadSpy = jest.spyOn(Downloader, 'downloadContent').mockImplementation(async (url: string) => {
+      if (url === 'https://example.wiki/css/a.css') {
+        return { content: Buffer.from('@import url("/css/b.css");\n.from-a { color: red; }'), contentType: 'text/css', setCookie: null }
+      }
+      if (url === 'https://example.wiki/css/b.css') {
+        return { content: Buffer.from('.from-b { color: green; }'), contentType: 'text/css', setCookie: null }
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const rewrittenCSS = await processStylesheetContent('https://example.wiki/load.php?modules=site.styles', '', '@import url("/css/a.css");\n.main { color: blue; }', '')
+
+    expect(rewrittenCSS).toContain('.main { color: blue; }')
+    expect(rewrittenCSS).toContain('.from-a { color: red; }')
+    expect(rewrittenCSS).toContain('.from-b { color: green; }')
+    expect(rewrittenCSS).not.toContain('@import')
+    expect(rewrittenCSS.indexOf('.from-b { color: green; }')).toBeLessThan(rewrittenCSS.indexOf('.from-a { color: red; }'))
+    expect(rewrittenCSS.indexOf('.from-a { color: red; }')).toBeLessThan(rewrittenCSS.indexOf('.main { color: blue; }'))
+
+    downloadSpy.mockRestore()
+  })
+
+  test('handle circular @import without infinite loop', async () => {
+    const downloadSpy = jest.spyOn(Downloader, 'downloadContent').mockImplementation(async (url: string) => {
+      if (url === 'https://example.wiki/css/a.css') {
+        return { content: Buffer.from('@import url("/css/b.css");\n.from-a { color: red; }'), contentType: 'text/css', setCookie: null }
+      }
+      if (url === 'https://example.wiki/css/b.css') {
+        return { content: Buffer.from('@import url("/css/a.css");\n.from-b { color: green; }'), contentType: 'text/css', setCookie: null }
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const rewrittenCSS = await processStylesheetContent('https://example.wiki/load.php?modules=site.styles', '', '@import url("/css/a.css");\n.main { color: blue; }', '')
+
+    expect(rewrittenCSS).toContain('.main { color: blue; }')
+    expect(rewrittenCSS).toContain('.from-a { color: red; }')
+    expect(rewrittenCSS).toContain('.from-b { color: green; }')
+    expect(rewrittenCSS).not.toContain('@import')
+
+    downloadSpy.mockRestore()
+  })
+
+  test('resolve @import with quoted string syntax', async () => {
+    const downloadSpy = jest.spyOn(Downloader, 'downloadContent').mockImplementation(async (url: string) => {
+      if (url === 'https://example.wiki/css/quoted.css') {
+        return { content: Buffer.from('.quoted { font-weight: bold; }'), contentType: 'text/css', setCookie: null }
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const rewrittenCSS = await processStylesheetContent('https://example.wiki/load.php?modules=site.styles', '', '@import "/css/quoted.css";\n.main { color: blue; }', '')
+
+    expect(rewrittenCSS).toContain('.quoted { font-weight: bold; }')
+    expect(rewrittenCSS).toContain('.main { color: blue; }')
+    expect(rewrittenCSS).not.toContain('@import')
+
+    downloadSpy.mockRestore()
+  })
+
+  test('convert @import supports and media queries to wrappers', async () => {
+    const downloadSpy = jest.spyOn(Downloader, 'downloadContent').mockImplementation(async (url: string) => {
+      if (url === 'https://example.wiki/css/feature.css') {
+        return { content: Buffer.from('.feature { color: red; }'), contentType: 'text/css', setCookie: null }
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const rewrittenCSS = await processStylesheetContent(
+      'https://example.wiki/load.php?modules=site.styles',
+      '',
+      '@import url("/css/feature.css") supports(display: grid) screen and (min-width: 800px);\n.main { color: blue; }',
+      '',
+    )
+
+    expect(rewrittenCSS).not.toContain('@import')
+    expect(rewrittenCSS).toContain('@supports (display: grid)')
+    expect(rewrittenCSS).toContain('@media screen and (min-width: 800px)')
+    expect(rewrittenCSS).toContain('.feature { color: red; }')
+
+    downloadSpy.mockRestore()
+  })
+
+  test('rewrite url() in imported CSS relative to import URL', async () => {
+    const downloadSpy = jest.spyOn(Downloader, 'downloadContent').mockImplementation(async (url: string) => {
+      if (url === 'https://example.wiki/css/imported.css') {
+        return { content: Buffer.from('.bg { background: url(images/icon.png); }'), contentType: 'text/css', setCookie: null }
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    const rewrittenCSS = await processStylesheetContent('https://example.wiki/load.php?modules=site.styles', '', '@import url("/css/imported.css");', '')
+
+    // The url(images/icon.png) in imported.css should be resolved relative to
+    // https://example.wiki/css/imported.css, giving https://example.wiki/css/images/icon.png
+    expect(rewrittenCSS).toContain('_assets_/')
+    expect(Object.keys(Downloader.cssDependenceUrls)).toContain('https://example.wiki/css/images/icon.png')
+
+    downloadSpy.mockRestore()
   })
 })


### PR DESCRIPTION
Fix #2649

`processStylesheetContent` now uses an iterative worklist to resolve `@import` statements: each CSS body is scanned for `@import` URLs, which are downloaded and added to the queue for further processing. This loops until no new imports remain.

- Handles both `@import url(...)` and `@import "..."` syntaxes
- `url()` references in imported stylesheets are resolved relative to each stylesheet's own URL
- Circular imports are handled via a `Set` (no depth limit needed)
- Function is now `async`; call sites in `downloadModule` and `applyOtherTreatments` updated accordingly
