### PR TITLE
Fix-2658: do not always retry malformed JSON

### DIFF
--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -71,6 +71,10 @@ interface CompressionData {
   data: any
 }
 
+function isJsonContentType(contentType: string | null): boolean {
+  return typeof contentType === 'string' && /\b(?:application\/json|[\w.-]+\+json)\b/i.test(contentType)
+}
+
 function isMalformedJsonResponseError(err: unknown): boolean {
   if (err instanceof SyntaxError) {
     return true
@@ -81,6 +85,22 @@ function isMalformedJsonResponseError(err: unknown): boolean {
   }
 
   return err.cause instanceof SyntaxError
+}
+
+function parseJsonResponse<T>(url: string, status: number, contentType: string | null, body: unknown): T {
+  if (body !== null && typeof body === 'object') {
+    return body as T
+  }
+
+  if (typeof body !== 'string') {
+    return body as T
+  }
+
+  if (!isJsonContentType(contentType)) {
+    throw new DownloadError('Unexpected non-JSON response while calling API', url, status, contentType, body)
+  }
+
+  return JSON.parse(body) as T
 }
 
 export class DownloadError extends Error {
@@ -263,12 +283,7 @@ class Downloader {
         accept: 'application/json',
         'accept-encoding': 'gzip, deflate',
       },
-      responseType: 'json',
-      transitional: {
-        // Parse failures must throw so backoff retries can be triggered.
-        silentJSONParsing: false,
-        forcedJSONParsing: true,
-      },
+      responseType: 'text',
       method: 'GET',
     }
 
@@ -675,10 +690,13 @@ class Downloader {
     logger.info(`Getting JSON from [${url}]`)
     this.request<T>({ url, method: 'GET', ...this.jsonRequestOptions })
       .then((val) => {
-        if ((val.data as any).error) {
-          handler(new DownloadError(`Error returned while calling API`, url, val.status, val.headers['content-type'].toString(), val.data))
+        const contentType = val.headers['content-type']?.toString() || null
+        const data = parseJsonResponse<T>(url, val.status, contentType, val.data)
+
+        if ((data as any).error) {
+          handler(new DownloadError(`Error returned while calling API`, url, val.status, contentType, data))
         } else {
-          handler(null, val.data)
+          handler(null, data)
         }
       })
       .catch((err) => {

--- a/test/unit/downloader.retry.test.ts
+++ b/test/unit/downloader.retry.test.ts
@@ -20,13 +20,29 @@ const createDownloader = () => {
   return downloader
 }
 
+const stubImmediateBackoff = (downloader: DownloaderClass) => {
+  ;(downloader as any).backoffCall = (handler: any, url: string, kind: any, cb: any) => {
+    const retryIf = (downloader as any).backoffOptions.retryIf as (error?: any) => boolean
+    let attempts = 0
+    const run = () => {
+      attempts += 1
+      handler(url, kind, (err: any, val: any) => {
+        if (err && attempts < 3 && retryIf(err)) {
+          run()
+          return
+        }
+        cb(err, val)
+      })
+    }
+    run()
+  }
+}
+
 describe('Downloader malformed JSON retry strategy', () => {
-  test('enables strict JSON parsing', () => {
+  test('requests raw text for JSON responses', () => {
     const downloader = createDownloader()
-    expect((downloader as any).jsonRequestOptions.transitional).toEqual({
-      silentJSONParsing: false,
-      forcedJSONParsing: true,
-    })
+    expect((downloader as any).jsonRequestOptions.responseType).toBe('text')
+    expect((downloader as any).jsonRequestOptions.transitional).toBeUndefined()
   })
 
   test('retries plain SyntaxError parse failures', () => {
@@ -63,35 +79,58 @@ describe('Downloader malformed JSON retry strategy', () => {
     expect(retryIf(err)).toBe(false)
   })
 
+  test('getJSON parses successful raw string JSON responses', async () => {
+    const downloader = createDownloader()
+    ;(downloader as any).request = jest.fn().mockResolvedValue({
+      data: '{"ok":true}',
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+    stubImmediateBackoff(downloader)
+
+    await expect(downloader.getJSON('https://example.org/api')).resolves.toEqual({ ok: true })
+  })
+
   test('getJSON retries once and succeeds after malformed JSON', async () => {
     const downloader = createDownloader()
-    const malformed = new AxiosError('Failed to parse API response', AxiosError.ERR_BAD_RESPONSE)
-    ;(malformed as any).cause = new SyntaxError('Unexpected end of JSON input')
     ;(downloader as any).request = jest
       .fn()
-      .mockRejectedValueOnce(malformed)
       .mockResolvedValueOnce({
-        data: { ok: true },
+        data: '{"ok":',
         status: 200,
         headers: { 'content-type': 'application/json' },
       })
-    ;(downloader as any).backoffCall = (handler: any, url: string, kind: any, cb: any) => {
-      const retryIf = (downloader as any).backoffOptions.retryIf as (error?: any) => boolean
-      let attempts = 0
-      const run = () => {
-        attempts += 1
-        handler(url, kind, (err: any, val: any) => {
-          if (err && attempts < 3 && retryIf(err)) {
-            run()
-            return
-          }
-          cb(err, val)
-        })
-      }
-      run()
-    }
+      .mockResolvedValueOnce({
+        data: '{"ok":true}',
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    stubImmediateBackoff(downloader)
 
     await expect(downloader.getJSON('https://example.org/api')).resolves.toEqual({ ok: true })
     expect((downloader as any).request).toHaveBeenCalledTimes(2)
+  })
+
+  test('getJSON preserves raw HTML body for HTTP errors', async () => {
+    const downloader = createDownloader()
+    const err = new AxiosError('Request failed with status code 404', AxiosError.ERR_BAD_REQUEST)
+    ;(err as any).response = {
+      status: 404,
+      data: '<html><body>Not found</body></html>',
+      headers: { 'content-type': 'text/html' },
+    }
+    ;(err as any).config = { url: 'https://example.org/api' }
+    ;(downloader as any).request = jest.fn().mockRejectedValue(err)
+    stubImmediateBackoff(downloader)
+
+    const retryIf = (downloader as any).backoffOptions.retryIf as (error?: any) => boolean
+    expect(retryIf(err)).toBe(false)
+    await expect(downloader.getJSON('https://example.org/api')).rejects.toMatchObject({
+      response: {
+        status: 404,
+        data: '<html><body>Not found</body></html>',
+        headers: { 'content-type': 'text/html' },
+      },
+    })
   })
 })


### PR DESCRIPTION
This fixes #2658 by restoring raw-response handling for `getJSON()` requests and only retrying actual malformed JSON parse failures.

`#2621` made Axios parse API responses eagerly with strict JSON parsing. That caused HTML error pages returned by MediaWiki (for example `404`, `429`, `503`) to be misclassified as malformed JSON retry candidates before `mwoffliner` could inspect the raw status/body/content type.

This change switches JSON requests back to raw text handling, parses successful API responses manually, and keeps malformed JSON retries limited to true parse failures.

## Changes

- change `Downloader` JSON requests to use `responseType: "text"`
- remove Axios transitional strict JSON parsing from the JSON request options
- manually parse successful API responses in `getJSONCb()`
- retry only real malformed JSON parse failures (`SyntaxError`, direct or wrapped with `cause`)
- preserve raw non-`2xx` HTML/text responses for existing error handling
- fallback to ActionParse `jsconfigvars` when `headhtml` config cannot be parsed as strict JSON
- add unit coverage for:
  - raw text JSON parsing
  - malformed JSON retry and success-after-retry
  - generic `ERR_BAD_RESPONSE` not being treated as malformed JSON
  - raw HTML `404` responses being preserved
  - `extractJsConfigVars()` fallback for non-JSON config blobs

