### PR TITLE
Bug : Remove unused Redis deps from test files

### DIFF
--- a/test/unit/dump.test.ts
+++ b/test/unit/dump.test.ts
@@ -1,10 +1,6 @@
-import { startRedis, stopRedis } from './bootstrap.js'
 import { Dump } from '../../src/Dump.js'
 
 describe('Dump filename radical', () => {
-  beforeAll(startRedis)
-  afterAll(stopRedis)
-
   describe('Based on format', () => {
     const formatTests = {
       '': '',

--- a/test/unit/saveStaticFiles.test.ts
+++ b/test/unit/saveStaticFiles.test.ts
@@ -1,4 +1,3 @@
-import { startRedis, stopRedis } from './bootstrap.js'
 import { jest } from '@jest/globals'
 import { ActionParseRenderer } from '../../src/renderers/action-parse.renderer.js'
 import MediaWiki from '../../src/MediaWiki.js'
@@ -6,9 +5,6 @@ import MediaWiki from '../../src/MediaWiki.js'
 jest.setTimeout(10000)
 
 describe('saveStaticFiles', () => {
-  beforeAll(startRedis)
-  afterAll(stopRedis)
-
   beforeEach(() => {
     MediaWiki.reset()
   })


### PR DESCRIPTION
There were 2 unused Redis imports and calls in the listed files below, these increased the tests times and now they are intended to reduce the timing of the tests as both currently failed without a running redis server even though they don't need one.

FIles :
- saveStaticFiles.test.ts
- dump.test.ts