### PR TITLE
bug : use logger.error instead of console.log 

### DIFF
--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -458,7 +458,7 @@ export async function saveArticles(zimCreator: Creator, dump: Dump) {
            */
           const err = await parsePromise
           if (err) {
-            console.log(err)
+            logger.error(err)
 
             logger.error(`Error parsing article ${articleId}`)
             timer.clear()

--- a/test/unit/misc.test.ts
+++ b/test/unit/misc.test.ts
@@ -147,7 +147,7 @@ describe('Misc utility', () => {
 
     test('falls back to specified fallback language', () => {
       const strings = getStringsForLang('XX', 'de')
-      console.log(JSON.stringify(strings))
+
       expect(strings).toMatchObject({
         DISCLAIMER:
           'Dieser Artikel wurde von ${creator} herausgegeben. Der Text ist unter ${license} verfügbar, sofern nicht anders angegeben. Für die Mediendateien können zusätzliche Bedingungen gelten.',


### PR DESCRIPTION
I changed the console.log to logger.error in the article parse error handler and removed the debug console.log left in the misc.test.ts file.

the raw error object bypasses the logger's level filtering and timestamp formatting. the human readable message already uses the logger.error correctly so the error object should go through the same path for better code quality.

Files changed :
- saveArticles.ts
- misc.test.ts