### PR TITLE
fix (issue#2663) : improve test coverage  

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -14,6 +14,7 @@ Unreleased:
 * FIX: Handle categorylockdown error with placeholder instead of crashing (@triemerge #2150)
 * FIX: Improve mwUrl and adminEmail input validation and expanding test coverage for input sanitation (@RishabhThakur-19 #2657)
 * FIX: Recursively resolve CSS @import statements (@triemerge #2649)
+* FIX: Improve test coverage for MediaWiki.extractPageTitleFromHref and Rediscompression, also add unit tests for RedisStore.articleDetailXId (@RishabhThakur-19 #2663)
 * DEL: Remove deprecated CLI parameters `mwWikiPath`, `mwIndexPhpPath`, `keepEmptyParagraphs` (@Markus-Rost #2489)
 * NEW: Add `--customCss` CLI option to inject custom stylesheets
 

--- a/test/unit/mwApi.test.ts
+++ b/test/unit/mwApi.test.ts
@@ -128,6 +128,18 @@ describe('mwApi', () => {
     const absoluteIndexPathNoTitle = MediaWiki.extractPageTitleFromHref('/w/index.php?action=edit&redlink=1')
     // An index.php link missing the article title
     expect(absoluteIndexPathNoTitle).toBeNull()
+
+    const fullUrl = MediaWiki.extractPageTitleFromHref('https://en.wikipedia.org/wiki/Blue_whale')
+    // test for a complete  URL
+    expect(fullUrl).toBe('Blue_whale')
+
+    const encodedUrl = MediaWiki.extractPageTitleFromHref('/wiki/Radio_Rom%C3%A2nia_Actualit%C4%83%C8%9Bi')
+    // URL with special encoded characters
+    expect(encodedUrl).toBe('Radio_România_Actualități')
+
+    const emptyInput = MediaWiki.extractPageTitleFromHref('')
+    // Empty input should return null
+    expect(emptyInput).toBeNull()
   })
 })
 

--- a/test/unit/redis.test.ts
+++ b/test/unit/redis.test.ts
@@ -61,3 +61,129 @@ describe('Redis', () => {
     expect(flushedLen).toEqual(0)
   })
 })
+
+describe('RedisStore: articleDetailXId', () => {
+  beforeAll(startRedis)
+  afterAll(stopRedis)
+
+  const mockArticles = {
+    London: {
+      title: 'London',
+      categories: [{ title: 'City' }],
+      revisionId: 123,
+      coordinates: '51.5074,0.1278',
+    },
+    UK: {
+      title: 'United_Kingdom',
+      categories: [{ title: 'Country' }],
+      revisionId: 456,
+      thumbnail: { source: 'uk.png', height: 200, width: 200 },
+    },
+    TestArticle: {
+      title: 'TestArticle',
+      categories: [],
+      revisionId: 789,
+    },
+  }
+
+  beforeEach(async () => {
+    await RedisStore.articleDetailXId.flush()
+  })
+  //
+  test('set and get single article', async () => {
+    // if it fails that means serialization/deserialization is broken
+    const kvs = RedisStore.articleDetailXId
+
+    await kvs.set('London', mockArticles.London)
+    const result = await kvs.get('London')
+
+    expect(result).toBeDefined()
+    expect(result?.title).toBe('London')
+    expect(result?.categories?.[0]?.title).toBe('City')
+    expect(result?.revisionId).toBe(123)
+    expect(result?.coordinates).toBe('51.5074,0.1278')
+  })
+
+  test('set and get multiple articles', async () => {
+    // if it fails that means bulk retrieval is broken
+    const kvs = RedisStore.articleDetailXId
+
+    await kvs.set('London', mockArticles.London)
+    await kvs.set('UK', mockArticles.UK)
+
+    const results = await kvs.getMany(['London', 'UK'])
+
+    expect(results.London).toBeDefined()
+    expect(results.UK).toBeDefined()
+    expect(results.UK?.thumbnail?.source).toBe('uk.png')
+  })
+
+  test('delete single and multiple articles', async () => {
+    // if it fails that means memory leaks in Redis
+    const kvs = RedisStore.articleDetailXId
+
+    await kvs.set('London', mockArticles.London)
+    await kvs.set('UK', mockArticles.UK)
+
+    await kvs.delete('London')
+    const deleted = await kvs.get('London')
+    expect(deleted).toBeNull()
+
+    await kvs.deleteMany(['UK'])
+    const results = await kvs.getMany(['UK'])
+    expect(results.UK).toBeNull()
+  })
+
+  test('keys, len and flush', async () => {
+    const kvs = RedisStore.articleDetailXId
+
+    await kvs.set('London', mockArticles.London)
+    await kvs.set('UK', mockArticles.UK)
+    await kvs.set('TestArticle', mockArticles.TestArticle)
+
+    const keys = await kvs.keys()
+    expect(keys.length).toBe(3)
+    expect(keys).toEqual(expect.arrayContaining(['London', 'UK', 'TestArticle']))
+
+    const len = await kvs.len()
+    expect(len).toBe(3)
+
+    await kvs.flush()
+    const newLen = await kvs.len()
+    expect(newLen).toBe(0)
+  })
+
+  test('edge cases: non-existent keys', async () => {
+    // if it fails that means error in fucntion's logic
+    const kvs = RedisStore.articleDetailXId
+
+    const result = await kvs.get('DoesNotExist')
+    expect(result).toBeNull()
+
+    const many = await kvs.getMany(['Nope1', 'Nope2'])
+    expect(many.Nope1).toBeNull()
+    expect(many.Nope2).toBeNull()
+
+    await kvs.delete('Nope1')
+    await kvs.deleteMany(['Nope2'])
+  })
+
+  test('overwrite existing article', async () => {
+    // if this fails this means that updates dont propogate
+    const kvs = RedisStore.articleDetailXId
+
+    await kvs.set('London', mockArticles.London)
+
+    await kvs.set('London', {
+      title: 'London Updated',
+      categories: [{ title: 'Capital' }],
+      revisionId: 999,
+    })
+
+    const updated = await kvs.get('London')
+
+    expect(updated?.title).toBe('London Updated')
+    expect(updated?.categories?.[0]?.title).toBe('Capital')
+    expect(updated?.revisionId).toBe(999)
+  })
+})

--- a/test/unit/redisCompression.test.ts
+++ b/test/unit/redisCompression.test.ts
@@ -1,0 +1,91 @@
+import RedisKvs from '../../src/util/RedisKvs.js'
+import RedisStore from '../../src/RedisStore.js'
+import { startRedis, stopRedis } from './bootstrap.js'
+
+describe('RedisKvs Compression Mapping (ArticleDetail)', () => {
+  beforeAll(startRedis)
+  afterAll(stopRedis)
+
+  const mapping = {
+    s: 'subCategories',
+    c: 'categories',
+    p: 'pages',
+    h: 'thumbnail',
+    g: 'coordinates',
+    t: 'timestamp',
+    r: 'revisionId',
+    i: 'internalThumbnailUrl',
+    m: 'missing',
+    n: 'title',
+  }
+
+  test('compression -> decompression is lossless (full object)', async () => {
+    const kvs = new RedisKvs<any>(RedisStore.client, 'article-test', mapping)
+
+    const input = {
+      title: 'London',
+      categories: [{ title: 'City' }],
+      subCategories: [{ title: 'Capital cities' }],
+      revisionId: 123,
+      coordinates: '51.5074,0.1278',
+      thumbnail: { source: 'img.jpg', height: 200, width: 200 },
+      timestamp: '2024-01-01',
+      internalThumbnailUrl: 'internal.jpg',
+      pages: [{ title: 'Page1' }],
+    }
+    await kvs.set('London', input)
+    const result = await kvs.get('London')
+    expect(result).toEqual(input)
+  })
+
+  test('handles missing optional fields correctly', async () => {
+    const kvs = new RedisKvs<any>(RedisStore.client, 'article-test-2', mapping)
+    const input = {
+      title: 'Paris',
+      revisionId: 456,
+    }
+    await kvs.set('Paris', input)
+
+    const result = await kvs.get('Paris')
+    expect(result.title).toBe('Paris')
+    expect(result.revisionId).toBe(456)
+
+    // optional fields should NOT magically appear
+    expect(result.categories).toBeUndefined()
+    expect(result.thumbnail).toBeUndefined()
+  })
+
+  test('handles "missing" flag correctly', async () => {
+    const kvs = new RedisKvs<any>(RedisStore.client, 'article-test-3', mapping)
+    const input = {
+      title: 'FakeArticle',
+      missing: true,
+    }
+
+    await kvs.set('FakeArticle', input)
+    const result = await kvs.get('FakeArticle')
+    expect(result.missing).toBe(true)
+  })
+
+  test('empty object does not break compression', async () => {
+    const kvs = new RedisKvs<any>(RedisStore.client, 'article-test-4', mapping)
+    await kvs.set('Empty', {})
+    const result = await kvs.get('Empty')
+    expect(result).toEqual({})
+  })
+
+  test('overwrite maintains correct mapping', async () => {
+    const kvs = new RedisKvs<any>(RedisStore.client, 'article-test-5', mapping)
+    await kvs.set('London', { title: 'Old', revisionId: 1 })
+    await kvs.set('London', {
+      title: 'New',
+      revisionId: 999,
+      categories: [{ title: 'Updated' }],
+    })
+
+    const result = await kvs.get('London')
+    expect(result.title).toBe('New')
+    expect(result.revisionId).toBe(999)
+    expect(result.categories?.[0]?.title).toBe('Updated')
+  })
+})


### PR DESCRIPTION
fixed issue #2663 

# Changes

- Created `redisCompression.test.ts` to validate Redis compression and ensure lossless mapping
- Added unit tests for ArticleDetailXId
- Covered edge cases for ExtractPageTitleFromHref
- Added edge case tests for GetDefaultSkin
- Improved GetDefaultSkin to ignore unusable default skins and log appropriate warnings
- Enhanced overall test reliability and robustness 

