### PR TITLE
replace loose equality with strict equality

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,6 @@
 Unreleased:
 * FIX: Preserve inline data: URL images instead of rewriting them (@nishantharkut #2670)
+* FIX: Replace loose equality with strict equality (@nishantharkut #2669)
 * UPDATE: Replace iFrame with a placeholder card instead of deleting them (@kunalsiyag #2481)
 * NEW: Scrape only wikitext contentmodel articles by default (@triemerge #2445)
 * FIX: In nopic mode, fixed layout issues by preserving image layout using SVG placeholders (@kunalsiyag #1004)

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -221,7 +221,7 @@ class Downloader {
           logger.log(`Retrying ${requestedUrl} URL due to ${err.code} error`)
           return true // retry all connection issues
         }
-        if (err.responseData?.error?.code == 'maxlag') {
+        if (err.responseData?.error?.code === 'maxlag') {
           logger.log(`Mediawiki server is lagging ${err.responseData?.error?.lag}s; retrying in few seconds`)
           return true // note that we do not honor Retry-After header value because it is not possible in current code architecture
         }

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -410,7 +410,7 @@ class MediaWiki {
 
   public getDefaultSkin(skins: SiteInfoSkin[]) {
     const defaultSkins = skins.filter((skin) => skin.default).map((skin) => skin.code)
-    if (defaultSkins.length == 0) {
+    if (defaultSkins.length === 0) {
       throw new Error(`This wiki has no default skin:\n${JSON.stringify(skins)}`)
     }
     if (defaultSkins.length > 1) {

--- a/src/error.manager.ts
+++ b/src/error.manager.ts
@@ -277,13 +277,13 @@ export function findFirstMatchingRule(err: DownloadErrorContext): MatchingRule |
         matchingRule.httpReturnCodes.findIndex((httpReturnCode) => err.httpReturnCode >= httpReturnCode.min && err.httpReturnCode <= httpReturnCode.max) >= 0) &&
       (!matchingRule.contentTypes ||
         matchingRule.contentTypes.findIndex((contentType) => (err.responseContentType || '').toLowerCase().includes(contentType.toLowerCase())) >= 0) &&
-      (!matchingRule.responseIsEmpty || err.responseData == '') &&
+      (!matchingRule.responseIsEmpty || err.responseData === '') &&
       (!matchingRule.rawResponseDataContains ||
-        matchingRule.rawResponseDataContains.findIndex((rawResponseDataContain) => typeof err.responseData == 'string' && err.responseData.includes(rawResponseDataContain)) >=
+        matchingRule.rawResponseDataContains.findIndex((rawResponseDataContain) => typeof err.responseData === 'string' && err.responseData.includes(rawResponseDataContain)) >=
           0) &&
       (!matchingRule.jsonResponseDataContains ||
         matchingRule.jsonResponseDataContains.findIndex(
-          (jsonResponseDataContain) => typeof err.responseData == 'object' && jsonMatch(err.responseData, jsonResponseDataContain.key, jsonResponseDataContain.valueContains),
+          (jsonResponseDataContain) => typeof err.responseData === 'object' && jsonMatch(err.responseData, jsonResponseDataContain.key, jsonResponseDataContain.valueContains),
         ) >= 0)
     ) {
       return matchingRule

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -559,7 +559,7 @@ async function execute(argv: any) {
     await redirectsXId.iterateItems(Downloader.speed, async (redirects) => {
       for (const [redirectId, { targetId, fragment }] of Object.entries(redirects)) {
         processed += 1
-        if (processed > 0 && processed % 5000 == 0) {
+        if (processed > 0 && processed % 5000 === 0) {
           logger.log(`${processed} redirects have been processed (${Math.round((processed / total) * 1000) / 10} %)`)
         }
         if (await RedisStore.articleDetailXId.exists(redirectId)) {

--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -171,7 +171,7 @@ export abstract class Renderer {
     const originalSrc = videoEl.getAttribute('src')
 
     // Take into account the rare edge case where <video> has no <source> child
-    if (videoSourceEls.length == 0) {
+    if (videoSourceEls.length === 0) {
       if (originalSrc && originalSrc.endsWith('.webm')) {
         // If video has a webm `src` attribute, this is an acceptable src
         return videoEl
@@ -260,7 +260,7 @@ export abstract class Renderer {
     audioEl.removeAttribute('resource')
 
     // Take into account the standard case where <audio> has no <source> child
-    if (audioSourceEls.length == 0) {
+    if (audioSourceEls.length === 0) {
       if (originalSrc) {
         // If audio has a single `src` or `resource` attribute, this is an acceptable src
         // Set this source back in `src`, no matter where it originally was

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -71,7 +71,7 @@ export async function getArticlesByIds(articleIds: string[], log = true): Promis
           }
         }
         const keys = Object.keys(articleDetails)
-        if (keys.length == 0) {
+        if (keys.length === 0) {
           return
         }
         const existingArticleDetails = await articleDetailXId.getMany(keys)

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -99,7 +99,7 @@ export async function downloadFiles(fileStore: RKVS<FileDetail>, zimCreator: Cre
       const completedHosts = hostValues.reduce((buf, host) => {
         return host.downloadsComplete ? buf + 1 : 0
       }, 0)
-      if (completedHosts == hostValues.length) {
+      if (completedHosts === hostValues.length) {
         return null
       }
 
@@ -167,7 +167,7 @@ export async function downloadFiles(fileStore: RKVS<FileDetail>, zimCreator: Cre
         }
       })
       .catch(async (err) => {
-        if (fileToDownload.downloadAttempts > MAX_FILE_DOWNLOAD_RETRIES || (err.response && err.response.status == 404)) {
+        if (fileToDownload.downloadAttempts > MAX_FILE_DOWNLOAD_RETRIES || (err.response && err.response.status === 404)) {
           logger.warn(`Error downloading file [${urlHelper.deserializeUrl(fileToDownload.url)}] [status=${err.response?.status}], skipping`)
           dump.status.files.fail += 1
           hostData.downloadFailure += 1


### PR DESCRIPTION
there is a strict equality used in the rest of the codebase except the modified files. 
Hence, All 11 remaining "**==**" comparisons are replaced with the "**===**". 
Every case compares the same type operands so the behaviour is not changed at all. 