### PR TITLE
Fix #2670 by preserving inline data: URL images

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,5 @@
 Unreleased:
+* FIX: Preserve inline data: URL images instead of rewriting them (@nishantharkut #2670)
 * UPDATE: Replace iFrame with a placeholder card instead of deleting them (@kunalsiyag #2481)
 * NEW: Scrape only wikitext contentmodel articles by default (@triemerge #2445)
 * FIX: In nopic mode, fixed layout issues by preserving image layout using SVG placeholders (@kunalsiyag #1004)

--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -381,6 +381,13 @@ export abstract class Renderer {
       return { imageDependencies }
     }
 
+    /* Preserve inline data: URL images (e.g. from mw.svg) as-is */
+    const imgSrc = img.getAttribute('src')
+    if (imgSrc.startsWith('data:')) {
+      img.setAttribute('loading', 'lazy')
+      return { imageDependencies }
+    }
+
     if (dump.nopic && !this.isMathFallbackImage(img)) {
       this.convertImageToPlaceholder(img)
       return { imageDependencies }
@@ -488,7 +495,9 @@ export abstract class Renderer {
       const fontSize = Math.max(10, Math.min(16, Math.floor(safeHeight / 3)))
       text =
         `<g clip-path="url(#alt-text-clip)">` +
-        `<text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" fill="#54595d" font-size="${fontSize}" font-family="sans-serif">${this.escapeXml(meaningfulAlt)}</text>` +
+        `<text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" fill="#54595d" font-size="${fontSize}" font-family="sans-serif">${this.escapeXml(
+          meaningfulAlt,
+        )}</text>` +
         '</g>'
     }
 

--- a/test/unit/treatments/media.treatment.test.ts
+++ b/test/unit/treatments/media.treatment.test.ts
@@ -289,5 +289,19 @@ describe('MediaTreatment', () => {
       expect(svg).not.toContain('<text ')
       expect(ret.imageDependencies).toHaveLength(0)
     })
+
+    test('data: URL images are preserved as-is', async () => {
+      const { dump } = await setupScrapeClasses({ format: '' })
+      const dataUrl = 'data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjMwIiB3aWR0aD0iMzAiPjwvc3ZnPg=='
+      const testHtml = `<img src="${dataUrl}">`
+      const doc = domino.createDocument(testHtml)
+      const ret = await testableRenderer.testTreatMedias(doc, dump, 'Test_Article')
+
+      const imgEl = doc.querySelector('img')
+      expect(imgEl).not.toBeNull()
+      expect(imgEl.getAttribute('src')).toEqual(dataUrl)
+      expect(imgEl.getAttribute('loading')).toEqual('lazy')
+      expect(ret.imageDependencies.length).toEqual(0)
+    })
   })
 })


### PR DESCRIPTION
Images using the **"data:"** URLs (eg. generated by mediawiki 1.45's **mw.svg** library) were being processed by **treatImage()** which rewrote their **src** to a broken local path via **getMediaBase()**.
Since the **"data:"** URLs are self contained inline images, neither they need the downloading or path rewriting work..

Added an early return in treatImage() that preserves **"data:"** URL image as-is and set loading=lazy
Also, Added the relevant tests for the changes and modified the Changelog file.

Closing #2670 