### PR TITLE
 Allow custom User-Agent header via --userAgent flag

### DIFF
--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -106,6 +106,7 @@ async function execute(argv: any) {
     forceSkin,
     langVariant,
     customCss,
+    userAgent: _userAgent,
   } = argv
 
   let { articleList, articleListToIgnore } = argv
@@ -180,9 +181,13 @@ async function execute(argv: any) {
   const addModules = _addModules ? String(_addModules).split(',') : []
   const trustedJs = javaScript === 'none' ? null : javaScript === 'trusted' ? config.output.mw.js_trusted.concat(addModules) : []
 
+  /* HTTP user-agent string */
+  const uaString = `${_userAgent || config.userAgent} (${adminEmail})`
+  logger.log(`Using User-Agent: ${uaString}`)
+
   /* Download helpers; TODO: Merge with something else / expand this. */
   Downloader.init = {
-    uaString: `${config.userAgent} (${adminEmail})`,
+    uaString,
     speed,
     reqTimeout: requestTimeout * 1000 || config.defaults.requestTimeout,
     optimisationCacheUrl,

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -44,6 +44,7 @@ export const parameterDescriptions = {
   langVariant: 'Use a specific language variant, only for wikis supporting language conversion.',
   insecure: 'Skip HTTPS server authenticity verification step',
   customCss: 'Comma-separated list of CSS URLs to inject into all rendered pages',
+  userAgent: 'Custom User-Agent header for all HTTP requests. Defaults to "MWOffliner/<version> (<adminEmail>)"',
 }
 
 // TODO: Add an interface based on the object above


### PR DESCRIPTION
 #2653

<hr/>

Adds a --userAgent CLI parameter to allow overriding the HTTP User-Agent string used for all requests.

When omitted, the existing default userAgent is preserved. The active UA is now always logged at startup so users can see exactly what is being sent.

<img width="686" height="195" alt="image" src="https://github.com/user-attachments/assets/4ac84574-e848-4871-8a6c-4a0ada0f39d5" />

Changes

src/parameterList.ts : Added userAgent parameter description

src/mwoffliner.lib.ts : Wired the new flag with fallback to the default UA; added startup log line showing the active User-Agent