### PR TITLE
Deduplicate queued file paths with RedisSet

### DIFF
--- a/src/RedisStore.ts
+++ b/src/RedisStore.ts
@@ -3,6 +3,7 @@ import type { RedisClientType } from 'redis'
 import RedisKvs from './util/RedisKvs.js'
 import * as logger from './Logger.js'
 import RedisQueue from './util/RedisQueue.js'
+import RedisSet from './util/RedisSet.js'
 
 class RedisStore implements RS {
   private static instance: RedisStore
@@ -12,6 +13,7 @@ class RedisStore implements RS {
   #filesToDownloadXPath: RKVS<FileDetail>
   #articleDetailXId: RKVS<ArticleDetail>
   #redirectsXId: RKVS<ArticleRedirect>
+  #queuedFilePathsSet: RSET
   #filesQueues: RedisQueue<FileToDownload>[]
 
   private constructor() {
@@ -32,6 +34,10 @@ class RedisStore implements RS {
 
   public get redirectsXId(): RKVS<ArticleRedirect> {
     return this.#redirectsXId
+  }
+
+  public get queuedFilePathsSet(): RSET {
+    return this.#queuedFilePathsSet
   }
 
   public get filesQueues(): RedisQueue<FileToDownload>[] {
@@ -88,7 +94,13 @@ class RedisStore implements RS {
   public async close() {
     if (this.#client.isReady && this.#storesReady) {
       logger.log('Flushing Redis DBs')
-      await Promise.all([this.#filesToDownloadXPath.flush(), this.#articleDetailXId.flush(), this.#redirectsXId.flush(), ...this.#filesQueues.map((queue) => queue.flush)])
+      await Promise.all([
+        this.#filesToDownloadXPath.flush(),
+        this.#articleDetailXId.flush(),
+        this.#redirectsXId.flush(),
+        this.#queuedFilePathsSet.flush(),
+        ...this.#filesQueues.map((queue) => queue.flush()),
+      ])
     }
     if (this.#client.isOpen) {
       await this.#client.quit()
@@ -96,22 +108,35 @@ class RedisStore implements RS {
   }
 
   public async checkForExistingStores() {
-    const patterns = ['*-media', '*-detail', '*-redirect', '*-files']
+    const patterns = ['*-media', '*-detail', '*-redirect', '*-queued-paths', '*-files']
     let keys: string[] = []
     for (const pattern of patterns) {
       keys = keys.concat(await this.#client.keys(pattern))
     }
 
-    keys.forEach(async (key) => {
+    for (const key of keys) {
       try {
-        const length = await this.#client.hLen(key)
-        const time = new Date(Number(key.slice(0, key.indexOf('-'))))
-        logger.warn(`Deleting store from previous run from ${time} that was still in Redis: ${key} with length ${length}`)
-        this.#client.del(key)
+        let length: number
+        if (key.endsWith('-files')) {
+          length = await this.#client.lLen(key)
+        } else if (key.endsWith('-queued-paths')) {
+          length = await this.#client.sCard(key)
+        } else {
+          length = await this.#client.hLen(key)
+        }
+        const firstDashIdx = key.indexOf('-')
+        const maybeTimestamp = firstDashIdx > 0 ? Number(key.slice(0, firstDashIdx)) : Number.NaN
+        if (Number.isFinite(maybeTimestamp)) {
+          const time = new Date(maybeTimestamp)
+          logger.warn(`Deleting store from previous run from ${time} that was still in Redis: ${key} with length ${length}`)
+        } else {
+          logger.warn(`Deleting store from previous run with non-timestamped key: ${key} with length ${length}`)
+        }
+        await this.#client.del(key)
       } catch {
         logger.error(`Key ${key} exists in DB, and is no hash.`)
       }
-    })
+    }
   }
 
   private async populateStores() {
@@ -137,6 +162,7 @@ class RedisStore implements RS {
       t: 'targetId',
       n: 'title',
     })
+    this.#queuedFilePathsSet = new RedisSet(this.#client, `${Date.now()}-queued-paths`)
   }
 
   public createRedisKvs(...args: [string, KVS<string>?]): RKVS<any> {

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -769,7 +769,7 @@ async function execute(argv: any) {
   }
 
   MediaWiki.reset()
-  RedisStore.close()
+  await RedisStore.close()
 
   return dumps
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -77,12 +77,22 @@ interface RKVS<T> {
   flush: () => Promise<number>
 }
 
+interface RSET {
+  add: (value: string) => Promise<boolean>
+  has: (value: string) => Promise<boolean>
+  remove: (value: string) => Promise<number>
+  deleteMany: (values: string[]) => Promise<number>
+  len: () => Promise<number>
+  flush: () => Promise<number>
+}
+
 // RedisStore Interface
 interface RS {
   readonly client: any // RedisClientType
   readonly filesToDownloadXPath: RKVS<FileDetail>
   readonly articleDetailXId: RKVS<ArticleDetail>
   readonly redirectsXId: RKVS<ArticleRedirect>
+  readonly queuedFilePathsSet: RSET
   connect: (populateStores?: boolean) => Promise<void>
   close: () => Promise<void>
   createRedisKvs: (dbName: string, keyMapping?: KVS<string>) => RKVS<any>

--- a/src/util/RedisSet.ts
+++ b/src/util/RedisSet.ts
@@ -1,0 +1,38 @@
+import type { RedisClientType } from 'redis'
+
+export default class RedisSet {
+  private redisClient: RedisClientType
+  private readonly dbName: string
+
+  constructor(redisClient: RedisClientType, dbName: string) {
+    this.redisClient = redisClient
+    this.dbName = dbName
+  }
+
+  public async add(value: string): Promise<boolean> {
+    return (await this.redisClient.sAdd(this.dbName, value)) > 0
+  }
+
+  public has(value: string): Promise<boolean> {
+    return this.redisClient.sIsMember(this.dbName, value)
+  }
+
+  public remove(value: string): Promise<number> {
+    return this.redisClient.sRem(this.dbName, value)
+  }
+
+  public deleteMany(values: string[]): Promise<number> {
+    if (!values.length) {
+      return Promise.resolve(0)
+    }
+    return this.redisClient.sRem(this.dbName, values)
+  }
+
+  public len(): Promise<number> {
+    return this.redisClient.sCard(this.dbName)
+  }
+
+  public flush(): Promise<number> {
+    return this.redisClient.del(this.dbName)
+  }
+}

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -17,6 +17,7 @@ import { fileDownloadMutex, zimCreatorMutex } from '../mutex.js'
 import { truncateUtf8Bytes } from './misc.js'
 import { isMainPage } from './articles.js'
 import RedisQueue from './RedisQueue.js'
+import { processStylesheetContent } from './dump.js'
 
 // Maximum delay between file download attempts on a given host
 // Default upload.wikimedia.org Retry-After value is 11 seconds
@@ -34,38 +35,72 @@ export async function downloadFiles(fileStore: RKVS<FileDetail>, zimCreator: Cre
   }
 
   let prevPercentProgress: string
+  let filesTotal = 0
 
   // create structure + Redis queue to requests hosts in a responsible manner
   const hosts = new Map<string, HostData>()
-  const filesTotal = await RedisStore.filesToDownloadXPath.len()
 
-  await RedisStore.filesToDownloadXPath.iterateItems(1, async (filesToDownload: KVS<FileDetail>) => {
-    for (const [path, { url, mult, width, kind }] of Object.entries(filesToDownload)) {
-      const hostname = new URL(urlHelper.deserializeUrl(url)).hostname
-      if (!hosts.has(hostname)) {
-        const filesToDownload = new RedisQueue<FileToDownload>(RedisStore.client, `${hostname}-files`)
-        RedisStore.filesQueues.push(filesToDownload)
-        filesToDownload.flush()
-        hosts.set(hostname, {
-          filesToDownload,
-          requestInterval: 30, // initial request interval is 30 ms
-          downloadSuccess: 0,
-          downloadFailure: 0,
-          downloadsComplete: false,
+  const queuePendingFilesToDownload = async (isFirstCall = false) => {
+    const queuedPathsBatch: string[] = []
+    await fileStore.iterateItems(1, async (filesToDownload: KVS<FileDetail>) => {
+      for (const [path, { url, mult, width, kind }] of Object.entries(filesToDownload)) {
+        const pathWasQueuedNow = await RedisStore.queuedFilePathsSet.add(path)
+        if (!pathWasQueuedNow) {
+          logger.warn(
+            `Skipping already-queued file path [${path}]: ` +
+              `duplicate url=${urlHelper.deserializeUrl(url)}, width=${width ?? 'unset'}.`,
+          )
+          continue
+        }
+
+        if (!isFirstCall) {
+          queuedPathsBatch.push(path)
+        }
+        filesTotal += 1
+
+        const hostname = new URL(urlHelper.deserializeUrl(url)).hostname
+        if (!hosts.has(hostname)) {
+          const filesToDownload = new RedisQueue<FileToDownload>(RedisStore.client, `${hostname}-files`)
+          RedisStore.filesQueues.push(filesToDownload)
+          await filesToDownload.flush()
+          hosts.set(hostname, {
+            filesToDownload,
+            requestInterval: 30, // initial request interval is 30 ms
+            downloadSuccess: 0,
+            downloadFailure: 0,
+            downloadsComplete: false,
+          })
+        }
+
+        const hostData = hosts.get(hostname)
+        hostData.downloadsComplete = false
+        await hostData.filesToDownload.push({
+          path: path,
+          url: url,
+          mult: mult,
+          width: width,
+          kind: kind,
+          downloadAttempts: 0,
         })
       }
-      hosts.get(hostname).filesToDownload.push({
-        path: path,
-        url: url,
-        mult: mult,
-        width: width,
-        kind: kind,
-        downloadAttempts: 0,
-      })
-    }
-  })
+    })
 
-  await RedisStore.filesToDownloadXPath.flush()
+    if (isFirstCall) {
+      await fileStore.flush()
+      return
+    }
+
+    if (queuedPathsBatch.length > 0) {
+      await fileStore.deleteMany(queuedPathsBatch)
+    }
+  }
+
+  await queuePendingFilesToDownload(true)
+  // Throttle expensive fileStore scans across all workers/invocations.
+  // Access is serialized because getNextFileToDownload runs inside fileDownloadMutex.
+  // Keep this at 0 so the first polling pass always scans fileStore once.
+  let lastQueueingDate = 0
+  const queueingInterval = 200
 
   /**
    * Return next file ready to download or wait if all hosts need to make a pause.
@@ -85,6 +120,7 @@ export async function downloadFiles(fileStore: RKVS<FileDetail>, zimCreator: Cre
           while (await hostData.filesToDownload.pop()) {
             dump.status.files.fail += 1
             if (
+              filesTotal > 0 &&
               dump.status.files.fail > FILES_DOWNLOAD_FAILURE_MINIMUM_FOR_CHECK &&
               (dump.status.files.fail * 10000) / filesTotal > FILES_DOWNLOAD_FAILURE_TRESHOLD_PER_TEN_THOUSAND
             ) {
@@ -94,12 +130,18 @@ export async function downloadFiles(fileStore: RKVS<FileDetail>, zimCreator: Cre
         }
         return null
       }
+
+      if (Date.now() - lastQueueingDate >= queueingInterval) {
+        await queuePendingFilesToDownload(false)
+        lastQueueingDate = Date.now()
+      }
+
       // check if all donwloads have completed and exit
       const hostValues = Array.from(hosts.values())
       const completedHosts = hostValues.reduce((buf, host) => {
-        return host.downloadsComplete ? buf + 1 : 0
+        return host.downloadsComplete ? buf + 1 : buf
       }, 0)
-      if (completedHosts == hostValues.length) {
+      if (hostValues.length === 0 || completedHosts === hostValues.length) {
         return null
       }
 
@@ -146,7 +188,11 @@ export async function downloadFiles(fileStore: RKVS<FileDetail>, zimCreator: Cre
         prevPercentProgress = percentProgress
         logger.log(`Progress downloading files [${dump.status.files.success + dump.status.files.fail}/${filesTotal}] [${percentProgress}%]`)
       }
-      if (dump.status.files.fail > FILES_DOWNLOAD_FAILURE_MINIMUM_FOR_CHECK && (dump.status.files.fail * 10000) / filesTotal > FILES_DOWNLOAD_FAILURE_TRESHOLD_PER_TEN_THOUSAND) {
+      if (
+        filesTotal > 0 &&
+        dump.status.files.fail > FILES_DOWNLOAD_FAILURE_MINIMUM_FOR_CHECK &&
+        (dump.status.files.fail * 10000) / filesTotal > FILES_DOWNLOAD_FAILURE_TRESHOLD_PER_TEN_THOUSAND
+      ) {
         throw new Error(`Too many files failed to download: [${dump.status.files.fail}/${filesTotal}]`)
       }
     }
@@ -156,9 +202,13 @@ export async function downloadFiles(fileStore: RKVS<FileDetail>, zimCreator: Cre
     await Downloader.downloadContent(fileToDownload.url, fileToDownload.kind, false)
       .then(async (resp) => {
         if (resp && resp.content && resp.contentType) {
+          let content = resp.content
+          if (fileToDownload.kind === 'css') {
+            content = await processStylesheetContent(urlHelper.deserializeUrl(fileToDownload.url), '', resp.content.toString(), fileToDownload.path)
+          }
           // { FRONT_ARTICLE: 0 } is here very important, should we retrieve HTML we want to be sure the libzim will
           // not consider it for title index
-          const item = new StringItem(fileToDownload.path, resp.contentType, null, { FRONT_ARTICLE: 0 }, resp.content)
+          const item = new StringItem(fileToDownload.path, resp.contentType, null, { FRONT_ARTICLE: 0 }, content)
           await zimCreatorMutex.runExclusive(() => zimCreator.addItem(item))
           dump.status.files.success += 1
           hostData.downloadSuccess += 1
@@ -167,7 +217,15 @@ export async function downloadFiles(fileStore: RKVS<FileDetail>, zimCreator: Cre
         }
       })
       .catch(async (err) => {
-        if (fileToDownload.downloadAttempts > MAX_FILE_DOWNLOAD_RETRIES || (err.response && err.response.status == 404)) {
+        const isRetriableTransportError = !!(err?.response || err?.code)
+        if (!isRetriableTransportError) {
+          logger.warn(`Error processing file [${urlHelper.deserializeUrl(fileToDownload.url)}], skipping without retry`, err)
+          dump.status.files.fail += 1
+          hostData.downloadFailure += 1
+          return
+        }
+
+        if (fileToDownload.downloadAttempts > MAX_FILE_DOWNLOAD_RETRIES || (err.response && err.response.status === 404)) {
           logger.warn(`Error downloading file [${urlHelper.deserializeUrl(fileToDownload.url)}] [status=${err.response?.status}], skipping`)
           dump.status.files.fail += 1
           hostData.downloadFailure += 1
@@ -202,26 +260,49 @@ export async function downloadFiles(fileStore: RKVS<FileDetail>, zimCreator: Cre
       })
   }
 
-  await pmap(
-    Array.from({ length: Downloader.speed }, (_, i) => i),
-    async (workerId: number) => {
-      while (true) {
-        // get next file to download in a Mutex (we do not want two workers trying to get next file at same time
-        // since we need to take into account limits per hostname, so this getNextFileToDownload will update
-        // data about load per host)
-        const nextFileData = await fileDownloadMutex.runExclusive(getNextFileToDownload)
-        if (!nextFileData) break
-        const { fileToDownload, hostname, hostData } = nextFileData
-        await workerDownloadFile(fileToDownload, hostname, hostData, workerId)
-      }
-    },
-    { concurrency: Downloader.speed },
-  )
+  let processingError: unknown = null
+  let flushError: unknown = null
+  try {
+    await pmap(
+      Array.from({ length: Downloader.speed }, (_, i) => i),
+      async (workerId: number) => {
+        while (true) {
+          // get next file to download in a Mutex (we do not want two workers trying to get next file at same time
+          // since we need to take into account limits per hostname, so this getNextFileToDownload will update
+          // data about load per host)
+          const nextFileData = await fileDownloadMutex.runExclusive(getNextFileToDownload)
+          if (!nextFileData) break
+          const { fileToDownload, hostname, hostData } = nextFileData
+          await workerDownloadFile(fileToDownload, hostname, hostData, workerId)
+        }
+      },
+      { concurrency: Downloader.speed },
+    )
 
-  logger.log(
-    `Done with downloading ${filesTotal} files: ${dump.status.files.success} success, ${dump.status.files.fail} fail: `,
-    JSON.stringify(Object.fromEntries([...hosts].map(([hostname, hostData]) => [hostname, { success: hostData.downloadSuccess, fail: hostData.downloadFailure }])), null, '\t'),
-  )
+    logger.log(
+      `Done with downloading ${filesTotal} files: ${dump.status.files.success} success, ${dump.status.files.fail} fail: `,
+      JSON.stringify(Object.fromEntries([...hosts].map(([hostname, hostData]) => [hostname, { success: hostData.downloadSuccess, fail: hostData.downloadFailure }])), null, '\t'),
+    )
+  } catch (err) {
+    processingError = err
+  }
+
+  try {
+    await RedisStore.queuedFilePathsSet.flush()
+  } catch (err) {
+    flushError = err
+  }
+
+  if (processingError) {
+    if (flushError) {
+      logger.warn('Failed to flush queuedFilePathsSet while handling another error', flushError)
+    }
+    throw processingError
+  }
+
+  if (flushError) {
+    throw flushError
+  }
 }
 
 async function getAllArticlesToKeep(articleDetailXId: RKVS<ArticleDetail>, dump: Dump, articlesRenderer: Renderer) {

--- a/test/unit/bootstrap.ts
+++ b/test/unit/bootstrap.ts
@@ -9,8 +9,8 @@ RedisStore.setOptions(process.env.REDIS || config.defaults.redisPath, { quitOnEr
 
 export const startRedis = async () => {
   await RedisStore.connect()
-  const { articleDetailXId, redirectsXId, filesToDownloadXPath, filesQueues } = RedisStore
-  await Promise.all([articleDetailXId.flush(), redirectsXId.flush(), filesToDownloadXPath.flush(), ...filesQueues.map((queue) => queue.flush())])
+  const { articleDetailXId, redirectsXId, filesToDownloadXPath, queuedFilePathsSet, filesQueues } = RedisStore
+  await Promise.all([articleDetailXId.flush(), redirectsXId.flush(), filesToDownloadXPath.flush(), queuedFilePathsSet.flush(), ...filesQueues.map((queue) => queue.flush())])
 }
 
 export const stopRedis = async () => {

--- a/test/unit/util/RedisSet.test.ts
+++ b/test/unit/util/RedisSet.test.ts
@@ -1,0 +1,51 @@
+import RedisSet from '../../../src/util/RedisSet.js'
+import RedisStore from '../../../src/RedisStore.js'
+import { startRedis, stopRedis } from '../bootstrap.js'
+
+describe('Test RedisSet operations', () => {
+  beforeAll(startRedis)
+  afterAll(stopRedis)
+
+  let set1: RedisSet
+  let set2: RedisSet
+
+  beforeAll(async () => {
+    const client = RedisStore.client
+    set1 = new RedisSet(client, 'test-set1')
+    await set1.flush()
+    set2 = new RedisSet(client, 'test-set2')
+    await set2.flush()
+  })
+
+  test('add and has', async () => {
+    expect(await set1.add('value1')).toBe(true)
+    expect(await set1.add('value1')).toBe(false)
+    expect(await set1.has('value1')).toBe(true)
+    expect(await set1.has('missing')).toBe(false)
+  })
+
+  test('set isolation and remove', async () => {
+    await set1.add('value1')
+    await set2.add('value2')
+
+    expect(await set1.has('value1')).toBe(true)
+    expect(await set1.has('value2')).toBe(false)
+    expect(await set2.has('value2')).toBe(true)
+
+    expect(await set1.remove('value1')).toBe(1)
+    expect(await set1.remove('value1')).toBe(0)
+    expect(await set1.has('value1')).toBe(false)
+  })
+
+  test('len and flush', async () => {
+    await set1.flush()
+    await set1.add('a')
+    await set1.add('b')
+    await set1.add('b')
+
+    expect(await set1.len()).toBe(2)
+
+    await set1.flush()
+    expect(await set1.len()).toBe(0)
+  })
+})


### PR DESCRIPTION
Follow-up to discussion in [#2656 (comment)](https://github.com/openzim/mwoffliner/pull/2656#discussion_r2958501827).

`queuedFilePathsSet` now deduplicates file paths across repeated `queuePendingFilesToDownload` polls using a Redis-backed `RedisSet`, keeping large dedup state out of Node.js memory.

- Adds `RedisSet` abstraction alongside `RedisKvs` and `RedisQueue`
- Registers `queuedFilePathsSet` in `RedisStore` with full lifecycle handling (`checkForExistingStores`, `close`)
- Uses `SADD` return value as atomic enqueue gate
- First call flushes the file store; subsequent calls delete only the processed batch
- Fixes fire-and-forget `RedisStore.close` by awaiting it in `src/mwoffliner.lib.ts`
- Makes stale Redis cleanup deterministic (await per-key delete) in `src/RedisStore.ts`
- Ensures `queuedFilePathsSet` is flushed even when download processing fails in `src/util/saveArticles.ts`
- Fixes host completion accounting logic in `src/util/saveArticles.ts`
- Adds polling scan throttling + first-scan guarantee in `src/util/saveArticles.ts`
- Avoids retrying non-transport processing errors in `src/util/saveArticles.ts`
- Fixes async setup race in `RedisSet` unit test in `test/unit/util/RedisSet.test.ts`