### PR TITLE
Detect continuation cycles in article pagination

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -17,6 +17,7 @@ Unreleased:
 * FIX: Improve test coverage for MediaWiki.extractPageTitleFromHref and Rediscompression, also add unit tests for RedisStore.articleDetailXId (@RishabhThakur-19 #2663)
 * DEL: Remove deprecated CLI parameters `mwWikiPath`, `mwIndexPhpPath`, `keepEmptyParagraphs` (@Markus-Rost #2489)
 * NEW: Add `--customCss` CLI option to inject custom stylesheets
+* FIX: Detect continuation cycles in article pagination (@triemerge #2532)
 
 
 1.17.5:

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -374,6 +374,7 @@ class Downloader {
   public async getArticleDetailsIds(articleIds: string[], shouldGetThumbnail = false): Promise<QueryMwRet> {
     let continuation: ContinueOpts
     let finalProcessedResp: QueryMwRet
+    const visitedUrls = new Set<string>()
 
     while (true) {
       const queryOpts: KVS<any> = {
@@ -390,6 +391,10 @@ class Downloader {
       }
 
       const reqUrl = this.apiUrlDirector.buildQueryURL(queryOpts)
+      if (visitedUrls.has(reqUrl)) {
+        throw new Error(`Detected continuation cycle while fetching article details by IDs. ` + `visitedUrls=[\n${[...visitedUrls].join('\n')}\n]`)
+      }
+      visitedUrls.add(reqUrl)
 
       const resp = await this.getJSON<MwApiResponse>(reqUrl)
 
@@ -415,6 +420,7 @@ class Downloader {
     let queryContinuation: QueryContinueOpts
     let finalProcessedResp: QueryMwRet
     let gCont: string = null
+    const visitedUrls = new Set<string>()
 
     while (true) {
       const queryOpts: KVS<any> = {
@@ -442,6 +448,10 @@ class Downloader {
       }
 
       const reqUrl = this.apiUrlDirector.buildQueryURL(queryOpts)
+      if (visitedUrls.has(reqUrl)) {
+        throw new Error(`Detected continuation cycle while fetching article details in namespace ${ns}. ` + `visitedUrls=[\n${[...visitedUrls].join('\n')}\n]`)
+      }
+      visitedUrls.add(reqUrl)
 
       const resp = await this.getJSON<MwApiResponse>(reqUrl)
       Downloader.handleMWWarningsAndErrors(resp)

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -101,6 +101,7 @@ export function getArticlesByNS(ns: number, articleIdsToIgnore?: string[], allow
   return new Promise(async (resolve, reject) => {
     let totalArticles = 0
     let chunk: { articleDetails: QueryMwRet; gapContinue: string }
+    const seenGapContinueValues: string[] = []
 
     const { articleDetailXId, redirectsXId } = RedisStore
 
@@ -128,6 +129,16 @@ export function getArticlesByNS(ns: number, articleIdsToIgnore?: string[], allow
         timer.reset()
         curStage = 0
         chunk = await Downloader.getArticleDetailsNS(ns, chunk && chunk.gapContinue)
+
+        if (chunk.gapContinue) {
+          if (seenGapContinueValues.includes(chunk.gapContinue)) {
+            throw new Error(
+              `Detected continuation cycle while fetching articles in namespace ${ns}. ` +
+                `Repeated gapContinue=${chunk.gapContinue} after visiting: [${seenGapContinueValues.join(', ')}]`,
+            )
+          }
+          seenGapContinueValues.push(chunk.gapContinue)
+        }
 
         // Filter articles without revisions (#2238)
         const newArticlesToIgnore = Object.values(chunk.articleDetails)


### PR DESCRIPTION
Fix #2532

`getArticleDetailsIds` and `getArticleDetailsNS` follow MediaWiki `continue` parameters in unbounded `while(true)` loops. `getArticlesByNS` follows the returned `gapContinue` token in an unbounded `do...while` loop. A malformed token (as seen in [openzim/zim-requests#1260 (comment)](https://github.com/openzim/zim-requests/issues/1260#issuecomment-3324636008)) can create a cycle that hangs Zimfarm indefinitely. Both methods now track seen continuation states in a per-call `Set` and throw if a cycle is detected.

- `Set` is scoped to each invocation so memory stays bounded
- Throws rather than warns since a detected cycle means the API response cannot be trusted