### PR TITLE
Fix fire-and-forget async patterns and file download accounting bugs

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,5 @@
 Unreleased:
+* FIX: Fix fire-and-forget async patterns and file download accounting bugs (@triemerge #2681)
 * FIX: Preserve inline data: URL images instead of rewriting them (@nishantharkut #2670)
 * FIX: Replace loose equality with strict equality (@nishantharkut #2669)
 * DEL: Remove unused mocha from production dependencies (@nishantharkut #2668)

--- a/src/RedisStore.ts
+++ b/src/RedisStore.ts
@@ -88,7 +88,7 @@ class RedisStore implements RS {
   public async close() {
     if (this.#client.isReady && this.#storesReady) {
       logger.log('Flushing Redis DBs')
-      await Promise.all([this.#filesToDownloadXPath.flush(), this.#articleDetailXId.flush(), this.#redirectsXId.flush(), ...this.#filesQueues.map((queue) => queue.flush)])
+      await Promise.all([this.#filesToDownloadXPath.flush(), this.#articleDetailXId.flush(), this.#redirectsXId.flush(), ...this.#filesQueues.map((queue) => queue.flush())])
     }
     if (this.#client.isOpen) {
       await this.#client.quit()
@@ -102,16 +102,18 @@ class RedisStore implements RS {
       keys = keys.concat(await this.#client.keys(pattern))
     }
 
-    keys.forEach(async (key) => {
-      try {
-        const length = await this.#client.hLen(key)
-        const time = new Date(Number(key.slice(0, key.indexOf('-'))))
-        logger.warn(`Deleting store from previous run from ${time} that was still in Redis: ${key} with length ${length}`)
-        this.#client.del(key)
-      } catch {
-        logger.error(`Key ${key} exists in DB, and is no hash.`)
-      }
-    })
+    await Promise.all(
+      keys.map(async (key) => {
+        try {
+          const length = await this.#client.hLen(key)
+          const time = new Date(Number(key.slice(0, key.indexOf('-'))))
+          logger.warn(`Deleting store from previous run from ${time} that was still in Redis: ${key} with length ${length}`)
+          await this.#client.del(key)
+        } catch {
+          logger.error(`Key ${key} exists in DB, and is no hash.`)
+        }
+      }),
+    )
   }
 
   private async populateStores() {

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -774,7 +774,7 @@ async function execute(argv: any) {
   }
 
   MediaWiki.reset()
-  RedisStore.close()
+  await RedisStore.close()
 
   return dumps
 }

--- a/src/util/dump.ts
+++ b/src/util/dump.ts
@@ -325,14 +325,16 @@ export async function downloadAndSaveCustomCss(zimCreator: Creator, cssUrl: stri
 
 // URLs should be kept the same as Kiwix JS relies on it.
 export async function addWebpJsScripts(zimCreator: Creator) {
-  ;[
-    { name: 'webpHeroPolyfill', path: path.join(__dirname, '../../node_modules/webp-hero/dist-cjs/polyfills.js') },
-    { name: 'webpHeroBundle', path: path.join(__dirname, '../../node_modules/webp-hero/dist-cjs/webp-hero.bundle.js') },
-    { name: 'webpHandler', path: path.join(__dirname, '../../res/webpHandler.js') },
-  ].forEach(async ({ name, path }) => {
-    const item = new StringItem(`${config.output.dirs.webp}/${jsPath(name)}`, 'text/javascript', null, { FRONT_ARTICLE: 0 }, fs.readFileSync(path, 'utf8').toString())
-    await zimCreatorMutex.runExclusive(() => zimCreator.addItem(item))
-  })
+  await Promise.all(
+    [
+      { name: 'webpHeroPolyfill', path: path.join(__dirname, '../../node_modules/webp-hero/dist-cjs/polyfills.js') },
+      { name: 'webpHeroBundle', path: path.join(__dirname, '../../node_modules/webp-hero/dist-cjs/webp-hero.bundle.js') },
+      { name: 'webpHandler', path: path.join(__dirname, '../../res/webpHandler.js') },
+    ].map(async ({ name, path: scriptPath }) => {
+      const item = new StringItem(`${config.output.dirs.webp}/${jsPath(name)}`, 'text/javascript', null, { FRONT_ARTICLE: 0 }, fs.readFileSync(scriptPath, 'utf8').toString())
+      await zimCreatorMutex.runExclusive(() => zimCreator.addItem(item))
+    }),
+  )
 }
 
 export interface ResourceLoaderModule extends Array<any> {

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -177,28 +177,30 @@ export function interpolateTranslationString(str: string, parameters: { [key: st
 
 export async function saveStaticFiles(staticFiles: Set<string>, zimCreator: Creator) {
   try {
-    staticFiles.forEach(async (file) => {
-      const staticFilesContent = await readFilePromise(pathParser.resolve(__dirname, `../../res/${file}`))
+    await Promise.all(
+      Array.from(staticFiles).map(async (file) => {
+        const staticFilesContent = await readFilePromise(pathParser.resolve(__dirname, `../../res/${file}`))
 
-      let zimPath: string
-      let mimetype: string
-      if (file.endsWith('.ttf')) {
-        zimPath = anyPath('ttf', file)
-        mimetype = 'font/ttf'
-      } else if (file.endsWith('.svg')) {
-        zimPath = anyPath('svg', file)
-        mimetype = 'image/svg+xml'
-      } else if (file.endsWith('.css')) {
-        zimPath = cssPath(file)
-        mimetype = 'text/css'
-      } else {
-        zimPath = jsPath(file)
-        mimetype = 'application/javascript'
-      }
+        let zimPath: string
+        let mimetype: string
+        if (file.endsWith('.ttf')) {
+          zimPath = anyPath('ttf', file)
+          mimetype = 'font/ttf'
+        } else if (file.endsWith('.svg')) {
+          zimPath = anyPath('svg', file)
+          mimetype = 'image/svg+xml'
+        } else if (file.endsWith('.css')) {
+          zimPath = cssPath(file)
+          mimetype = 'text/css'
+        } else {
+          zimPath = jsPath(file)
+          mimetype = 'application/javascript'
+        }
 
-      const article = new StringItem(`${config.output.dirs.res}/${zimPath}`, mimetype, null, { FRONT_ARTICLE: 0 }, staticFilesContent)
-      await zimCreatorMutex.runExclusive(() => zimCreator.addItem(article))
-    })
+        const article = new StringItem(`${config.output.dirs.res}/${zimPath}`, mimetype, null, { FRONT_ARTICLE: 0 }, staticFilesContent)
+        await zimCreatorMutex.runExclusive(() => zimCreator.addItem(article))
+      }),
+    )
   } catch (err) {
     logger.error(err)
   }

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -45,7 +45,7 @@ export async function downloadFiles(fileStore: RKVS<FileDetail>, zimCreator: Cre
       if (!hosts.has(hostname)) {
         const filesToDownload = new RedisQueue<FileToDownload>(RedisStore.client, `${hostname}-files`)
         RedisStore.filesQueues.push(filesToDownload)
-        filesToDownload.flush()
+        await filesToDownload.flush()
         hosts.set(hostname, {
           filesToDownload,
           requestInterval: 30, // initial request interval is 30 ms
@@ -85,6 +85,7 @@ export async function downloadFiles(fileStore: RKVS<FileDetail>, zimCreator: Cre
           while (await hostData.filesToDownload.pop()) {
             dump.status.files.fail += 1
             if (
+              filesTotal > 0 &&
               dump.status.files.fail > FILES_DOWNLOAD_FAILURE_MINIMUM_FOR_CHECK &&
               (dump.status.files.fail * 10000) / filesTotal > FILES_DOWNLOAD_FAILURE_TRESHOLD_PER_TEN_THOUSAND
             ) {
@@ -97,7 +98,7 @@ export async function downloadFiles(fileStore: RKVS<FileDetail>, zimCreator: Cre
       // check if all donwloads have completed and exit
       const hostValues = Array.from(hosts.values())
       const completedHosts = hostValues.reduce((buf, host) => {
-        return host.downloadsComplete ? buf + 1 : 0
+        return host.downloadsComplete ? buf + 1 : buf
       }, 0)
       if (completedHosts === hostValues.length) {
         return null
@@ -146,7 +147,11 @@ export async function downloadFiles(fileStore: RKVS<FileDetail>, zimCreator: Cre
         prevPercentProgress = percentProgress
         logger.log(`Progress downloading files [${dump.status.files.success + dump.status.files.fail}/${filesTotal}] [${percentProgress}%]`)
       }
-      if (dump.status.files.fail > FILES_DOWNLOAD_FAILURE_MINIMUM_FOR_CHECK && (dump.status.files.fail * 10000) / filesTotal > FILES_DOWNLOAD_FAILURE_TRESHOLD_PER_TEN_THOUSAND) {
+      if (
+        filesTotal > 0 &&
+        dump.status.files.fail > FILES_DOWNLOAD_FAILURE_MINIMUM_FOR_CHECK &&
+        (dump.status.files.fail * 10000) / filesTotal > FILES_DOWNLOAD_FAILURE_TRESHOLD_PER_TEN_THOUSAND
+      ) {
         throw new Error(`Too many files failed to download: [${dump.status.files.fail}/${filesTotal}]`)
       }
     }


### PR DESCRIPTION
- Replaced all `forEach(async` callbacks with `await Promise.all(items.map(async ...))` to properly await async operations
- Added missing `await` on `RedisStore.close()`, `filesToDownload.flush()`, and `client.del()`
- Fixed `queue.flush` referenced as a property instead of called as `queue.flush()`
- Fixed `completedHosts` reduce accumulator reset bug
- Added `filesTotal > 0` guard to prevent division-by-zero in download progress accounting