### PR TITLE
Avoid retrying non-transport processing errors

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,6 @@
 Unreleased:
 * FIX: Fix fire-and-forget async patterns and file download accounting bugs (@triemerge #2681)
+* FIX: Avoid retrying non-transport processing errors (@triemerge #2685)
 * FIX: Preserve inline data: URL images instead of rewriting them (@nishantharkut #2670)
 * FIX: Replace loose equality with strict equality (@nishantharkut #2669)
 * DEL: Remove unused mocha from production dependencies (@nishantharkut #2668)

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -172,6 +172,13 @@ export async function downloadFiles(fileStore: RKVS<FileDetail>, zimCreator: Cre
         }
       })
       .catch(async (err) => {
+        const isRetriableTransportError = !!(err?.response || err?.code)
+        if (!isRetriableTransportError) {
+          logger.warn(`Error processing file [${urlHelper.deserializeUrl(fileToDownload.url)}], skipping without retry`, err)
+          dump.status.files.fail += 1
+          hostData.downloadFailure += 1
+          return
+        }
         if (fileToDownload.downloadAttempts > MAX_FILE_DOWNLOAD_RETRIES || (err.response && err.response.status === 404)) {
           logger.warn(`Error downloading file [${urlHelper.deserializeUrl(fileToDownload.url)}] [status=${err.response?.status}], skipping`)
           dump.status.files.fail += 1


### PR DESCRIPTION
`workerDownloadFile` previously retried most failures, including deterministic processing errors. It now generally treats processing failures such as `zimCreator.addItem` errors as non-transport failures and skips re-queueing.

This reduces unnecessary retries and queue churn while preserving retries for recognized transport/network errors.