### PR TITLE
fix: gradually recover requestInterval after successful downloads

### DIFF
--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -162,6 +162,7 @@ export async function downloadFiles(fileStore: RKVS<FileDetail>, zimCreator: Cre
           await zimCreatorMutex.runExclusive(() => zimCreator.addItem(item))
           dump.status.files.success += 1
           hostData.downloadSuccess += 1
+          hostData.requestInterval = Math.max(30, hostData.requestInterval * 0.9) // gradually recover interval on success
         } else {
           throw new Error(`Bad response received: ${resp}`)
         }
@@ -188,7 +189,7 @@ export async function downloadFiles(fileStore: RKVS<FileDetail>, zimCreator: Cre
               }
             }
           }
-          // slow down except for wikimedia thumbnails whose server is known to be lying (see https://github.com/openzim/mwoffliner/issues/2572)
+          // slow down on 429/503/524, except for wikimedia thumbnails whose server is known to be lying
           if (
             err.response &&
             [429, 503, 524].includes(err.response.status) &&


### PR DESCRIPTION
## Problem

Fixes #2572

When a server returns HTTP 429/503/524, `requestInterval` is multiplied by `1.2` (capped at `MAXIMUM_FILE_DOWNLOAD_DELAY` = 20 seconds). However, after the server recovers and downloads succeed again, `requestInterval` **never decreases** — the scraper stays permanently throttled at the maximum interval for that host, making it appear frozen.

## Fix

On each successful download, gradually reduce `requestInterval` by multiplying by `0.9`, with a floor of `30ms` (the initial value):
```ts
hostData.requestInterval = Math.max(30, hostData.requestInterval * 0.9)
// gradually recover interval on success
```

This mirrors the existing slow-down logic symmetrically — the interval increases on failure and recovers on success.

## Changes

- `src/util/saveArticles.ts`: Add interval recovery on successful download + update comment