### PR TITLE
Restrict the list of available formats + add more meaningful labels

### DIFF
--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -98,15 +98,10 @@
       "description": "Which flavours to build, as `<flavour>:<custom-suffix>`. Empty option is full without suffix.",
       "alias": "format",
       "choices": [
-        { "title": "NODET_NOPIC_MINI", "value": "nodet,nopic:mini" },
-        { "title": "NODET_MINI", "value": "nodet:mini" },
-        { "title": "NOPIC_NOPIC", "value": "nopic:nopic" },
-        { "title": "NOVID_MAXI", "value": "novid:maxi" },
-        { "title": "EMPTY", "value": "" },
-        { "title": "NODET", "value": "nodet" },
-        { "title": "NOPIC", "value": "nopic" },
-        { "title": "NOVID", "value": "novid" },
-        { "title": "NODET_NOPIC", "value": "nodet,nopic" }
+        { "title": "mini: no article details or pictures or videos", "value": "nodet,nopic:mini" },
+        { "title": "nopic: no article pictures or videos", "value": "nopic:nopic" },
+        { "title": "maxi: all except article videos", "value": "novid:maxi" },
+        { "title": "all: everything including videos", "value": "" }
       ]
     },
     "customFlavour": {


### PR DESCRIPTION
For some reasons, we've originally allowed more flavours / formats than what we really used in production

I've check prod DB and these are the sole values we use.

@Popolechien do I miss something or do you confirm these are the only formats we wanna use on Zimfarm?

@elfkuzco do you see any problem to have such labels?

Current:
<img width="1757" height="96" alt="image" src="https://github.com/user-attachments/assets/9e4a40ed-33d0-4ee6-8e08-8e81c7c20774" />

After:
<img width="1760" height="103" alt="image" src="https://github.com/user-attachments/assets/88cb6aa7-da49-4807-8c41-9d7c7101330b" />
