### PR TITLE
Refactor file download pipeline to inline host queueing

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -22,6 +22,7 @@ Unreleased:
 * DEL: Remove deprecated CLI parameters `mwWikiPath`, `mwIndexPhpPath`, `keepEmptyParagraphs` (@Markus-Rost #2489)
 * NEW: Add `--customCss` CLI option to inject custom stylesheets
 * FIX: Detect continuation cycles in article pagination (@triemerge #2532)
+* FIX: Refactor file download pipeline to inline host queueing (@triemerge #2689)
 
 
 1.17.5:

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -145,7 +145,6 @@ class Downloader {
     return Downloader.instance
   }
   private _speed: number
-  public cssDependenceUrls: KVS<boolean> = {}
   private _webp: boolean = false
   private _requestTimeout: number
   private _basicRequestOptions: AxiosRequestConfig
@@ -316,8 +315,6 @@ class Downloader {
     this._arrayBufferRequestOptions = undefined
     this._jsonRequestOptions = undefined
     this._streamRequestOptions = undefined
-
-    this.cssDependenceUrls = {}
 
     this.articleUrlDirector = undefined
   }

--- a/src/RedisStore.ts
+++ b/src/RedisStore.ts
@@ -105,12 +105,11 @@ class RedisStore implements RS {
     await Promise.all(
       keys.map(async (key) => {
         try {
-          const length = await this.#client.hLen(key)
           const time = new Date(Number(key.slice(0, key.indexOf('-'))))
-          logger.warn(`Deleting store from previous run from ${time} that was still in Redis: ${key} with length ${length}`)
+          logger.warn(`Deleting store from previous run from ${time} that was still in Redis: ${key}`)
           await this.#client.del(key)
-        } catch {
-          logger.error(`Key ${key} exists in DB, and is no hash.`)
+        } catch (err) {
+          logger.error(`Failed to delete stale key ${key}:`, err)
         }
       }),
     )
@@ -121,6 +120,7 @@ class RedisStore implements RS {
       u: 'url',
       m: 'mult',
       w: 'width',
+      k: 'kind',
     })
     this.#articleDetailXId = new RedisKvs(this.#client, `${Date.now()}-detail`, {
       s: 'subCategories',

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -54,10 +54,11 @@ import MediaWiki from './MediaWiki.js'
 import Downloader from './Downloader.js'
 import RenderingContext from './renderers/rendering.context.js'
 import { articleListHomeTemplate, htmlRedirectTemplateCode } from './Templates.js'
-import { downloadFiles, saveArticles } from './util/saveArticles.js'
+import { saveArticles } from './util/saveArticles.js'
 import { getCategoriesForArticles, trimUnmirroredPages } from './util/categories.js'
 import urlHelper from './util/url.helper.js'
 import { parseCustomCssUrls, customCssUrlToFilename } from './util/customCss.js'
+import FileManager from './util/FileManager.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -397,7 +398,6 @@ async function execute(argv: any) {
     } else {
       await doDump(dump)
       await filesToDownloadXPath.flush()
-      Downloader.cssDependenceUrls = {}
       logger.log('Finished dump')
     }
   }
@@ -410,6 +410,9 @@ async function execute(argv: any) {
     const outZim = path.resolve(dump.opts.outputDirectory, dump.computeFilenameRadical() + '.zim')
     logger.log(`Writing ZIM to [${outZim}]`)
     dump.outFile = outZim
+
+    // Reset FileManager for the new dump
+    FileManager.reset()
 
     const metadata = {
       ...metaDataRequiredKeys,
@@ -546,7 +549,7 @@ async function execute(argv: any) {
       }),
     )
 
-    await downloadFiles(filesToDownloadXPath, zimCreator, dump)
+    await FileManager.startDownloading(zimCreator, dump)
 
     logger.log('Writing Article Redirects')
     await writeArticleRedirects(dump, zimCreator)
@@ -752,7 +755,7 @@ async function execute(argv: any) {
     articleDetail.internalThumbnailUrl = getRelativeFilePath('Main_Page', getMediaBase(suitableResUrl, true))
 
     await Promise.all([
-      filesToDownloadXPath.set(path, { url: urlHelper.serializeUrl(suitableResUrl), mult, width, kind: 'image' } as FileDetail),
+      FileManager.addFileToProcess(path, { url: urlHelper.serializeUrl(suitableResUrl), mult, width, kind: 'image' } as FileDetail),
       articleDetailXId.set(articleId, articleDetail),
     ])
   }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -42,7 +42,7 @@ type ArticleDetail = PageInfo & {
   contentmodel?: string
 }
 
-type FileToDownload = FileDetail & {
+type FileToDownload = {
   path: string
   downloadAttempts: number
 }

--- a/src/util/FileManager.ts
+++ b/src/util/FileManager.ts
@@ -1,0 +1,281 @@
+import * as logger from '../Logger.js'
+import Downloader from '../Downloader.js'
+import RedisStore from '../RedisStore.js'
+import { Creator, StringItem } from '@openzim/libzim'
+import pmap from 'p-map'
+import { Dump } from '../Dump.js'
+import { parseRetryAfterHeader } from './misc.js'
+import { FILES_DOWNLOAD_FAILURE_MINIMUM_FOR_CHECK, FILES_DOWNLOAD_FAILURE_TRESHOLD_PER_TEN_THOUSAND, MAX_FILE_DOWNLOAD_RETRIES } from './const.js'
+import urlHelper from './url.helper.js'
+import { fileDownloadMutex, zimCreatorMutex } from '../mutex.js'
+import RedisQueue from './RedisQueue.js'
+
+const MAXIMUM_FILE_DOWNLOAD_DELAY = 20000
+
+interface HostData {
+  queue: RedisQueue<FileToDownload>
+  lastRequestDate?: number
+  requestInterval: number
+  notBeforeDate?: number
+  downloadSuccess: number
+  downloadFailure: number
+  downloadsComplete: boolean
+}
+
+class FileManager {
+  private static instance: FileManager
+  public static getInstance() {
+    if (!FileManager.instance) {
+      FileManager.instance = new FileManager()
+    }
+    return FileManager.instance
+  }
+
+  private hosts: Map<string, HostData> = new Map()
+
+  private get filesToDownloadXPath(): RKVS<FileDetail> {
+    return RedisStore.filesToDownloadXPath
+  }
+
+  private constructor() {}
+
+  /**
+   * Reset internal state for a new dump cycle.
+   */
+  public reset(): void {
+    this.hosts = new Map()
+  }
+
+  /**
+   * Add a single file to download. Checks dedup via filesToDownloadXPath.
+   * On first add: writes to both filesToDownloadXPath and host queue.
+   * On resolution upgrade: updates filesToDownloadXPath only (queue already has the path).
+   *
+   * This method is typically called multiple times when the file is an image and the scraper detects
+   * a second use of an image already seen but with a higher resolution. Could be that we call this
+   * method twice with different urls / data for other usage in the future.
+   */
+  public async addFileToProcess(path: string, detail: FileDetail): Promise<void> {
+    const existing = await this.filesToDownloadXPath.get(path)
+    if (existing) {
+      const isHigherRes = existing.width < (detail.width || 10e6) || existing.mult < (detail.mult || 1)
+      if (!isHigherRes) return
+      // Resolution upgrade: update store only, queue already has this path
+      await this.filesToDownloadXPath.set(path, detail)
+      return
+    }
+    // New file: add to both store and host queue
+    await this.filesToDownloadXPath.set(path, detail)
+    await this.pushToHostQueue(path, detail)
+  }
+
+  /**
+   * Batch version of addFileToProcess. Uses getMany for efficiency.
+   */
+  public async addManyFilesToProcess(files: KVS<FileDetail>): Promise<void> {
+    const paths = Object.keys(files)
+    if (!paths.length) return
+
+    const existingVals = await this.filesToDownloadXPath.getMany(paths)
+    const toSet: KVS<FileDetail> = {}
+
+    for (const [path, detail] of Object.entries(files)) {
+      const existing = existingVals[path]
+      if (existing) {
+        const isHigherRes = existing.width < (detail.width || 10e6) || existing.mult < (detail.mult || 1)
+        if (!isHigherRes) continue
+        toSet[path] = detail // upgrade only, no queue push
+      } else {
+        toSet[path] = detail
+        await this.pushToHostQueue(path, detail)
+      }
+    }
+
+    if (Object.keys(toSet).length) {
+      await this.filesToDownloadXPath.setMany(toSet)
+    }
+  }
+
+  private async pushToHostQueue(path: string, detail: FileDetail): Promise<void> {
+    const hostname = new URL(urlHelper.deserializeUrl(detail.url)).hostname
+    if (!this.hosts.has(hostname)) {
+      const queue = new RedisQueue<FileToDownload>(RedisStore.client, `${hostname}-files`)
+      await queue.flush()
+      RedisStore.filesQueues.push(queue)
+      this.hosts.set(hostname, {
+        queue,
+        requestInterval: 30,
+        downloadSuccess: 0,
+        downloadFailure: 0,
+        downloadsComplete: false,
+      })
+    }
+    await this.hosts.get(hostname).queue.push({
+      path,
+      downloadAttempts: 0,
+    })
+  }
+
+  /**
+   * Start download workers. Queues are already populated via addFileToProcess/addManyFilesToProcess.
+   */
+  public async startDownloading(zimCreator: Creator, dump: Dump): Promise<void> {
+    const filesTotal = await this.filesToDownloadXPath.len()
+    let prevPercentProgress: string
+
+    const hosts = this.hosts
+    const filesToDownloadXPath = this.filesToDownloadXPath
+
+    async function getNextFileToDownload(): Promise<{ fileToDownload: FileToDownload; hostData: HostData; hostname: string }> {
+      const startPolling = Date.now()
+      while (true) {
+        if (startPolling + 1000 * 60 * 60 < Date.now()) {
+          logger.warn('No file to download for more than 1 hour, exiting the loop')
+          for (const hostData of hosts.values()) {
+            if (hostData.downloadsComplete) continue
+            while (await hostData.queue.pop()) {
+              dump.status.files.fail += 1
+              if (
+                dump.status.files.fail > FILES_DOWNLOAD_FAILURE_MINIMUM_FOR_CHECK &&
+                (dump.status.files.fail * 10000) / filesTotal > FILES_DOWNLOAD_FAILURE_TRESHOLD_PER_TEN_THOUSAND
+              ) {
+                throw new Error(`Too many files failed to download: [${dump.status.files.fail}/${filesTotal}]`)
+              }
+            }
+          }
+          return null
+        }
+
+        const hostValues = Array.from(hosts.values())
+        const completedHosts = hostValues.reduce((buf, host) => {
+          return host.downloadsComplete ? buf + 1 : buf
+        }, 0)
+        if (completedHosts === hostValues.length) return null
+
+        for (const [hostname, hostData] of hosts.entries()) {
+          if (
+            hostData.downloadsComplete ||
+            (hostData.notBeforeDate && hostData.notBeforeDate > Date.now()) ||
+            (hostData.lastRequestDate && hostData.lastRequestDate + hostData.requestInterval > Date.now())
+          ) {
+            continue
+          }
+
+          const fileToDownload = await hostData.queue.pop()
+          if (!fileToDownload) {
+            hostData.downloadsComplete = true
+            continue
+          }
+
+          hostData.lastRequestDate = Date.now()
+          return { fileToDownload, hostData, hostname }
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      }
+    }
+
+    async function workerDownloadFile(fileToDownload: FileToDownload, hostname: string, hostData: HostData, workerId: number) {
+      if ((dump.status.files.success + dump.status.files.fail) % (10 * Downloader.speed) === 0) {
+        const percentProgress = (((dump.status.files.success + dump.status.files.fail) / filesTotal) * 100).toFixed(1)
+        if (percentProgress !== prevPercentProgress) {
+          prevPercentProgress = percentProgress
+          logger.log(`Progress downloading files [${dump.status.files.success + dump.status.files.fail}/${filesTotal}] [${percentProgress}%]`)
+        }
+        if (
+          filesTotal > 0 &&
+          dump.status.files.fail > FILES_DOWNLOAD_FAILURE_MINIMUM_FOR_CHECK &&
+          (dump.status.files.fail * 10000) / filesTotal > FILES_DOWNLOAD_FAILURE_TRESHOLD_PER_TEN_THOUSAND
+        ) {
+          throw new Error(`Too many files failed to download: [${dump.status.files.fail}/${filesTotal}]`)
+        }
+      }
+
+      fileToDownload.downloadAttempts += 1
+
+      // Read latest details from filesToDownloadXPath (resolution may have been upgraded since queuing)
+      const latestDetail = await filesToDownloadXPath.get(fileToDownload.path)
+
+      if (!latestDetail) {
+        logger.warn(`File details missing in RedisStore for path [${fileToDownload.path}], unable to download`)
+        dump.status.files.fail += 1
+        hostData.downloadFailure += 1
+        return
+      }
+
+      const downloadUrl = latestDetail.url
+      const downloadKind = latestDetail.kind
+      const downloadWidth = latestDetail.width
+
+      logger.info(`Worker ${workerId} downloading ${urlHelper.deserializeUrl(downloadUrl)} (${downloadKind})`)
+      await Downloader.downloadContent(downloadUrl, downloadKind, false, downloadWidth)
+        .then(async (resp) => {
+          if (resp && resp.content && resp.contentType) {
+            const item = new StringItem(fileToDownload.path, resp.contentType, null, { FRONT_ARTICLE: 0 }, resp.content)
+            await zimCreatorMutex.runExclusive(() => zimCreator.addItem(item))
+            dump.status.files.success += 1
+            hostData.downloadSuccess += 1
+          } else {
+            throw new Error(`Bad response received: ${resp}`)
+          }
+        })
+        .catch(async (err) => {
+          const isRetriableTransportError = !!(err?.response || err?.code)
+          if (!isRetriableTransportError) {
+            logger.warn(`Error processing file [${urlHelper.deserializeUrl(downloadUrl)}], skipping without retry`, err)
+            dump.status.files.fail += 1
+            hostData.downloadFailure += 1
+            return
+          }
+          if (fileToDownload.downloadAttempts > MAX_FILE_DOWNLOAD_RETRIES || (err.response && err.response.status === 404)) {
+            logger.warn(`Error downloading file [${urlHelper.deserializeUrl(downloadUrl)}] [status=${err.response?.status}], skipping`)
+            dump.status.files.fail += 1
+            hostData.downloadFailure += 1
+          } else {
+            if (err.response) {
+              const retryAfterHeader = err.response.headers['retry-after']?.toString()
+              if (retryAfterHeader) {
+                const retryDate = parseRetryAfterHeader(retryAfterHeader)
+                if (retryDate) {
+                  if (retryDate > Date.now() + MAXIMUM_FILE_DOWNLOAD_DELAY) {
+                    logger.log(`Received a [Retry-After=${retryAfterHeader}] on ${hostname} but this is too far away, ignoring`)
+                  } else {
+                    hostData.notBeforeDate = retryDate
+                    logger.log(`Received a [Retry-After=${retryAfterHeader}], pausing down ${hostname} until ${hostData.notBeforeDate}`)
+                  }
+                } else {
+                  logger.warn(`Received a [Retry-After=${retryAfterHeader}] from ${hostname} but failed to interpret it`)
+                }
+              }
+            }
+            if (err.response && [429, 503, 524].includes(err.response.status) && !urlHelper.deserializeUrl(downloadUrl).match(/^https?:\/\/upload\.wikimedia\.org\/.*\/thumb\//)) {
+              hostData.requestInterval = Math.min(MAXIMUM_FILE_DOWNLOAD_DELAY, hostData.requestInterval * 1.2)
+              logger.log(`Received a [status=${err.response.status}], slowing down ${hostname} to ${hostData.requestInterval}ms interval`)
+            }
+            await hostData.queue.push(fileToDownload)
+          }
+        })
+    }
+
+    await pmap(
+      Array.from({ length: Downloader.speed }, (_, i) => i),
+      async (workerId: number) => {
+        while (true) {
+          const nextFileData = await fileDownloadMutex.runExclusive(getNextFileToDownload)
+          if (!nextFileData) break
+          const { fileToDownload, hostname, hostData } = nextFileData
+          await workerDownloadFile(fileToDownload, hostname, hostData, workerId)
+        }
+      },
+      { concurrency: Downloader.speed },
+    )
+
+    logger.log(
+      `Done with downloading ${filesTotal} files: ${dump.status.files.success} success, ${dump.status.files.fail} fail: `,
+      JSON.stringify(Object.fromEntries([...hosts].map(([hostname, hostData]) => [hostname, { success: hostData.downloadSuccess, fail: hostData.downloadFailure }])), null, '\t'),
+    )
+  }
+}
+
+const fm = FileManager.getInstance()
+export default fm as FileManager

--- a/src/util/RedisQueue.ts
+++ b/src/util/RedisQueue.ts
@@ -25,7 +25,7 @@ export default class RedisQueue<T> {
   }
 
   public len(): Promise<number> {
-    return this.redisClient.hLen(this.dbName)
+    return this.redisClient.lLen(this.dbName)
   }
 
   public flush(): Promise<number> {

--- a/src/util/dump.ts
+++ b/src/util/dump.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'url'
 import * as logger from '../Logger.js'
 import Downloader from '../Downloader.js'
-import RedisStore from '../RedisStore.js'
+import FileManager from './FileManager.js'
 import { getFullUrl, jsPath, cssPath, getRelativeFilePath, getMediaBase } from './index.js'
 import { config } from '../config.js'
 import MediaWiki from '../MediaWiki.js'
@@ -19,7 +19,6 @@ export async function processStylesheetContent(cssUrl: string, linkMedia: string
   // articleId is supposed to be passed only when we rewrite inline CSS for a given article and we hence have
   // to compute relative path to assets
 
-  const { filesToDownloadXPath } = RedisStore
   const importRegexp = /@import\s+(?:url\(\s*(['"]?)(.*?)\1\s*\)|(['"])(.*?)\3)\s*([^;]*);/gi
   const cssUrlRegexp = new RegExp('url\\([\'"]{0,1}(.*?)[\'"]{0,1}\\)', 'gi')
 
@@ -47,7 +46,7 @@ export async function processStylesheetContent(cssUrl: string, linkMedia: string
     return `\n/* start ${url} */\n\n${wrappedCss}\n/* end   ${url} */\n`
   }
 
-  const rewriteCssDependencies = (sourceCss: string, sourceUrl: string) => {
+  const rewriteCssDependencies = async (sourceCss: string, sourceUrl: string) => {
     let rewrittenCss = sourceCss
     let match: any
 
@@ -63,11 +62,7 @@ export async function processStylesheetContent(cssUrl: string, linkMedia: string
         const relativePath = articleId ? getRelativeFilePath(articleId, filepath) : isJs ? `__RELATIVE_FILE_PATH__${filepath}` : `../${filepath}`
         rewrittenCss = rewrittenCss.replace(url, relativePath.replace(/'/g, '%27').replace(/\(/g, '%28').replace(/\)/g, '%29'))
 
-        /* Download CSS dependency, but avoid duplicate calls */
-        if (!Object.prototype.hasOwnProperty.call(Downloader.cssDependenceUrls, fullurl) && filepath) {
-          Downloader.cssDependenceUrls[fullurl] = true
-          filesToDownloadXPath.set(filepath, { url: urlHelper.serializeUrl(fullurl), kind: 'media' })
-        }
+        await FileManager.addFileToProcess(filepath, { url: urlHelper.serializeUrl(fullurl), kind: 'media' })
       }
     }
 
@@ -127,7 +122,7 @@ export async function processStylesheetContent(cssUrl: string, linkMedia: string
   const renderedImportedUrls = new Set<string>()
   const renderStack = new Set<string>()
 
-  const renderStylesheet = (url: string, conditions = ''): string => {
+  const renderStylesheet = async (url: string, conditions = ''): Promise<string> => {
     if (renderedImportedUrls.has(url)) {
       return ''
     }
@@ -145,9 +140,9 @@ export async function processStylesheetContent(cssUrl: string, linkMedia: string
     let currentBody = ''
     for (const part of parts) {
       if (part.type === 'css') {
-        currentBody += rewriteCssDependencies(part.text, url)
+        currentBody += await rewriteCssDependencies(part.text, url)
       } else {
-        currentBody += renderStylesheet(part.url, part.conditions)
+        currentBody += await renderStylesheet(part.url, part.conditions)
       }
     }
     renderStack.delete(url)
@@ -155,7 +150,7 @@ export async function processStylesheetContent(cssUrl: string, linkMedia: string
     return wrapStylesheetContent(currentBody, url, conditions)
   }
 
-  return renderStylesheet(cssUrl, linkMedia)
+  return await renderStylesheet(cssUrl, linkMedia)
 }
 
 export async function downloadModule(module: string, type: 'js' | 'css') {

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -3,238 +3,18 @@ import Downloader from '../Downloader.js'
 import RedisStore from '../RedisStore.js'
 import { Creator, StringItem } from '@openzim/libzim'
 
-import pmap from 'p-map'
 import * as domino from 'domino'
 import { Dump } from '../Dump.js'
 import Timer from './Timer.js'
 import { config } from '../config.js'
-import { getSizeFromUrl, parseRetryAfterHeader } from './misc.js'
-import { FILES_DOWNLOAD_FAILURE_MINIMUM_FOR_CHECK, FILES_DOWNLOAD_FAILURE_TRESHOLD_PER_TEN_THOUSAND, MAX_FILE_DOWNLOAD_RETRIES } from './const.js'
+import { getSizeFromUrl } from './misc.js'
 import urlHelper from './url.helper.js'
 import { Renderer } from '../renderers/abstract.renderer.js'
 import RenderingContext from '../renderers/rendering.context.js'
-import { fileDownloadMutex, zimCreatorMutex } from '../mutex.js'
+import { zimCreatorMutex } from '../mutex.js'
+import FileManager from './FileManager.js'
 import { truncateUtf8Bytes } from './misc.js'
 import { isMainPage } from './articles.js'
-import RedisQueue from './RedisQueue.js'
-
-// Maximum delay between file download attempts on a given host
-// Default upload.wikimedia.org Retry-After value is 11 seconds
-const MAXIMUM_FILE_DOWNLOAD_DELAY = 20000
-
-export async function downloadFiles(fileStore: RKVS<FileDetail>, zimCreator: Creator, dump: Dump) {
-  interface HostData {
-    filesToDownload: RedisQueue<FileToDownload>
-    lastRequestDate?: number
-    requestInterval: number
-    notBeforeDate?: number
-    downloadSuccess: number
-    downloadFailure: number
-    downloadsComplete: boolean
-  }
-
-  let prevPercentProgress: string
-
-  // create structure + Redis queue to requests hosts in a responsible manner
-  const hosts = new Map<string, HostData>()
-  const filesTotal = await RedisStore.filesToDownloadXPath.len()
-
-  await RedisStore.filesToDownloadXPath.iterateItems(1, async (filesToDownload: KVS<FileDetail>) => {
-    for (const [path, { url, mult, width, kind }] of Object.entries(filesToDownload)) {
-      const hostname = new URL(urlHelper.deserializeUrl(url)).hostname
-      if (!hosts.has(hostname)) {
-        const filesToDownload = new RedisQueue<FileToDownload>(RedisStore.client, `${hostname}-files`)
-        RedisStore.filesQueues.push(filesToDownload)
-        await filesToDownload.flush()
-        hosts.set(hostname, {
-          filesToDownload,
-          requestInterval: 30, // initial request interval is 30 ms
-          downloadSuccess: 0,
-          downloadFailure: 0,
-          downloadsComplete: false,
-        })
-      }
-      hosts.get(hostname).filesToDownload.push({
-        path: path,
-        url: url,
-        mult: mult,
-        width: width,
-        kind: kind,
-        downloadAttempts: 0,
-      })
-    }
-  })
-
-  await RedisStore.filesToDownloadXPath.flush()
-
-  /**
-   * Return next file ready to download or wait if all hosts need to make a pause.
-   * Return null when there is no more file to download.
-   */
-  async function getNextFileToDownload(): Promise<{ fileToDownload: FileToDownload; hostData: HostData; hostname: string }> {
-    const startPolling = Date.now()
-    // loop until we've found a file to download or list is empty
-    while (true) {
-      // ensure we are not in a dead loop forever (1 hour is way too much, but this is a safety net anyway)
-      if (startPolling + 1000 * 60 * 60 < Date.now()) {
-        logger.warn('No file to download for more than 1 hour, exiting the loop')
-        for (const hostData of hosts.values()) {
-          if (hostData.downloadsComplete) {
-            continue
-          }
-          while (await hostData.filesToDownload.pop()) {
-            dump.status.files.fail += 1
-            if (
-              filesTotal > 0 &&
-              dump.status.files.fail > FILES_DOWNLOAD_FAILURE_MINIMUM_FOR_CHECK &&
-              (dump.status.files.fail * 10000) / filesTotal > FILES_DOWNLOAD_FAILURE_TRESHOLD_PER_TEN_THOUSAND
-            ) {
-              throw new Error(`Too many files failed to download: [${dump.status.files.fail}/${filesTotal}]`)
-            }
-          }
-        }
-        return null
-      }
-      // check if all donwloads have completed and exit
-      const hostValues = Array.from(hosts.values())
-      const completedHosts = hostValues.reduce((buf, host) => {
-        return host.downloadsComplete ? buf + 1 : buf
-      }, 0)
-      if (completedHosts === hostValues.length) {
-        return null
-      }
-
-      for (const [hostname, hostData] of hosts.entries()) {
-        // check conditions which leads to ignore current host
-        if (
-          hostData.downloadsComplete ||
-          (hostData.notBeforeDate && hostData.notBeforeDate > Date.now()) ||
-          (hostData.lastRequestDate && hostData.lastRequestDate + hostData.requestInterval > Date.now())
-        ) {
-          continue
-        }
-
-        // grab next item from Redis queue
-        const fileToDownload = await hostData.filesToDownload.pop()
-        if (!fileToDownload) {
-          hostData.downloadsComplete = true
-          continue
-        }
-
-        // modify lastRequestDate immediately so that all workers are aware
-        hostData.lastRequestDate = Date.now()
-        return { fileToDownload, hostData, hostname }
-      }
-
-      // pause few milliseconds, no host has something to process (just to not burn CPU)
-      await new Promise((resolve) => {
-        setTimeout(resolve, 10)
-      })
-    }
-  }
-
-  /**
-   * Really try to download one file, handling potential errors received to slow down host, stop scraper, ignore failed file
-   * @param fileToDownload information about the file to download
-   * @param hostname hostname to process
-   * @param hostData data about the host to process
-   * @param workerId ID of worker currently processing this download
-   */
-  async function workerDownloadFile(fileToDownload: FileToDownload, hostname: string, hostData: HostData, workerId: number) {
-    if ((dump.status.files.success + dump.status.files.fail) % (10 * Downloader.speed) === 0) {
-      const percentProgress = (((dump.status.files.success + dump.status.files.fail) / filesTotal) * 100).toFixed(1)
-      if (percentProgress !== prevPercentProgress) {
-        prevPercentProgress = percentProgress
-        logger.log(`Progress downloading files [${dump.status.files.success + dump.status.files.fail}/${filesTotal}] [${percentProgress}%]`)
-      }
-      if (
-        filesTotal > 0 &&
-        dump.status.files.fail > FILES_DOWNLOAD_FAILURE_MINIMUM_FOR_CHECK &&
-        (dump.status.files.fail * 10000) / filesTotal > FILES_DOWNLOAD_FAILURE_TRESHOLD_PER_TEN_THOUSAND
-      ) {
-        throw new Error(`Too many files failed to download: [${dump.status.files.fail}/${filesTotal}]`)
-      }
-    }
-
-    fileToDownload.downloadAttempts += 1
-    logger.info(`Worker ${workerId} downloading ${urlHelper.deserializeUrl(fileToDownload.url)} (${fileToDownload.kind})`)
-    await Downloader.downloadContent(fileToDownload.url, fileToDownload.kind, false, fileToDownload.width)
-      .then(async (resp) => {
-        if (resp && resp.content && resp.contentType) {
-          // { FRONT_ARTICLE: 0 } is here very important, should we retrieve HTML we want to be sure the libzim will
-          // not consider it for title index
-          const item = new StringItem(fileToDownload.path, resp.contentType, null, { FRONT_ARTICLE: 0 }, resp.content)
-          await zimCreatorMutex.runExclusive(() => zimCreator.addItem(item))
-          dump.status.files.success += 1
-          hostData.downloadSuccess += 1
-        } else {
-          throw new Error(`Bad response received: ${resp}`)
-        }
-      })
-      .catch(async (err) => {
-        const isRetriableTransportError = !!(err?.response || err?.code)
-        if (!isRetriableTransportError) {
-          logger.warn(`Error processing file [${urlHelper.deserializeUrl(fileToDownload.url)}], skipping without retry`, err)
-          dump.status.files.fail += 1
-          hostData.downloadFailure += 1
-          return
-        }
-        if (fileToDownload.downloadAttempts > MAX_FILE_DOWNLOAD_RETRIES || (err.response && err.response.status === 404)) {
-          logger.warn(`Error downloading file [${urlHelper.deserializeUrl(fileToDownload.url)}] [status=${err.response?.status}], skipping`)
-          dump.status.files.fail += 1
-          hostData.downloadFailure += 1
-        } else {
-          if (err.response) {
-            const retryAfterHeader = err.response.headers['retry-after']?.toString()
-            if (retryAfterHeader) {
-              const retryDate = parseRetryAfterHeader(retryAfterHeader)
-              if (retryDate) {
-                if (retryDate > Date.now() + MAXIMUM_FILE_DOWNLOAD_DELAY) {
-                  logger.log(`Received a [Retry-After=${retryAfterHeader}] on ${hostname} but this is too far away, ignoring`)
-                } else {
-                  hostData.notBeforeDate = retryDate
-                  logger.log(`Received a [Retry-After=${retryAfterHeader}], pausing down ${hostname} until ${hostData.notBeforeDate}`)
-                }
-              } else {
-                logger.warn(`Received a [Retry-After=${retryAfterHeader}] from ${hostname} but failed to interpret it`)
-              }
-            }
-          }
-          // slow down except for wikimedia thumbnails whose server is known to be lying (see https://github.com/openzim/mwoffliner/issues/2572)
-          if (
-            err.response &&
-            [429, 503, 524].includes(err.response.status) &&
-            !urlHelper.deserializeUrl(fileToDownload.url).match(/^https?:\/\/upload\.wikimedia\.org\/.*\/thumb\//)
-          ) {
-            hostData.requestInterval = Math.min(MAXIMUM_FILE_DOWNLOAD_DELAY, hostData.requestInterval * 1.2) // 1.2 is arbitrary value to progressively slow requests to host down
-            logger.log(`Received a [status=${err.response.status}], slowing down ${hostname} to ${hostData.requestInterval}ms interval`)
-          }
-          await hostData.filesToDownload.push(fileToDownload)
-        }
-      })
-  }
-
-  await pmap(
-    Array.from({ length: Downloader.speed }, (_, i) => i),
-    async (workerId: number) => {
-      while (true) {
-        // get next file to download in a Mutex (we do not want two workers trying to get next file at same time
-        // since we need to take into account limits per hostname, so this getNextFileToDownload will update
-        // data about load per host)
-        const nextFileData = await fileDownloadMutex.runExclusive(getNextFileToDownload)
-        if (!nextFileData) break
-        const { fileToDownload, hostname, hostData } = nextFileData
-        await workerDownloadFile(fileToDownload, hostname, hostData, workerId)
-      }
-    },
-    { concurrency: Downloader.speed },
-  )
-
-  logger.log(
-    `Done with downloading ${filesTotal} files: ${dump.status.files.success} success, ${dump.status.files.fail} fail: `,
-    JSON.stringify(Object.fromEntries([...hosts].map(([hostname, hostData]) => [hostname, { success: hostData.downloadSuccess, fail: hostData.downloadFailure }])), null, '\t'),
-  )
-}
 
 async function getAllArticlesToKeep(articleDetailXId: RKVS<ArticleDetail>, dump: Dump, articlesRenderer: Renderer) {
   await articleDetailXId.iterateItems(Downloader.speed, async (articleKeyValuePairs) => {
@@ -291,71 +71,38 @@ async function saveArticle(
   articleTitle: string,
 ): Promise<Error> {
   try {
-    const filesToDownload: KVS<FileDetail> = {}
+    const articleFiles: KVS<FileDetail> = {}
 
     if (subtitles?.length > 0) {
       subtitles.forEach((s) => {
-        filesToDownload[s.path] = { url: s.url, kind: 'subtitle' }
+        articleFiles[s.path] = { url: s.url, kind: 'subtitle' }
       })
     }
 
     if (mediaDependencies && mediaDependencies.length) {
-      const existingVals = await RedisStore.filesToDownloadXPath.getMany(mediaDependencies.map((dep) => dep.path))
-
       for (const dep of mediaDependencies) {
         const { mult, width } = getSizeFromUrl(dep.url)
-        const existingVal = existingVals[dep.path]
-        const currentDepIsHigherRes = !existingVal || existingVal.width < (width || 10e6) || existingVal.mult < (mult || 1)
-        if (currentDepIsHigherRes) {
-          filesToDownload[dep.path] = {
-            url: urlHelper.serializeUrl(dep.url),
-            kind: 'media',
-            mult,
-            width,
-          }
-        }
+        articleFiles[dep.path] = { url: urlHelper.serializeUrl(dep.url), kind: 'media', mult, width }
       }
     }
 
     if (imageDependencies && imageDependencies.length) {
-      const existingVals = await RedisStore.filesToDownloadXPath.getMany(imageDependencies.map((dep) => dep.path))
-
       for (const dep of imageDependencies) {
         const urlSize = getSizeFromUrl(dep.url)
         const width = dep.width || urlSize.width
         const mult = urlSize.mult
-        const existingVal = existingVals[dep.path]
-        const currentDepIsHigherRes = !existingVal || existingVal.width < (width || 10e6) || existingVal.mult < (mult || 1)
-        if (currentDepIsHigherRes) {
-          filesToDownload[dep.path] = {
-            url: urlHelper.serializeUrl(dep.url),
-            kind: 'image',
-            mult,
-            width,
-          }
-        }
+        articleFiles[dep.path] = { url: urlHelper.serializeUrl(dep.url), kind: 'image', mult, width }
       }
     }
 
     if (videoDependencies && videoDependencies.length) {
-      const existingVals = await RedisStore.filesToDownloadXPath.getMany(videoDependencies.map((dep) => dep.path))
-
       for (const dep of videoDependencies) {
         const { mult, width } = getSizeFromUrl(dep.url)
-        const existingVal = existingVals[dep.path]
-        const currentDepIsHigherRes = !existingVal || existingVal.width < (width || 10e6) || existingVal.mult < (mult || 1)
-        if (currentDepIsHigherRes) {
-          filesToDownload[dep.path] = {
-            url: urlHelper.serializeUrl(dep.url),
-            kind: 'video',
-            mult,
-            width,
-          }
-        }
+        articleFiles[dep.path] = { url: urlHelper.serializeUrl(dep.url), kind: 'video', mult, width }
       }
     }
 
-    await RedisStore.filesToDownloadXPath.setMany(filesToDownload)
+    await FileManager.addManyFilesToProcess(articleFiles)
 
     const zimArticle = new StringItem(articleId, 'text/html', truncateUtf8Bytes(articleTitle, 245), { FRONT_ARTICLE: 1 }, finalHTML)
     await zimCreatorMutex.runExclusive(() => zimCreator.addItem(zimArticle))

--- a/test/unit/bootstrap.ts
+++ b/test/unit/bootstrap.ts
@@ -4,6 +4,7 @@
 import 'dotenv/config'
 import RedisStore from '../../src/RedisStore.js'
 import { config } from '../../src/config.js'
+import FileManager from '../../src/util/FileManager.js'
 
 RedisStore.setOptions(process.env.REDIS || config.defaults.redisPath, { quitOnError: false })
 
@@ -11,6 +12,7 @@ export const startRedis = async () => {
   await RedisStore.connect()
   const { articleDetailXId, redirectsXId, filesToDownloadXPath, filesQueues } = RedisStore
   await Promise.all([articleDetailXId.flush(), redirectsXId.flush(), filesToDownloadXPath.flush(), ...filesQueues.map((queue) => queue.flush())])
+  FileManager.reset()
 }
 
 export const stopRedis = async () => {

--- a/test/unit/util/dump.test.ts
+++ b/test/unit/util/dump.test.ts
@@ -6,14 +6,16 @@ import { downloadModule, processStylesheetContent } from '../../../src/util/dump
 import RedisStore from '../../../src/RedisStore.js'
 import urlHelper from '../../../src/util/url.helper.js'
 import { jest } from '@jest/globals'
+import FileManager from '../../../src/util/FileManager.js'
 
 describe('Download CSS or JS Module', () => {
   beforeAll(startRedis)
   afterAll(stopRedis)
 
-  beforeEach(() => {
+  beforeEach(async () => {
     const { filesToDownloadXPath } = RedisStore
-    filesToDownloadXPath.flush()
+    await filesToDownloadXPath.flush()
+    FileManager.reset()
     MediaWiki.base = 'https://en.wikipedia.org'
     Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
   })
@@ -27,10 +29,9 @@ describe('Download CSS or JS Module', () => {
     // Check if CSS module still contain this background image
     expect(content).toContain(`background-image:url(../_assets_/4bcf8483172f7467f47867020b95783b/link-external-small-ltr-progressive.svg`)
 
-    // One SVG (among others) expected to be used inside the CSS
-    expect(Object.keys(Downloader.cssDependenceUrls)).toContain(
-      'https://en.wikipedia.org/w/skins/Vector/resources/skins.vector.styles/images/link-external-small-ltr-progressive.svg?fb64d',
-    )
+    // One SVG (among others) expected to be tracked in filesToDownloadXPath
+    const keys = await RedisStore.filesToDownloadXPath.keys()
+    expect(keys).toContain('_assets_/4bcf8483172f7467f47867020b95783b/link-external-small-ltr-progressive.svg')
   })
 
   test('rewrite standalone CSS', async () => {
@@ -209,7 +210,8 @@ describe('Download CSS or JS Module', () => {
     // The url(images/icon.png) in imported.css should be resolved relative to
     // https://example.wiki/css/imported.css, giving https://example.wiki/css/images/icon.png
     expect(rewrittenCSS).toContain('_assets_/')
-    expect(Object.keys(Downloader.cssDependenceUrls)).toContain('https://example.wiki/css/images/icon.png')
+    const keys = await RedisStore.filesToDownloadXPath.keys()
+    expect(keys.some((k) => k.includes('icon.png'))).toBe(true)
 
     downloadSpy.mockRestore()
   })


### PR DESCRIPTION
Follow-up to discussion in [#2674 (comment)](https://github.com/openzim/mwoffliner/pull/2674#pullrequestreview-4019512661).

Extracts the `downloadFiles` block from `saveArticles.ts` into a dedicated `FileManager` class. 

File discovery (CSS images, thumbnails, article media) now pushes files inline. They are deduplicated and queued during discovery, instead of batching everything at the end of the dump.

* Removes `Downloader.cssDependenceUrls` cache. Redis is now the sole source of truth for CSS dependencies.
* Flushes per-host Redis queues immediately upon creation to ensure clean per-host queue state for the dump.
* Adds `addManyFilesToProcess` primitive for batched article media pushes.