### PR TITLE
fix: use single article list entry as ZIM main page.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,5 @@
 Unreleased:
+* FIX: Use single article as ZIM main page when articleList contains only one entry (@kunalsiyag #1891)
 * FIX: Fix fire-and-forget async patterns and file download accounting bugs (@triemerge #2681)
 * FIX: Avoid retrying non-transport processing errors (@triemerge #2685)
 * FIX: Preserve inline data: URL images instead of rewriting them (@nishantharkut #2670)

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -318,6 +318,14 @@ async function execute(argv: any) {
       logger.error(`Failed to read articleList from [${articleList}]`, err)
       throw err
     }
+
+    // When the article list contains exactly one article and no custom main
+    // page was provided, use that article as the ZIM main page directly
+    //(#1891)
+    if (articleListLines.length === 1 && !customMainPage) {
+      mainPage = articleListLines[0].replace(/ /g, '_')
+      logger.log(`Using single article list entry as main page: ${mainPage}`)
+    }
   }
 
   const allowedContentModels = ['wikitext', ...addContentModels]


### PR DESCRIPTION
Fixes #1891
<hr/>
The issue was that ` mainPage = articleList ? '' : mwMetaData.mainPage` was unconditionally blanking mainPage whenever an articleList was provided. This triggered a cascade that forced the creation of a synthetic index page (createIndexPage) even when a single, valid article was targeted.


<b>The Fix</b>
After parsing the article list, we now re-evaluate mainPage. If the list contains exactly one entry and no customMainPage is set, we assign that entry as the mainPage.

```
if (articleListLines.length === 1 && !customMainPage) {
  mainPage = articleListLines[0].replace(/ /g, '_')
  logger.log(`Using single article list entry as main page: ${mainPage}`)
}
```

ZIMs with a single-article list now correctly open to that article instead of a generated index.

Follows the implementation as suggested by @benoit74.

<b>Validation:</b>
Created a zim file with the command:  
        ```npx mwoffliner \
          --mwUrl=https:en.wikivoyage.org \
          --adminEmail=mail@mail.com \
          --articleList=Main_Page ```

and after that passed it a article list with 3 article names
to test it out and it was as expected.
a) Main_Page passed directly or the list contains only 1 item : we assign that entry as the mainPage.
b) When multiple items are present in the list: synthetic index generated.
<img width="759" height="186" alt="image" src="https://github.com/user-attachments/assets/fc34cf10-b9ce-4899-ba64-9c53e4852ca8" />
