### PR TITLE
Remove Jest stack trace decoration from E2E test logs

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -23,6 +23,7 @@ Unreleased:
 * NEW: Add `--customCss` CLI option to inject custom stylesheets
 * FIX: Detect continuation cycles in article pagination (@triemerge #2532)
 * FIX: Refactor file download pipeline to inline host queueing (@triemerge #2689)
+* FIX: Remove Jest stack trace decoration from E2E test logs (@triemerge #2038)
 
 
 1.17.5:

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,3 +1,5 @@
+import { format } from 'util'
+
 export const logLevels = ['info', 'log', 'warn', 'error', 'quiet']
 export type LogLevel = (typeof logLevels)[number]
 
@@ -15,7 +17,7 @@ const isVerbose = (level: LogLevel) => {
 
 const doLog = (type: LogLevel, args: any[]) => {
   if (isVerbose(type)) {
-    console[type](`[${type}] [${getTs()}]`, ...args)
+    process.stdout.write(format(`[${type}] [${getTs()}]`, ...args) + '\n')
   }
 }
 

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -425,7 +425,7 @@ async function execute(argv: any) {
     }
     validateMetadata(metadata)
 
-    const zimCreator = new Creator().configCompression(Compression.Zstd)
+    const zimCreator = new Creator().configCompression(Compression.Zstd).configVerbose(verbose === 'info' || verbose === true)
     if (!dump.opts.withoutZimFullTextIndex) {
       zimCreator.configIndexing(true, dump.mwMetaData.langIso3)
     }

--- a/test/testRenders.ts
+++ b/test/testRenders.ts
@@ -63,6 +63,7 @@ export async function testRenders(testName: string, parameters: Parameters, call
     try {
       const now = new Date()
       const testId = `mwo-test-${testName}-${renderer}-${+now}`
+      process.stdout.write(`\n${'='.repeat(60)}\n  TEST: ${testName} [${renderer}]\n${'='.repeat(60)}\n`)
       const outFiles = (await getOutFiles(renderer, testId, parameters)) as TestDump[]
       outFiles[0].testId = testId
       outFiles[0].renderer = renderer

--- a/test/unit/logger.test.ts
+++ b/test/unit/logger.test.ts
@@ -2,28 +2,14 @@ import * as logger from '../../src/Logger.js'
 import { jest } from '@jest/globals'
 
 describe('Logger', () => {
-  let info
-  let log
-  let warn
-  let error
+  let stdoutSpy: ReturnType<typeof jest.spyOn>
 
   afterEach(() => {
     jest.clearAllMocks()
   })
 
   beforeEach(() => {
-    info = jest.spyOn(console, 'info').mockImplementation(() => {
-      return
-    })
-    log = jest.spyOn(console, 'log').mockImplementation(() => {
-      return
-    })
-    warn = jest.spyOn(console, 'warn').mockImplementation(() => {
-      return
-    })
-    error = jest.spyOn(console, 'error').mockImplementation(() => {
-      return
-    })
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true)
   })
 
   test('logger info level', async () => {
@@ -34,10 +20,11 @@ describe('Logger', () => {
     logger.warn('test warn', 'warn test message')
     logger.error('test error', 'error test message')
 
-    expect(info).toBeCalledWith(expect.any(String), 'test info', 'info test message')
-    expect(log).toBeCalledWith(expect.any(String), 'test log', 'log test message')
-    expect(warn).toBeCalledWith(expect.any(String), 'test warn', 'warn test message')
-    expect(error).toBeCalledWith(expect.any(String), 'test error', 'error test message')
+    expect(stdoutSpy).toHaveBeenCalledTimes(4)
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[info]'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[log]'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[warn]'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[error]'))
   })
 
   test('logger log level', async () => {
@@ -48,10 +35,11 @@ describe('Logger', () => {
     logger.warn('test warn', 'warn test message')
     logger.error('test error', 'error test message')
 
-    expect(info).not.toBeCalled()
-    expect(log).toBeCalledWith(expect.any(String), 'test log', 'log test message')
-    expect(warn).toBeCalledWith(expect.any(String), 'test warn', 'warn test message')
-    expect(error).toBeCalledWith(expect.any(String), 'test error', 'error test message')
+    expect(stdoutSpy).toHaveBeenCalledTimes(3)
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('[info]'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[log]'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[warn]'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[error]'))
   })
 
   test('logger warn level', async () => {
@@ -62,10 +50,11 @@ describe('Logger', () => {
     logger.warn('test warn', 'warn test message')
     logger.error('test error', 'error test message')
 
-    expect(info).not.toBeCalled()
-    expect(log).not.toBeCalled()
-    expect(warn).toBeCalledWith(expect.any(String), 'test warn', 'warn test message')
-    expect(error).toBeCalledWith(expect.any(String), 'test error', 'error test message')
+    expect(stdoutSpy).toHaveBeenCalledTimes(2)
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('[info]'))
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('[log]'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[warn]'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[error]'))
   })
 
   test('logger error level', async () => {
@@ -76,10 +65,11 @@ describe('Logger', () => {
     logger.warn('test warn', 'warn test message')
     logger.error('test error', 'error test message')
 
-    expect(info).not.toBeCalled()
-    expect(log).not.toBeCalled()
-    expect(warn).not.toBeCalled()
-    expect(error).toBeCalledWith(expect.any(String), 'test error', 'error test message')
+    expect(stdoutSpy).toHaveBeenCalledTimes(1)
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('[info]'))
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('[log]'))
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('[warn]'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[error]'))
   })
 
   test('logger verbose true', async () => {
@@ -90,10 +80,11 @@ describe('Logger', () => {
     logger.warn('test warn', 'warn test message')
     logger.error('test error', 'error test message')
 
-    expect(info).toBeCalledWith(expect.any(String), 'test info', 'info test message')
-    expect(log).toBeCalledWith(expect.any(String), 'test log', 'log test message')
-    expect(warn).toBeCalledWith(expect.any(String), 'test warn', 'warn test message')
-    expect(error).toBeCalledWith(expect.any(String), 'test error', 'error test message')
+    expect(stdoutSpy).toHaveBeenCalledTimes(4)
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[info]'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[log]'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[warn]'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[error]'))
   })
 
   test('logger verbose empty', async () => {
@@ -104,9 +95,15 @@ describe('Logger', () => {
     logger.warn('test warn', 'warn test message')
     logger.error('test error', 'error test message')
 
-    expect(info).not.toBeCalled()
-    expect(log).not.toBeCalled()
-    expect(warn).not.toBeCalled()
-    expect(error).not.toBeCalled()
+    expect(stdoutSpy).not.toHaveBeenCalled()
+  })
+
+  test('logger message format includes args', async () => {
+    logger.setVerboseLevel('info')
+
+    logger.info('test info', 'info test message')
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('test info'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('info test message'))
   })
 })


### PR DESCRIPTION
Fix #2038

Jest was decorating logger calls with stack traces, making E2E output hard to read. Logger now writes directly to stdout using util.format, so logger lines stay plain and readable while keeping stdout behavior.

Instead of:
```
 console.warn
    [warn] [2026-04-03T11:50:31.216Z] Error downloading file [https://en.wikipedia.org/w/extensions/Kartographer/styles/images/grab.cur?b06c2] [status=404], skipping

      16 | const doLog = (type: LogLevel, args: any[]) => {
      17 |   if (isVerbose(type)) {
    > 18 |     console[type](`[${type}] [${getTs()}]`, ...args)
         |                  ^
      19 |   }
      20 | }
      21 |

      at doLog (src/Logger.ts:18:18)
      at Module.warn (src/Logger.ts:39:3)
      at src/util/saveArticles.ts:183:18
      at workerDownloadFile (src/util/saveArticles.ts:161:5)
      at pmap.concurrency (src/util/saveArticles.ts:227:9)
      at node_modules/p-map/index.js:121:20

  console.log
    [log] [2026-04-03T11:50:31.468Z] Progress downloading files [40/198] [20.2%]

      at doLog (src/Logger.ts:18:18)
```
we now have:
```
============================================================
  TEST: en-wikipedia [ActionParse]
============================================================

[warn] [2026-04-03T11:12:09.432Z] Error downloading file [https://en.wikipedia.org/w/extensions/Kartographer/styles/images/grab.cur?b06c2] [status=404], skipping
[log] [2026-04-03T11:12:09.557Z] Progress downloading files [40/198] [20.2%]
```

Also:
- Wires libzim verbosity to scraper verbosity with `Creator.configVerbose`
- Prints test-name separators in `testRenders` so E2E logs are easier to follow