### PR TITLE
Add CLI option to optionally prefer stable revisions (only FlaggedRevs-enabled wikis supported)

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,7 @@ Unreleased:
 * CHANGED: Create multiple files for language variants, similar to different formats (@Markus-Rost #2691)
 * CHANGED: Redesign speed to handle both worker count and request pacing (@triemerge #2393)
 * FIX: Fix file name detection for Wikimedia image urls (@Markus-Rost #2701)
+* NEW: Prefer stable (FlaggedRevs-reviewed) revisions when scraping with --stableRevision opt-in (@kunalsiyag #1587 #2072)
 * FIX: Use single article as ZIM main page when articleList contains only one entry (@kunalsiyag #1891)
 * FIX: Fix fire-and-forget async patterns and file download accounting bugs (@triemerge #2681)
 * FIX: Avoid retrying non-transport processing errors (@triemerge #2685)

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -699,7 +699,7 @@ class Downloader {
   }
 
   private async getArticleQueryOpts(includePageimages = false, followRedirects = false): Promise<QueryOpts> {
-    const prop = `${includePageimages ? '|pageimages' : ''}${(await MediaWiki.hasCoordinates()) ? '|coordinates' : ''}${MediaWiki.getCategories ? '|categories' : ''}`
+    const prop = `${includePageimages ? '|pageimages' : ''}${(await MediaWiki.hasCoordinates()) ? '|coordinates' : ''}${MediaWiki.getCategories ? '|categories' : ''}${(await MediaWiki.hasFlaggedRevs()) ? '|flagged' : ''}`
     return {
       ...MediaWiki.queryOpts,
       prop: MediaWiki.queryOpts.prop.concat(prop),

--- a/src/Dump.ts
+++ b/src/Dump.ts
@@ -23,6 +23,7 @@ interface DumpOpts {
   keepEmptySections: boolean
   tags?: string
   filenameDate: string
+  stableRevision?: boolean
 }
 
 export class Dump {

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -127,6 +127,7 @@ class MediaWiki {
   #hasActionParseApi: boolean | null
   #hasCoordinates: boolean | null
   #hasModuleApi: boolean | null
+  #hasFlaggedRevs: boolean | null
 
   set username(value: string) {
     this.#username = value
@@ -221,6 +222,7 @@ class MediaWiki {
     this.#hasActionParseApi = null
     this.#hasCoordinates = null
     this.#hasModuleApi = null
+    this.#hasFlaggedRevs = null
     this.metaData = null
   }
 
@@ -267,6 +269,25 @@ class MediaWiki {
       logger.log('Checked for Module API at', checkUrl, '-- result is: ', this.#hasModuleApi)
     }
     return this.#hasModuleApi
+  }
+
+  public async hasFlaggedRevs(): Promise<boolean> {
+    if (this.#hasFlaggedRevs === null) {
+      const reqOpts = {
+        ...this.queryOpts,
+        prop: 'info|flagged',
+        titles: this.apiCheckArticleId,
+      }
+      const resp = await Downloader.getJSON<MwApiResponse>(this.#apiUrlDirector.buildQueryURL(reqOpts))
+      const isFlaggedWarning = JSON.stringify(resp?.warnings?.query ?? '').includes('flagged')
+      if (isFlaggedWarning) {
+        logger.log('FlaggedRevs not available on this wiki')
+        return (this.#hasFlaggedRevs = false)
+      }
+      logger.log('FlaggedRevs available on this wiki')
+      return (this.#hasFlaggedRevs = true)
+    }
+    return this.#hasFlaggedRevs
   }
 
   private setModuleURL() {

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -103,6 +103,7 @@ async function execute(argv: any) {
     langVariant,
     customCss,
     userAgent: _userAgent,
+    stableRevision,
   } = argv
 
   let { articleList, articleListToIgnore } = argv
@@ -258,6 +259,10 @@ async function execute(argv: any) {
   await MediaWiki.hasActionParseApi()
   await MediaWiki.hasModuleApi()
 
+  if (stableRevision && !(await MediaWiki.hasFlaggedRevs())) {
+    throw new Error('--stableRevision was specified but this wiki does not support stable revisions (FlaggedRevs extension not found)')
+  }
+
   await RenderingContext.createRenderers(forceRender)
 
   await RedisStore.connect()
@@ -378,6 +383,7 @@ async function execute(argv: any) {
           keepEmptySections,
           tags: customZimTags,
           filenameDate,
+          stableRevision,
         },
         { ...mwMetaData, mainPage },
         customProcessor,
@@ -393,7 +399,6 @@ async function execute(argv: any) {
       } catch {
         shouldSkip = true
       }
-
       if (shouldSkip) {
         logger.log('Skipping dump')
       } else {

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -45,6 +45,7 @@ export const parameterDescriptions = {
   insecure: 'Skip HTTPS server authenticity verification step',
   customCss: 'Comma-separated list of CSS URLs to inject into all rendered pages',
   userAgent: 'Custom User-Agent header for all HTTP requests. Defaults to "MWOffliner/<version> (<adminEmail>)"',
+  stableRevision: 'Prefer stable articles revisions when available, based on FlaggedRevs extension (which needs to be active on the wiki).',
 }
 
 // TODO: Add an interface based on the object above

--- a/src/renderers/action-parse.renderer.ts
+++ b/src/renderers/action-parse.renderer.ts
@@ -177,7 +177,7 @@ export class ActionParseRenderer extends Renderer {
       styleDependenciesList: config.output.mw.css.concat(styleDependenciesList),
     }
 
-    const normalizedRedirects = data.parse.redirects.map((redirect) => {
+    const normalizedRedirects = (data.parse.redirects || []).map((redirect) => {
       // The API returns the redirect title (!?), we fake the
       // redirectId by putting the underscore.
       redirect.from = String(redirect.from).replace(/ /g, '_')

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -33,6 +33,7 @@ type ArticleDetail = PageInfo & {
   coordinates?: string // coordinates.0.lat;coordinates.0.lon
   timestamp?: string // revisions.0.timestamp
   revisionId?: number // revisions.0.revid
+  stableRevisionId?: number // flagged.stable_revid (FlaggedRevs)
   internalThumbnailUrl?: string // internalThumbnailUrl
   nextArticleId?: string
   prevArticleId?: string
@@ -120,6 +121,9 @@ interface QueryRet {
   revisions?: QueryRevisionsRet
   coordinates?: QueryCoordinatesRet
   redirects?: QueryRedirectsRet
+  flagged?: {
+    stable_revid?: number
+  }
   pagelanguagehtmlcode?: string
   pagelanguagedir?: TextDirection
   contentmodel: string
@@ -237,6 +241,7 @@ interface QueryContinueOpts {
 interface RendererArticleOpts {
   sectionId?: string
   langVar?: string
+  oldid?: number
 }
 
 interface PageInfo {

--- a/src/util/builders/url/action-parse.director.ts
+++ b/src/util/builders/url/action-parse.director.ts
@@ -15,7 +15,7 @@ export default class ActionParseURLDirector {
   }
 
   buildArticleURL(articleId: string, articleUrlOpts: RendererArticleOpts = {}) {
-    const { sectionId, langVar } = articleUrlOpts
+    const { sectionId, langVar, oldid } = articleUrlOpts
     return urlBuilder
       .setDomain(this.baseDomain)
       .setQueryParams(
@@ -27,7 +27,8 @@ export default class ActionParseURLDirector {
           disabletoc: '1',
           disableeditsection: '1',
           disablelimitreport: '1',
-          page: articleId,
+          page: oldid ? undefined : articleId,
+          oldid: oldid ? String(oldid) : undefined,
           useskin: this.skin,
           variant: langVar || undefined,
           redirects: '1',

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -321,6 +321,7 @@ export function mwRetToArticleDetail(obj: QueryMwRet): KVS<ArticleDetail> {
       ...(val.ns !== 0 ? { ns: val.ns } : {}),
       ...(val.contentmodel !== 'wikitext' ? { contentmodel: val.contentmodel } : {}),
       ...(rev ? { revisionId: rev.revid, timestamp: rev.timestamp } : {}),
+      ...(val.flagged?.stable_revid ? { stableRevisionId: val.flagged.stable_revid } : {}),
       ...(geo ? { coordinates: `${geo.lat};${geo.lon}` } : {}),
     }
   }

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -16,14 +16,19 @@ import FileManager from './FileManager.js'
 import { truncateUtf8Bytes } from './misc.js'
 import { isMainPage } from './articles.js'
 
+function getArticleRenderUrl(articleId: string, articleDetail: ArticleDetail, dump: Dump): string {
+  const leadSectionId = dump.nodet && !articleDetail.contentmodel && !articleDetail.missing ? config.filters.leadSectionId : ''
+  const oldid = dump.opts.stableRevision && articleDetail.stableRevisionId !== undefined ? articleDetail.stableRevisionId : undefined
+  return Downloader.getArticleUrl(articleId, { sectionId: leadSectionId, oldid, langVar: dump.langVar })
+}
+
 async function getAllArticlesToKeep(articleDetailXId: RKVS<ArticleDetail>, dump: Dump, articlesRenderer: Renderer) {
   await articleDetailXId.iterateItems(Downloader.workers, async (articleKeyValuePairs) => {
     for (const [articleId, articleDetail] of Object.entries(articleKeyValuePairs)) {
       let rets: any
       try {
         const mainPage = isMainPage(articleId)
-        const leadSectionId = dump.nodet && !articleDetail.contentmodel && !articleDetail.missing ? config.filters.leadSectionId : ''
-        const articleUrl = Downloader.getArticleUrl(articleId, { sectionId: leadSectionId, langVar: dump.langVar })
+        const articleUrl = getArticleRenderUrl(articleId, articleDetail, dump)
 
         rets = await Downloader.getArticle(articleId, articleDetailXId, articlesRenderer, articleUrl, dump, articleDetail)
         await new Promise((resolve) => setTimeout(resolve, Downloader.articleRequestInterval))
@@ -164,8 +169,7 @@ export async function saveArticles(zimCreator: Creator, dump: Dump) {
 
         let rets: any
         try {
-          const leadSectionId = dump.nodet && !articleDetail.contentmodel && !articleDetail.missing ? config.filters.leadSectionId : ''
-          const articleUrl = Downloader.getArticleUrl(articleId, { sectionId: leadSectionId, langVar: dump.langVar })
+          const articleUrl = getArticleRenderUrl(articleId, articleDetail, dump)
 
           rets = await Downloader.getArticle(articleId, articleDetailXId, RenderingContext.articlesRenderer, articleUrl, dump, articleDetail)
           await new Promise((resolve) => setTimeout(resolve, Downloader.articleRequestInterval))

--- a/test/unit/builders/url/action-parse.director.test.ts
+++ b/test/unit/builders/url/action-parse.director.test.ts
@@ -11,5 +11,32 @@ describe('ActionParseUrlDirector', () => {
         'https://zh.wikipedia.org/?action=parse&format=json&prop=modules%7Cjsconfigvars%7Cheadhtml%7Ctext%7Cdisplaytitle%7Csubtitle&usearticle=1&disabletoc=1&disableeditsection=1&disablelimitreport=1&page=article-123&useskin=vector&variant=zh-cn&redirects=1&formatversion=2&maxlag=5',
       )
     })
+
+    it('should use oldid instead of page when oldid is provided (FlaggedRevs stable revision)', () => {
+      const url = actionParseUrlDirector.buildArticleURL('article-123', { oldid: 12345, langVar: 'zh-cn' })
+
+      // oldid should be present, page should NOT be present
+      expect(url).toContain('oldid=12345')
+      expect(url).not.toContain('page=article-123')
+      expect(url).toContain('action=parse')
+      expect(url).toContain('format=json')
+      expect(url).toContain('useskin=vector')
+      expect(url).toContain('variant=zh-cn')
+    })
+
+    it('should use page (not oldid) when oldid is not provided', () => {
+      const url = actionParseUrlDirector.buildArticleURL('article-123', {})
+
+      expect(url).toContain('page=article-123')
+      expect(url).not.toContain('oldid=')
+    })
+
+    it('should support both sectionId and oldid together', () => {
+      const url = actionParseUrlDirector.buildArticleURL('article-123', { sectionId: '2', oldid: 99999 })
+
+      expect(url).toContain('oldid=99999')
+      expect(url).toContain('section=2')
+      expect(url).not.toContain('page=article-123')
+    })
   })
 })

--- a/test/unit/mwApi.test.ts
+++ b/test/unit/mwApi.test.ts
@@ -2,7 +2,7 @@ import { startRedis, stopRedis } from './bootstrap.js'
 import Downloader from '../../src/Downloader.js'
 import MediaWiki, { SiteInfoSkin } from '../../src/MediaWiki.js'
 import RedisStore from '../../src/RedisStore.js'
-import { getArticleIds } from '../../src/util/mw-api.js'
+import { getArticleIds, mwRetToArticleDetail } from '../../src/util/mw-api.js'
 import { getArticlesByNS } from '../../src/util/index.js'
 import { config } from '../../src/config.js'
 import { jest } from '@jest/globals'
@@ -224,5 +224,109 @@ describe('Mediawiki utils', () => {
     ],
   ])('Get skin', (skins: SiteInfoSkin[]) => {
     expect(() => MediaWiki.getDefaultSkin(skins)).toThrow()
+  })
+})
+
+describe('mwRetToArticleDetail — FlaggedRevs stableRevisionId extraction', () => {
+  test('extracts stableRevisionId when flagged.stable_revid is present', () => {
+    const mockQueryRet: QueryMwRet = {
+      Berlin: {
+        title: 'Berlin',
+        ns: 0,
+        contentmodel: 'wikitext',
+        revisions: [{ revid: 200, parentid: 199, minor: '', user: 'TestUser', timestamp: '2024-01-01T00:00:00Z', comment: '' }],
+        flagged: {
+          stable_revid: 180,
+          level: 0,
+          level_text: 'stable',
+        },
+      } as any,
+    }
+
+    const result = mwRetToArticleDetail(mockQueryRet)
+
+    expect(result.Berlin).toBeDefined()
+    expect(result.Berlin.revisionId).toBe(200)
+    expect(result.Berlin.stableRevisionId).toBe(180)
+  })
+
+  test('does not include stableRevisionId when flagged data is absent', () => {
+    const mockQueryRet: QueryMwRet = {
+      London: {
+        title: 'London',
+        ns: 0,
+        contentmodel: 'wikitext',
+        revisions: [{ revid: 100, parentid: 99, minor: '', user: 'SomeUser', timestamp: '2024-01-01T00:00:00Z', comment: '' }],
+      } as any,
+    }
+
+    const result = mwRetToArticleDetail(mockQueryRet)
+
+    expect(result.London).toBeDefined()
+    expect(result.London.revisionId).toBe(100)
+    expect(result.London.stableRevisionId).toBeUndefined()
+  })
+
+  test('does not include stableRevisionId when flagged exists but stable_revid is missing', () => {
+    const mockQueryRet: QueryMwRet = {
+      Paris: {
+        title: 'Paris',
+        ns: 0,
+        contentmodel: 'wikitext',
+        revisions: [{ revid: 300, parentid: 299, minor: '', user: 'Editor', timestamp: '2024-06-01T00:00:00Z', comment: '' }],
+        flagged: {
+          level: 1,
+          level_text: 'quality',
+        },
+      } as any,
+    }
+
+    const result = mwRetToArticleDetail(mockQueryRet)
+
+    expect(result.Paris).toBeDefined()
+    expect(result.Paris.revisionId).toBe(300)
+    expect(result.Paris.stableRevisionId).toBeUndefined()
+  })
+
+  test('handles mix of articles with and without FlaggedRevs data', () => {
+    const mockQueryRet: QueryMwRet = {
+      München: {
+        title: 'München',
+        ns: 0,
+        contentmodel: 'wikitext',
+        revisions: [{ revid: 500, parentid: 499, minor: '', user: 'DEUser', timestamp: '2024-03-01T00:00:00Z', comment: '' }],
+        flagged: { stable_revid: 490 },
+      } as any,
+      Tokyo: {
+        title: 'Tokyo',
+        ns: 0,
+        contentmodel: 'wikitext',
+        revisions: [{ revid: 600, parentid: 599, minor: '', user: 'JPUser', timestamp: '2024-03-01T00:00:00Z', comment: '' }],
+      } as any,
+    }
+
+    const result = mwRetToArticleDetail(mockQueryRet)
+
+    expect(result['München'].stableRevisionId).toBe(490)
+    expect(result['München'].revisionId).toBe(500)
+    expect(result.Tokyo.stableRevisionId).toBeUndefined()
+    expect(result.Tokyo.revisionId).toBe(600)
+  })
+
+  test('handles stableRevisionId equal to latest revisionId (both should be set)', () => {
+    const mockQueryRet: QueryMwRet = {
+      Hamburg: {
+        title: 'Hamburg',
+        ns: 0,
+        contentmodel: 'wikitext',
+        revisions: [{ revid: 400, parentid: 399, minor: '', user: 'User1', timestamp: '2024-02-01T00:00:00Z', comment: '' }],
+        flagged: { stable_revid: 400 },
+      } as any,
+    }
+
+    const result = mwRetToArticleDetail(mockQueryRet)
+
+    expect(result.Hamburg.revisionId).toBe(400)
+    expect(result.Hamburg.stableRevisionId).toBe(400)
   })
 })


### PR DESCRIPTION
This PR adds automatic detection of the FlaggedRevs extension and, when available, prefers stable (reviewed) revisions instead of the latest ones. The goal is to reduce vandalism and improve the quality of generated ZIM files.

Closes #1587, relates to #2072 

## Changes
- **`MediaWiki.ts`**: Added `hasFlaggedRevs()` method that probes `prop=info|flagged` to detect the extension (cached, similar to `hasCoordinates()`)
- **`Downloader.ts`**: Appends `|flagged` to article query `prop` when FlaggedRevs is active
- **`mw-api.ts`**: Extracts `val.flagged.stable_revid` → `articleDetail.stableRevisionId` in `mwRetToArticleDetail()`
- **`types.d.ts`**: Added `flagged` , `stableRevisionId`, `oldid`
- **`action-parse.director.ts`**: 
   - `buildArticleURL()` uses `oldid=<stable_revid>` instead of `page=<title>` when `oldid` is provided
  - Handle missing `redirects` field in API response when using `oldid=` (not returned for specific revision requests)
- **`saveArticles.ts`**: Both `saveArticles()` and `getAllArticlesToKeep()` pass `stableRevisionId` as `oldid` when `useLatestRevision` is not set
- **`parameterList.ts`**: Added `--useLatestRevision` CLI flag description
- **`Dump.ts`**: Added `useLatestRevision` to dump opts
- **`mwoffliner.lib.ts`**: Wires detection at boot, passes flag through, adds `flaggedrevs:stable` ZIM tag

## Testing
### Unit Tests (new)
- `mwRetToArticleDetail`: extracts `stableRevisionId`, handles absence, handles mixed data
- `buildArticleURL`: uses `oldid` instead of `page`, preserves existing behavior, combines `oldid` + `sectionId`

### Manual Docker Test
- ✅ `de.wikipedia.org` (FlaggedRevs) -> stable revision used, `oldid=` in parse URL
- ✅ `de.wikipedia.org` + `--useLatestRevision` -> latest revision used, `page=` in parse URL
- ✅ `en.wikipedia.org` (no FlaggedRevs) -> graceful fallback, no behavior change
