### PR TITLE
Fix Request-URI Too Long when fetching batches of article details

### DIFF
--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -11,7 +11,10 @@ export async function getArticlesByIds(articleIds: string[], log = true): Promis
   let from = 0
   let numThumbnails = 0
   const MAX_BATCH_SIZE = 50
-  const MAX_URL_SIZE = 7900 // in bytes, approx.
+  // HTTP servers typically limit URLs to ~8000 bytes. The full URL includes the
+  // base URL, other query params, and continuation params (~500-600 bytes overhead).
+  // This limit applies to the "titles=<encoded>" portion of the query string.
+  const MAX_TITLES_PARAM_SIZE = 7400
 
   const { articleDetailXId, redirectsXId } = RedisStore
 
@@ -25,9 +28,12 @@ export async function getArticlesByIds(articleIds: string[], log = true): Promis
       while (from < articleIds.length) {
         // Secure the request has the max articleIds as possible (within boudaries)
         const articleIdsBatch = articleIds.slice(from, from + MAX_BATCH_SIZE)
-        let urlSize = encodeURIComponent(articleIdsBatch.join('|')).length
-        while (urlSize > MAX_URL_SIZE) {
-          urlSize -= encodeURIComponent(articleIdsBatch.pop()).length + 1
+        // Use URLSearchParams for size estimation to match the encoding used by
+        // buildQueryURL (which differs from encodeURIComponent for chars like parentheses)
+        let titlesParamSize = new URLSearchParams({ titles: articleIdsBatch.join('|') }).toString().length
+        while (titlesParamSize > MAX_TITLES_PARAM_SIZE && articleIdsBatch.length > 1) {
+          articleIdsBatch.pop()
+          titlesParamSize = new URLSearchParams({ titles: articleIdsBatch.join('|') }).toString().length
         }
 
         // Udpate articleIds slicing boundaries


### PR DESCRIPTION
## Summary

- **Use `URLSearchParams` for URL size estimation** to match the encoding actually used by `buildQueryURL`, fixing a mismatch where `encodeURIComponent` underestimates the size for characters like `(`, `)`, `!`, `~`, `'` (1 byte vs 3 bytes with `URLSearchParams`)
- **Reduce max titles param size from 7900 to 7400** to account for the ~500-600 bytes of URL overhead (base URL, other query params, continuation params) that was previously ignored
- **Add `articleIdsBatch.length > 1` guard** to prevent popping all articles, and recompute size on each pop instead of buggy incremental subtraction

Fixes #2705

## Test plan

- [ ] Verify scraping a non-Latin wiki (e.g. Telugu Wikipedia with `top` recipe) no longer triggers 414 Request-URI Too Long
- [ ] Verify Latin wiki scraping still works correctly with unchanged batch sizes
- [ ] Verify the `all` recipe continues to work as before

