### PR TITLE
Fix changed URL linked to changed thumbnail max size

### DIFF
--- a/test/e2e/multimediaContent.test.ts
+++ b/test/e2e/multimediaContent.test.ts
@@ -37,7 +37,7 @@ await testAllRenders('multimedia-content', parameters, async (outFiles) => {
           '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_icon.svg.png',
           '_assets_/0c70a452f799bfe840676ee341124611/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).mp3.ogg',
           '_assets_/0c70a452f799bfe840676ee341124611/page1-120px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
-          '_assets_/0c70a452f799bfe840676ee341124611/page1-1500px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
+          '_assets_/0c70a452f799bfe840676ee341124611/page1-1280px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
           '_res_/favicon.png',
         ].sort(),
       )
@@ -81,7 +81,7 @@ await testAllRenders('multimedia-content', { ...parameters, format: ['nopic', 'n
               // '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_icon.svg.png',
               // '_assets_/0c70a452f799bfe840676ee341124611/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).mp3.ogg',
               // '_assets_/0c70a452f799bfe840676ee341124611/page1-120px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
-              // '_assets_/0c70a452f799bfe840676ee341124611/page1-1500px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
+              // '_assets_/0c70a452f799bfe840676ee341124611/page1-1280px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
               '_res_/favicon.png',
             ].sort(),
           )
@@ -96,7 +96,7 @@ await testAllRenders('multimedia-content', { ...parameters, format: ['nopic', 'n
               '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_icon.svg.png',
               // '_assets_/0c70a452f799bfe840676ee341124611/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).mp3.ogg',
               '_assets_/0c70a452f799bfe840676ee341124611/page1-120px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
-              '_assets_/0c70a452f799bfe840676ee341124611/page1-1500px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
+              '_assets_/0c70a452f799bfe840676ee341124611/page1-1280px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
               '_res_/favicon.png',
             ].sort(),
           )
@@ -111,7 +111,7 @@ await testAllRenders('multimedia-content', { ...parameters, format: ['nopic', 'n
               '_assets_/0c70a452f799bfe840676ee341124611/Kiwix_icon.svg.png',
               '_assets_/0c70a452f799bfe840676ee341124611/Local_Forecast_-_Elevator_(ISRC_USUAN1300012).mp3.ogg',
               '_assets_/0c70a452f799bfe840676ee341124611/page1-120px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
-              '_assets_/0c70a452f799bfe840676ee341124611/page1-1500px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
+              '_assets_/0c70a452f799bfe840676ee341124611/page1-1280px-Kiwix_-_WikiArabia_Cairo_2017.pdf.jpg',
               '_res_/favicon.png',
             ].sort(),
           )


### PR DESCRIPTION
CI is failing because wikimedia seems to have changed logic around max thumbnail size which seems to be 1280px now.

<img width="1042" height="122" alt="Screenshot 2026-04-16 at 15 55 21" src="https://github.com/user-attachments/assets/da4ae372-17b7-4b2c-ba13-2d16a49f56f9" />
