### PR TITLE
Redesign speed to handle both worker count and request pacing

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,6 @@
 Unreleased:
 * CHANGED: Create multiple files for language variants, similar to different formats (@Markus-Rost #2691)
+* CHANGED: Redesign speed to handle both worker count and request pacing (@triemerge #2393)
 * FIX: Fix file name detection for Wikimedia image urls (@Markus-Rost #2701)
 * FIX: Use single article as ZIM main page when articleList contains only one entry (@kunalsiyag #1891)
 * FIX: Fix fire-and-forget async patterns and file download accounting bugs (@triemerge #2681)

--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -200,7 +200,7 @@
       "type": "float",
       "title": "Speed",
       "required": false,
-      "description": "Multiplicator for the number of parallel HTTP requests on Parsoid backend (default is the number of CPU cores). Reduce on throttled Wikis."
+      "description": "Controls scraping speed. 1 is the default, 0.1 makes it ten times slower, 10 makes it ten times faster. Values above 1 must be integers (number of parallel workers)."
     },
     "withoutZimFullTextIndex": {
       "type": "boolean",

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -50,7 +50,8 @@ imageminOptions.get('webp').set('image/jpeg', {
 
 interface DownloaderOpts {
   uaString: string
-  speed: number
+  workers: number
+  articleRequestInterval?: number
   reqTimeout: number
   optimisationCacheUrl: string
   s3?: S3
@@ -144,7 +145,8 @@ class Downloader {
     }
     return Downloader.instance
   }
-  private _speed: number
+  private _workers: number
+  private _articleRequestInterval: number
   private _webp: boolean = false
   private _requestTimeout: number
   private _basicRequestOptions: AxiosRequestConfig
@@ -164,8 +166,12 @@ class Downloader {
   private articleUrlDirector: URLDirector
   private insecure: boolean = false
 
-  get speed() {
-    return this._speed
+  get workers() {
+    return this._workers
+  }
+
+  get articleRequestInterval() {
+    return this._articleRequestInterval
   }
 
   get webp() {
@@ -190,10 +196,22 @@ class Downloader {
     return this._apiUrlDirector
   }
 
-  set init({ uaString, speed, reqTimeout, optimisationCacheUrl, s3, webp, trustedJs = config.output.mw.js_trusted.slice(), backoffOptions, insecure }: DownloaderOpts) {
+  set init({
+    uaString,
+    workers,
+    articleRequestInterval,
+    reqTimeout,
+    optimisationCacheUrl,
+    s3,
+    webp,
+    trustedJs = config.output.mw.js_trusted.slice(),
+    backoffOptions,
+    insecure,
+  }: DownloaderOpts) {
     this.reset()
     this.uaString = uaString
-    this._speed = speed
+    this._workers = workers
+    this._articleRequestInterval = articleRequestInterval
     this._requestTimeout = reqTimeout
     this.optimisationCacheUrl = optimisationCacheUrl
     this._webp = webp
@@ -301,7 +319,8 @@ class Downloader {
 
   private reset() {
     this.uaString = undefined
-    this._speed = undefined
+    this._workers = undefined
+    this._articleRequestInterval = undefined
     this._requestTimeout = undefined
     this.optimisationCacheUrl = undefined
     this._webp = false

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -6,7 +6,6 @@
 /* ********************************** */
 
 import fs, { readFileSync } from 'fs'
-import os from 'os'
 import pmap from 'p-map'
 import sharp from 'sharp'
 import domino from 'domino'
@@ -20,7 +19,6 @@ import { zimCreatorMutex } from './mutex.js'
 import { check_all } from './sanitize-argument.js'
 
 import {
-  MAX_CPU_CORES,
   MIN_IMAGE_THRESHOLD_ARTICLELIST_PAGE,
   downloadAndSaveModule,
   downloadAndSaveStartupModule,
@@ -55,6 +53,7 @@ import Downloader from './Downloader.js'
 import RenderingContext from './renderers/rendering.context.js'
 import { articleListHomeTemplate, htmlRedirectTemplateCode } from './Templates.js'
 import { saveArticles } from './util/saveArticles.js'
+import { ARTICLE_REQUEST_INTERVAL } from './util/const.js'
 import { getCategoriesForArticles, trimUnmirroredPages } from './util/categories.js'
 import urlHelper from './util/url.helper.js'
 import { parseCustomCssUrls, customCssUrlToFilename } from './util/customCss.js'
@@ -143,14 +142,9 @@ async function execute(argv: any) {
     throw new Error(`Admin email [${adminEmail}] is not valid`)
   }
 
-  // TODO: Move it to sanitize method
-  /* Number of parallel requests. To secure stability and avoid HTTP
-  429 errors, no more than MAX_CPU_CORES can be considered */
-  if (_speed && isNaN(_speed)) {
-    throw new Error('speed is not a number, please give a number value to --speed')
-  }
-  const cpuCount = Math.min(os.cpus().length, MAX_CPU_CORES)
-  const speed = Math.max(1, Math.round(cpuCount * (_speed || 1)))
+  const speed = _speed || 1
+  const workers = speed >= 1 ? Math.floor(speed) : 1
+  const articleRequestInterval = speed < 1 ? Math.round(ARTICLE_REQUEST_INTERVAL / speed) : ARTICLE_REQUEST_INTERVAL
 
   /* Check Node.js version */
   const nodeVersionSatisfiesPackage = semver.satisfies(process.version, packageJSON.engines.node)
@@ -196,7 +190,8 @@ async function execute(argv: any) {
   /* Download helpers; TODO: Merge with something else / expand this. */
   Downloader.init = {
     uaString,
-    speed,
+    workers,
+    articleRequestInterval,
     reqTimeout: requestTimeout * 1000 || config.defaults.requestTimeout,
     optimisationCacheUrl,
     s3,
@@ -551,7 +546,7 @@ async function execute(argv: any) {
             }
             return downloadAndSaveModule(zimCreator, oneModule, type as any, dump.langVar)
           },
-          { concurrency: Downloader.speed },
+          { concurrency: Downloader.workers },
         )
       }),
     )
@@ -579,7 +574,7 @@ async function execute(argv: any) {
     let processed = -1
     const total = await redirectsXId.len()
     logger.log(`${total} redirects to process`)
-    await redirectsXId.iterateItems(Downloader.speed, async (redirects) => {
+    await redirectsXId.iterateItems(Downloader.workers, async (redirects) => {
       for (const [redirectId, { targetId, fragment }] of Object.entries(redirects)) {
         processed += 1
         if (processed > 0 && processed % 5000 === 0) {

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -27,7 +27,7 @@ export const parameterDescriptions = {
   redis: 'Redis path (redis:// URL or path to UNIX socket)',
   requestTimeout: 'Request timeout in seconds (default is 120s)',
   resume: 'Skip already existing/created ZIM files',
-  speed: 'Multiplicator for the number of parallel HTTP requests on Parsoid backend (by default the number of CPU cores). Reduce on throttled Wikis.',
+  speed: 'Controls scraping speed. 1 is the default, 0.1 makes it ten times slower, 10 makes it ten times faster. Values above 1 must be integers (number of parallel workers).',
   verbose:
     'Print logging information to standard streams. To filter messages, one of the following values can be given: "info", "log", "warn", "error" or "quiet" (default level being "error"). All messages are printed from the given value and higher/worse.',
   withoutZimFullTextIndex: "Don't include a fulltext search index to the ZIM",

--- a/src/sanitize-argument.ts
+++ b/src/sanitize-argument.ts
@@ -172,8 +172,14 @@ export function sanitizeDoubleUsedParameters(options: object) {
 }
 
 export function sanitize_speed(_speed: any) {
-  if (_speed && isNaN(_speed)) {
-    throw new Error('speed is not a number, please give a number value to --speed.')
+  if (_speed !== undefined && _speed !== null) {
+    const numSpeed = Number(_speed)
+    if (isNaN(numSpeed) || numSpeed <= 0) {
+      throw new Error('speed must be a positive number. Values >= 1 set the number of parallel workers (integer). Values < 1 slow down the scraper.')
+    }
+    if (numSpeed >= 1 && !Number.isInteger(numSpeed)) {
+      throw new Error('speed values >= 1 must be integers (number of parallel workers).')
+    }
   }
 }
 

--- a/src/util/FileManager.ts
+++ b/src/util/FileManager.ts
@@ -176,7 +176,7 @@ class FileManager {
     }
 
     async function workerDownloadFile(fileToDownload: FileToDownload, hostname: string, hostData: HostData, workerId: number) {
-      if ((dump.status.files.success + dump.status.files.fail) % (10 * Downloader.speed) === 0) {
+      if ((dump.status.files.success + dump.status.files.fail) % (10 * Downloader.workers) === 0) {
         const percentProgress = (((dump.status.files.success + dump.status.files.fail) / filesTotal) * 100).toFixed(1)
         if (percentProgress !== prevPercentProgress) {
           prevPercentProgress = percentProgress
@@ -258,7 +258,7 @@ class FileManager {
     }
 
     await pmap(
-      Array.from({ length: Downloader.speed }, (_, i) => i),
+      Array.from({ length: Downloader.workers }, (_, i) => i),
       async (workerId: number) => {
         while (true) {
           const nextFileData = await fileDownloadMutex.runExclusive(getNextFileToDownload)
@@ -267,7 +267,7 @@ class FileManager {
           await workerDownloadFile(fileToDownload, hostname, hostData, workerId)
         }
       },
-      { concurrency: Downloader.speed },
+      { concurrency: Downloader.workers },
     )
 
     logger.log(

--- a/src/util/categories.ts
+++ b/src/util/categories.ts
@@ -9,7 +9,7 @@ export async function getCategoriesForArticles(articleStore: RKVS<ArticleDetail>
   const nextCategoriesBatch: RKVS<ArticleDetail> = RedisStore.createRedisKvs(`${Date.now()}-request`)
   logger.log(`Fetching categories for [${await articleStore.len()}] articles`)
 
-  await articleStore.iterateItems(Downloader.speed, async (articleKeyValuePairs: KVS<ArticleDetail>, runningWorkers: number) => {
+  await articleStore.iterateItems(Downloader.workers, async (articleKeyValuePairs: KVS<ArticleDetail>, runningWorkers: number) => {
     const articleKeys = Object.keys(articleKeyValuePairs)
     logger.log(`Worker getting categories for articles [${logger.logifyArray(articleKeys)}] - ${runningWorkers} worker(s) running`)
 
@@ -72,7 +72,7 @@ export async function trimUnmirroredPages() {
   let processedArticles = 0
   let modifiedArticles = 0
 
-  await articleDetailXId.iterateItems(Downloader.speed, async (articleKeyValuePairs) => {
+  await articleDetailXId.iterateItems(Downloader.workers, async (articleKeyValuePairs) => {
     for (const [articleId, articleDetail] of Object.entries(articleKeyValuePairs)) {
       processedArticles += 1
       if (typeof (articleDetail as any).missing === 'string') {
@@ -158,7 +158,7 @@ export async function simplifyGraph() {
   let processedArticles = 0
   let deletedNodes = 0
 
-  await articleDetailXId.iterateItems(Downloader.speed, async (articleKeyValuePairs) => {
+  await articleDetailXId.iterateItems(Downloader.workers, async (articleKeyValuePairs) => {
     for (const [articleId, articleDetail] of Object.entries(articleKeyValuePairs)) {
       processedArticles += 1
 

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -1,4 +1,4 @@
-export const MAX_CPU_CORES = 8
+export const ARTICLE_REQUEST_INTERVAL = 100 // default pause (ms) between action=parse API requests per worker
 export const IMAGE_THUMB_URL_REGEX =
   /^(.*?\/)(transcoded\/|thumb\/)?([0-9a-fA-F]{1}\/[0-9a-fA-F]{2}\/)?([^/]+\.[A-Za-z0-9]{2,6}\/)?(\d+px[-]+)?([^/]+?\.[A-Za-z0-9]{2,6}(\.[A-Za-z0-9]{2,6})?)(\?[0-9a-fA-F]+|\?utm_.+)?$/
 export const LATEX_IMAGE_URL_REGEX = /^(.*\/math\/render\/svg\/)([A-Za-z0-9]+)$/

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -18,7 +18,7 @@ export async function getArticlesByIds(articleIds: string[], log = true): Promis
   // using async iterator to spawn workers
   await pmap(
     ','
-      .repeat(Downloader.speed)
+      .repeat(Downloader.workers)
       .split(',')
       .map((_, i) => i),
     async (workerId: number) => {
@@ -78,7 +78,7 @@ export async function getArticlesByIds(articleIds: string[], log = true): Promis
         await articleDetailXId.setMany(deepmerge(existingArticleDetails, articleDetails))
       }
     },
-    { concurrency: Downloader.speed },
+    { concurrency: Downloader.workers },
   )
 }
 
@@ -378,7 +378,7 @@ export async function getArticleIds(mainPage?: string, articleIds?: string[], ar
       (namespace: string) => {
         return getArticlesByNS(MediaWiki.namespaces[namespace].num, articleIdsToIgnore, allowedContentModels)
       },
-      { concurrency: Downloader.speed },
+      { concurrency: Downloader.workers },
     )
   }
 }

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -17,7 +17,7 @@ import { truncateUtf8Bytes } from './misc.js'
 import { isMainPage } from './articles.js'
 
 async function getAllArticlesToKeep(articleDetailXId: RKVS<ArticleDetail>, dump: Dump, articlesRenderer: Renderer) {
-  await articleDetailXId.iterateItems(Downloader.speed, async (articleKeyValuePairs) => {
+  await articleDetailXId.iterateItems(Downloader.workers, async (articleKeyValuePairs) => {
     for (const [articleId, articleDetail] of Object.entries(articleKeyValuePairs)) {
       let rets: any
       try {
@@ -26,6 +26,7 @@ async function getAllArticlesToKeep(articleDetailXId: RKVS<ArticleDetail>, dump:
         const articleUrl = Downloader.getArticleUrl(articleId, { sectionId: leadSectionId, langVar: dump.langVar })
 
         rets = await Downloader.getArticle(articleId, articleDetailXId, articlesRenderer, articleUrl, dump, articleDetail)
+        await new Promise((resolve) => setTimeout(resolve, Downloader.articleRequestInterval))
         for (const { articleId, html } of rets) {
           if (!html) {
             continue
@@ -137,7 +138,7 @@ export async function saveArticles(zimCreator: Creator, dump: Dump) {
   // retry interval is an exponentional value from 1 to 60s
   // we assume rest of processing is "fast" and takes at most 1 minute
   const timeout = 2 * (Downloader.requestTimeout * 10 + (1 + 2 + 4 + 8 + 16 + 32 + 60 * 4) * 1000) + 60000
-  await articleDetailXId.iterateItems(Downloader.speed, (articleKeyValuePairs, runningWorkers) => {
+  await articleDetailXId.iterateItems(Downloader.workers, (articleKeyValuePairs, runningWorkers) => {
     // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve, reject) => {
       /*
@@ -167,6 +168,7 @@ export async function saveArticles(zimCreator: Creator, dump: Dump) {
           const articleUrl = Downloader.getArticleUrl(articleId, { sectionId: leadSectionId, langVar: dump.langVar })
 
           rets = await Downloader.getArticle(articleId, articleDetailXId, RenderingContext.articlesRenderer, articleUrl, dump, articleDetail)
+          await new Promise((resolve) => setTimeout(resolve, Downloader.articleRequestInterval))
 
           curStage += 1
           for (const {

--- a/test/unit/downloader.retry.test.ts
+++ b/test/unit/downloader.retry.test.ts
@@ -11,7 +11,7 @@ const createDownloader = () => {
   const downloader = new DownloaderClass()
   downloader.init = {
     uaString: 'mwoffliner-test-agent',
-    speed: 1,
+    workers: 1,
     reqTimeout: 1000,
     optimisationCacheUrl: '',
     webp: false,

--- a/test/unit/downloader.test.ts
+++ b/test/unit/downloader.test.ts
@@ -25,7 +25,7 @@ describe('Downloader class - wikipedia EN', () => {
     MediaWiki.reset()
     MediaWiki.base = 'https://en.wikipedia.org'
     MediaWiki.getCategories = true
-    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
+    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, workers: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
 
     await MediaWiki.getMwMetaData()
     await MediaWiki.hasCoordinates()
@@ -184,7 +184,7 @@ describe('Downloader class - wikipedia EN', () => {
       )
       Downloader.init = {
         uaString: `${config.userAgent} (contact@kiwix.org)`,
-        speed: 1,
+        workers: 1,
         reqTimeout: 1000 * 60,
         webp: false,
         optimisationCacheUrl: 'random-string',
@@ -255,7 +255,7 @@ describe('Downloader class - wikipedia ES', () => {
   beforeAll(async () => {
     MediaWiki.reset()
     MediaWiki.base = 'https://es.wikipedia.org'
-    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
+    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, workers: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
 
     await MediaWiki.getMwMetaData()
     await MediaWiki.hasCoordinates()

--- a/test/unit/mwApi.test.ts
+++ b/test/unit/mwApi.test.ts
@@ -26,7 +26,7 @@ describe('mwApi', () => {
 
     MediaWiki.base = 'https://en.wikipedia.org'
     MediaWiki.getCategories = true
-    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: false, optimisationCacheUrl: '' }
+    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, workers: 1, reqTimeout: 1000 * 60, webp: false, optimisationCacheUrl: '' }
 
     await initMW()
   })
@@ -150,7 +150,7 @@ describe('Test blacklisted NSs', () => {
     MediaWiki.base = 'https://id.wikipedia.org'
     MediaWiki.getCategories = true
 
-    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: false, optimisationCacheUrl: '' }
+    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, workers: 1, reqTimeout: 1000 * 60, webp: false, optimisationCacheUrl: '' }
 
     await initMW()
   })
@@ -168,7 +168,7 @@ describe('Test moved page with redirect', () => {
     await RedisStore.articleDetailXId.flush()
 
     MediaWiki.base = 'https://es.wikipedia.org'
-    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: false, optimisationCacheUrl: '' }
+    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, workers: 1, reqTimeout: 1000 * 60, webp: false, optimisationCacheUrl: '' }
 
     await initMW()
   })

--- a/test/unit/mwApiCapabilities.test.ts
+++ b/test/unit/mwApiCapabilities.test.ts
@@ -16,21 +16,21 @@ describe('Checking Mediawiki capabilities', () => {
 
   test('test capabilities of en.wikipedia.org', async () => {
     MediaWiki.base = 'https://en.wikipedia.org'
-    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
+    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, workers: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
     expect(await MediaWiki.hasActionParseApi()).toBe(true)
     expect(await MediaWiki.hasModuleApi()).toBe(true)
   })
 
   test('test capabilities of wiki.openstreetmap.org', async () => {
     MediaWiki.base = 'https://wiki.openstreetmap.org'
-    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
+    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, workers: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
     expect(await MediaWiki.hasActionParseApi()).toBe(true)
     expect(await MediaWiki.hasModuleApi()).toBe(true)
   })
 
   test('test capabilities of fo.wikisource.org', async () => {
     MediaWiki.base = 'https://fo.wikisource.org'
-    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
+    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, workers: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
     expect(await MediaWiki.hasActionParseApi()).toBe(true)
     expect(await MediaWiki.hasModuleApi()).toBe(true)
   })
@@ -39,7 +39,7 @@ describe('Checking Mediawiki capabilities', () => {
     MediaWiki.base = 'https://minecraft.wiki'
     MediaWiki.actionApiPath = '/api.php'
     MediaWiki.modulePathOpt = '/load.php'
-    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
+    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, workers: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
     expect(await MediaWiki.hasActionParseApi()).toBe(true)
     expect(await MediaWiki.hasModuleApi()).toBe(true)
   })
@@ -50,7 +50,7 @@ describe('Checking Mediawiki capabilities', () => {
     MediaWiki.modulePathOpt = '/load.php'
     MediaWiki.apiCheckArticleId = 'Volcarona' // MediaWiki:Sidebar does not exist in pokemon.fandom.com
     MediaWiki.skin = 'fandomdesktop' // vector skin does not exist in pokemon.fandom.com
-    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
+    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, workers: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
     expect(await MediaWiki.hasActionParseApi()).toBe(true)
     expect(await MediaWiki.hasModuleApi()).toBe(true)
   })

--- a/test/unit/renderers/article.renderer.test.ts
+++ b/test/unit/renderers/article.renderer.test.ts
@@ -13,7 +13,7 @@ describe('ArticleRenderer', () => {
     beforeAll(async () => {
       MediaWiki.base = 'https://zh.wikipedia.org'
       MediaWiki.getCategories = true
-      Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
+      Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, workers: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
       await MediaWiki.getMwMetaData()
       await MediaWiki.hasActionParseApi()
       Downloader.setUrlsDirectors(actionParseRenderer, actionParseRenderer)

--- a/test/unit/renderers/renderer.builder.test.ts
+++ b/test/unit/renderers/renderer.builder.test.ts
@@ -15,7 +15,7 @@ describe('RendererBuilder', () => {
   beforeEach(() => {
     rendererBuilder = new RendererBuilder()
     MediaWiki.base = 'https://en.wikipedia.org'
-    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
+    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, workers: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
   })
 
   it('should create a ActionParseRenderer for desktop mode', async () => {

--- a/test/unit/sanitize-argument.test.ts
+++ b/test/unit/sanitize-argument.test.ts
@@ -80,3 +80,51 @@ describe('URL validation', () => {
     await expect(sanitize_all({ mwUrl: 'invalid-url', adminEmail: 'test@example.com' })).rejects.toThrow(/url/i)
   })
 })
+
+describe('Speed validation', () => {
+  const baseValidParams = {
+    _: [],
+    verbose: true,
+    mwUrl: 'https://en.wikipedia.org',
+    'mw-url': 'https://en.wikipedia.org',
+    adminEmail: 'test@test.test',
+    'admin-email': 'test@test.test',
+    $0: 'node_modules/ts-node/dist/child/child-entrypoint.js',
+  }
+
+  test('accepts positive integer speed', async () => {
+    await expect(sanitize_all({ ...baseValidParams, speed: 4 })).resolves.toBeUndefined()
+  })
+
+  test('accepts integer string speed', async () => {
+    await expect(sanitize_all({ ...baseValidParams, speed: '4' })).resolves.toBeUndefined()
+  })
+
+  test('accepts undefined speed (default)', async () => {
+    await expect(sanitize_all({ ...baseValidParams })).resolves.toBeUndefined()
+  })
+
+  test('accepts float speed below 1', async () => {
+    await expect(sanitize_all({ ...baseValidParams, speed: 0.1 })).resolves.toBeUndefined()
+  })
+
+  test('accepts string float speed below 1', async () => {
+    await expect(sanitize_all({ ...baseValidParams, speed: '0.1' })).resolves.toBeUndefined()
+  })
+
+  test('rejects zero speed', async () => {
+    await expect(sanitize_all({ ...baseValidParams, speed: 0 })).rejects.toThrow(/positive number/)
+  })
+
+  test('rejects negative speed', async () => {
+    await expect(sanitize_all({ ...baseValidParams, speed: -1 })).rejects.toThrow(/positive number/)
+  })
+
+  test('rejects float speed above 1', async () => {
+    await expect(sanitize_all({ ...baseValidParams, speed: 1.5 })).rejects.toThrow(/integers/)
+  })
+
+  test('rejects non-numeric speed', async () => {
+    await expect(sanitize_all({ ...baseValidParams, speed: 'abc' })).rejects.toThrow(/positive number/)
+  })
+})

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -32,7 +32,7 @@ const __dirname = path.dirname(__filename)
 describe('Utils', () => {
   MediaWiki.base = 'https://en.wikipedia.org' // Mandatory setting for proper downloader initialization
   beforeAll(async () => {
-    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
+    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, workers: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
   })
 
   test('util -> interpolateTranslationString', async () => {

--- a/test/unit/util/dump.test.ts
+++ b/test/unit/util/dump.test.ts
@@ -17,7 +17,7 @@ describe('Download CSS or JS Module', () => {
     await filesToDownloadXPath.flush()
     FileManager.reset()
     MediaWiki.base = 'https://en.wikipedia.org'
-    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
+    Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, workers: 1, reqTimeout: 1000 * 60, webp: true, optimisationCacheUrl: '' }
   })
 
   test('download skins.vector.styles CSS', async () => {

--- a/test/util.ts
+++ b/test/util.ts
@@ -33,7 +33,7 @@ export async function setupScrapeClasses({ mwUrl = 'https://en.wikipedia.org', f
   MediaWiki.reset()
   MediaWiki.base = mwUrl
 
-  Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, speed: 1, reqTimeout: 1000 * 60, webp: false, optimisationCacheUrl: '' }
+  Downloader.init = { uaString: `${config.userAgent} (contact@kiwix.org)`, workers: 1, reqTimeout: 1000 * 60, webp: false, optimisationCacheUrl: '' }
 
   await MediaWiki.getMwMetaData()
   await MediaWiki.hasCoordinates()


### PR DESCRIPTION
Fix #2393

The CPU-count multiplier default was generating too much "pressure" on MediaWiki instances, particularly those not sized for high parallelism. Speed now directly controls behavior: values >= 1 set the worker count, values < 1 increase the inter-request delay for wikis that need gentler scraping.

Changes:
- default speed is 1 (single worker, 100ms inter-request delay)
- float values below 1 slow down further (e.g. 0.1 → 1s delay)
- speed validation moved to `sanitize_speed`