### PR TITLE
change articleList and articleListToIgnore flags from strings to txt blobs

### DIFF
--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -22,16 +22,20 @@
       "description": "Custom User-Agent header for all HTTP requests. Defaults to 'MWOffliner/<version> (<adminEmail>)'"
     },
     "articleList": {
-      "type": "string",
+      "type": "blob",
+      "kind": "txt",
       "required": false,
       "title": "Article List",
-      "description": "List of articles to include. Comma separated list of titles or HTTP(S) URL to a file with one title (in UTF8) per line"
+      "description": "List of articles to include. Comma separated list of titles or HTTP(S) URL to a file with one title (in UTF8) per line",
+      "allowRemoteUrl": true
     },
     "articleListToIgnore": {
-      "type": "string",
+      "type": "blob",
+      "kind": "txt",
       "required": false,
       "title": "Article List to ignore",
-      "description": "List of articles to ignore. Comma separated list of titles or HTTP(S) URL to a file with one title (in UTF8) per line"
+      "description": "List of articles to ignore. Comma separated list of titles or HTTP(S) URL to a file with one title (in UTF8) per line",
+      "allowRemoteUrl": true
     },
     "customMainPage": {
       "type": "string",


### PR DESCRIPTION
## Rationale
openzim/zimfarm#1863 adds support for `articleList` and `articeListToIgnore` flags to be blobs. This PR changes the offliner definition flag to conform to the new spec. 