### PR TITLE
build: Use node-libzim 4.2.0 (#2734)

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,5 @@
 Unreleased:
+* UPDATE: Use node-libzim 4.2.0 (@MD-Mushfiqur123 #2734)
 * FIX: Fix file name detection for Wikimedia image urls (@Markus-Rost #2701)
 * FIX: Use single article as ZIM main page when articleList contains only one entry (@kunalsiyag #1891)
 * FIX: Fix fire-and-forget async patterns and file download accounting bugs (@triemerge #2681)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.937.0",
         "@ladjs/country-language": "^1.0.3",
-        "@openzim/libzim": "^4.0.0",
+        "@openzim/libzim": "^4.2.0",
         "@types/async": "^3.2.25",
         "@types/backoff": "^2.5.5",
         "@types/bluebird": "^3.5.42",
@@ -2899,9 +2899,9 @@
       }
     },
     "node_modules/@openzim/libzim": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@openzim/libzim/-/libzim-4.1.0.tgz",
-      "integrity": "sha512-+JxCt4ikShuYWsnth7w7JvKJ2Y2rgl4HU9jUocqV90kKSWxhk2JCu0lGM9yD3lh7iNAy+ilsJqOlA2Sn719/gQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@openzim/libzim/-/libzim-4.2.0.tgz",
+      "integrity": "sha512-0okUHY3okPqxvO+M+1o+WN9ZtHrE0GROxULrUNukEH67Q4ONETtLRleGg5+ROef05c/Grj3CYSWIFSXqH9s3YA==",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.937.0",
     "@ladjs/country-language": "^1.0.3",
-    "@openzim/libzim": "^4.0.0",
+    "@openzim/libzim": "^4.2.0",
     "@types/async": "^3.2.25",
     "@types/backoff": "^2.5.5",
     "@types/bluebird": "^3.5.42",


### PR DESCRIPTION
## What
Updates `@openzim/libzim` (node-libzim) version to `^4.2.0` in `package.json`.

## Why
Resolves #2734.
The issue requested using `node-libzim 4.2.0`. This ensures we are utilizing the latest version of the library.

## How
Bumped the version dependency in `package.json`.

## Testing
- [x] Tests pass locally
- [ ] Added/updated tests
- [x] Manual testing steps: verified package.json update.
