### PR TITLE
Fix CI

### DIFF
--- a/test/e2e/bm.e2e.test.ts
+++ b/test/e2e/bm.e2e.test.ts
@@ -28,8 +28,8 @@ await testAllRenders('bm-wikipedia', parameters, async (outFiles) => {
       if (dump.nopic) {
         // nopic has enough files (this is just an estimate and can change
         // with time, as new Mediwiki versions are released).
-        expect(dump.status.files.success).toBeGreaterThanOrEqual(83)
-        expect(dump.status.files.success).toBeLessThan(105)
+        expect(dump.status.files.success).toBeGreaterThanOrEqual(100)
+        expect(dump.status.files.success).toBeLessThan(120)
         // nopic has enough redirects
         expect(dump.status.redirects.written).toBeGreaterThan(170)
         // nopic has enough articles

--- a/test/e2e/en.e2e.test.ts
+++ b/test/e2e/en.e2e.test.ts
@@ -69,7 +69,7 @@ await testAllRenders('en-wikipedia', parameters, async (outFiles) => {
       const expectedClasses = [
         'client-nojs',
         'skin-theme-clientpref-os',
-        'skin-theme-clientpref-thumb-standard',
+        'skin-thumbsize-clientpref-standard',
         'vector-feature-appearance-pinned-clientpref-0',
         'vector-feature-custom-font-size-clientpref-1',
         'vector-feature-language-in-header-enabled',

--- a/test/e2e/en10.e2e.test.ts
+++ b/test/e2e/en10.e2e.test.ts
@@ -24,8 +24,8 @@ await testAllRenders('en10-wikipedia', parameters, async (outFiles) => {
         if (dump.nopic) {
           // nopic has enough files (this is just an estimate and can change
           // with time, as new Mediwiki versions are released).
-          expect(dump.status.files.success).toBeGreaterThan(82)
-          expect(dump.status.files.success).toBeLessThan(110)
+          expect(dump.status.files.success).toBeGreaterThan(110)
+          expect(dump.status.files.success).toBeLessThan(130)
           // nopic has enough redirects
           expect(dump.status.redirects.written).toBeGreaterThan(500)
           // nopic has 10 articles

--- a/test/unit/downloader.test.ts
+++ b/test/unit/downloader.test.ts
@@ -62,20 +62,20 @@ describe('Downloader class - wikipedia EN', () => {
   })
 
   test('downloader.downloadContent returns', async () => {
-    const contentRes = await Downloader.downloadContent('https://upload.wikimedia.org/wikipedia/commons/thumb/c/cd/London_Montage_L.jpg/275px-London_Montage_L.jpg', 'image')
+    const contentRes = await Downloader.downloadContent('https://upload.wikimedia.org/wikipedia/commons/thumb/c/cd/London_Montage_L.jpg/250px-London_Montage_L.jpg', 'image')
     expect(contentRes.contentType).toBeDefined()
   })
 
   test('Webp compression working for cmyk color-space images', async () => {
-    const { content } = await Downloader.downloadContent('https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/LOGO_HAEMMERLIN.jpg/550px-LOGO_HAEMMERLIN.jpg', 'image')
+    const { content } = await Downloader.downloadContent('https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/LOGO_HAEMMERLIN.jpg/500px-LOGO_HAEMMERLIN.jpg', 'image')
     const fileType = await FileType.fileTypeFromBuffer(Buffer.from(content))
     expect(fileType?.mime).toEqual('image/webp')
   })
 
   test('downloader.downloadContent throws on non-existant url', async () => {
-    await expect(Downloader.downloadContent('https://upload.wikimedia.org/wikipedia/commons/thumb/c/cd/thisdoesnotexist.jpg', 'image')).rejects.toThrowError(
-      new Error('Request failed with status code 404'),
-    )
+    await expect(
+      Downloader.downloadContent('https://upload.wikimedia.org/wikipedia/commons/thumb/c/cd/thisdoesnotexist.jpg/500px-thisdoesnotexist.jpg', 'image'),
+    ).rejects.toThrowError(new Error('Request failed with status code 404'))
   })
 
   test("getArticleDetailsIds Scraped 'London', 'United_Kingdom', 'Paris', 'Zürich', 'THISARTICLEDOESNTEXIST' successfully", async () => {


### PR DESCRIPTION
- fix number of files in bm.wikipedia.org and en.wikipedia.org, list seems ok (increase probably linked to new SVG icons and/or new JS scripts)
- fix URLs of thumbnails now that wikipedia accepts only a fix list of thumbnails size
- fix list of expected CSS classes following upstream change