### PR TITLE
Keep mp4 video sources during media treatment

### DIFF
--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -163,6 +163,11 @@ export abstract class Renderer {
     videoEl.setAttribute('controls', '40')
   }
 
+  private isSupportedVideoSource(src: string): boolean {
+    const srcWithoutQuery = src.split(/[?#]/)[0]
+    return srcWithoutQuery.endsWith('.webm') || srcWithoutQuery.endsWith('.mp4')
+  }
+
   private chooseBestVideoSource(videoEl: DominoElement): DominoElement | null {
     /* Choose best fiting resolution <source> video node */
     if (videoEl.tagName !== 'VIDEO') {
@@ -173,8 +178,8 @@ export abstract class Renderer {
 
     // Take into account the rare edge case where <video> has no <source> child
     if (videoSourceEls.length === 0) {
-      if (originalSrc && originalSrc.endsWith('.webm')) {
-        // If video has a webm `src` attribute, this is an acceptable src
+      if (originalSrc && this.isSupportedVideoSource(originalSrc)) {
+        // If video has a supported `src` attribute, this is an acceptable src
         return videoEl
       } else {
         return null
@@ -190,8 +195,8 @@ export abstract class Renderer {
     let bestWidthDiff = 424242
     let chosenVideoSourceEl: DominoElement = null
     videoSourceEls.forEach((videoSourceEl: DominoElement) => {
-      // Ignore non-webm sources
-      if (!videoSourceEl.getAttribute('src').endsWith('.webm')) {
+      // Ignore non-supported video sources
+      if (!this.isSupportedVideoSource(videoSourceEl.getAttribute('src'))) {
         DOMUtils.deleteNode(videoSourceEl)
         return
       }

--- a/test/unit/treatments/media.treatment.test.ts
+++ b/test/unit/treatments/media.treatment.test.ts
@@ -120,6 +120,21 @@ describe('MediaTreatment', () => {
       expect(ret.imageDependencies).toHaveLength(0)
     })
 
+    test('keeps mp4 video sources with cache-busting query strings', async () => {
+      const { dump } = await setupScrapeClasses({ format: '' })
+      const htmlStr = `<video poster="/images/thumb/TrainWhistle.mp4/120px--TrainWhistle.mp4.jpg?9b2674" controls="" preload="metadata" width="120" height="68" data-mwtitle="TrainWhistle.mp4">
+        <source src="/images/TrainWhistle.mp4?9b2674" type="video/mp4; codecs=&quot;avc1.42E01E, mp4a.40.2&quot;" data-width="120" data-height="68" data-title="Original MP4 file">
+      </video>`
+      const htmlDoc = domino.createDocument(htmlStr)
+
+      const ret = await testableRenderer.testTreatVideo(dump, {}, 'Electric_Locomotive', htmlDoc.querySelector('video'))
+
+      expect(ret.videoDependencies).toEqual(['https://en.wikipedia.org/images/TrainWhistle.mp4?9b2674'])
+      expect(ret.imageDependencies).toEqual(['https://en.wikipedia.org/images/thumb/TrainWhistle.mp4/120px--TrainWhistle.mp4.jpg?9b2674'])
+      expect(htmlDoc.querySelector('video')).toBeDefined()
+      expect(htmlDoc.querySelector('source')).toBeDefined()
+    })
+
     test('Ogg audio retrival', async () => {
       const { dump } = await setupScrapeClasses({ format: '' })
       const htmlStr = `<audio controls="" preload="none" height="32" width="200" resource="./File:William_Shakespeare_(Spoken_Article).ogg">


### PR DESCRIPTION
## Summary

Fixes #2745.

This updates media treatment so MP4 video sources are kept as supported video sources instead of being removed as "non-webm". It also strips query/hash suffixes before checking video extensions, so MediaWiki-style cache-busting URLs such as `/images/TrainWhistle.mp4?9b2674` are accepted.

## Test coverage

Added a focused unit test covering the issue shape: a `<video>` element with an MP4 `<source>` URL containing a cache-busting query string.

## Testing

- `npm run prebuild`
- `npm run test:pattern test/unit/treatments/media.treatment.test.ts -- --runTestsByPath --testNamePattern='keeps mp4 video sources with cache-busting query strings'`
- `npx eslint src/renderers/abstract.renderer.ts test/unit/treatments/media.treatment.test.ts`
- `npx tsc --noEmit`
- `git diff --check`

Note: dependency install on this local macOS runner required Node 26 and `npm ci --ignore-scripts` plus `npm rebuild @openzim/libzim`; a full `media.treatment.test.ts` run hit the existing local Redis hook timeout in `treatMedias`, while the focused MP4 regression test passed.