### PR TITLE
Improve error message when incorrect (or no) value is passed for --mw…

### DIFF
--- a/src/sanitize-argument.ts
+++ b/src/sanitize-argument.ts
@@ -196,7 +196,7 @@ export async function check_mwApiReachability(mwUrl: string, mwActionApiPath: st
   // We are building an API query "by-hand" because we've not yet initialized the whole URL director / URL builder stack
   const apiQueryUrl = `${new URL(mwActionApiPath || MediaWiki.actionApiPath, mwUrl).toString()}?action=query&format=json&formatversion=2&maxlag=${config.defaults.maxlag}`
   const value = await Downloader.get(apiQueryUrl).catch((err) => {
-    throw new Error(`Mediawiki API is not reachable with ${apiQueryUrl}\n${err}`)
+    throw new Error(`Mediawiki API is not reachable with ${apiQueryUrl}\n${err}\nYou may need to pass a (different) value for --mwActionApiPath, see the FAQ.`)
   })
   const contentType = value.headers['content-type']
   if (!(contentType as string).includes('application/json')) {


### PR DESCRIPTION
…ActionApiPath

Make it easier for first-time users to find out which value to pass for --mwActionApiPath by pointing to the FAQ.

Fixes #2752.