### PR TITLE
Refactor codebase to really support rendering multiple ZIM HTML items for a single MW article

### DIFF
--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -24,7 +24,7 @@ import ApiURLDirector from './util/builders/url/api.director.js'
 import urlHelper from './util/url.helper.js'
 
 import ActionParseURLDirector from './util/builders/url/action-parse.director.js'
-import { Renderer } from './renderers/abstract.renderer.js'
+import { Renderer, RenderOutput } from './renderers/abstract.renderer.js'
 import { findFirstMatchingRule, renderDownloadError } from './error.manager.js'
 import RedisStore from './RedisStore.js'
 
@@ -503,7 +503,7 @@ class Downloader {
     articleUrl,
     dump: Dump,
     articleDetail?: ArticleDetail,
-  ): Promise<any> {
+  ): Promise<RenderOutput> {
     logger.info(`Getting article [${articleId}] from ${articleUrl}`)
 
     try {
@@ -608,19 +608,22 @@ class Downloader {
       RedisStore.articleDetailXId.delete(articleId) // Remove article from list so that we stop creating links to this placeholder
       const articleTitle = articleId.replace(/_/g, ' ')
       const errorPlaceholderHtml = renderDownloadError(errorRule, dump, articleId, articleTitle)
-      return [
-        {
-          articleId,
-          displayTitle: articleTitle,
-          html: errorPlaceholderHtml,
-          imageDependencies: [],
-          videoDependencies: [],
-          mediaDependencies: [],
-          moduleDependencies: [],
-          staticFiles: config.output.downloadErrorResources,
-          subtitles: [],
-        },
-      ]
+      return {
+        items: [
+          {
+            articleId: articleId,
+            zimPath: articleId,
+            zimTitle: '', // we do not want these failed downloads to end-up in suggestion search
+            htmlContent: errorPlaceholderHtml,
+          },
+        ],
+        mediaDependencies: [],
+        imageDependencies: [],
+        videoDependencies: [],
+        moduleDependencies: [],
+        subtitles: [],
+        needsDownloadErrorStaticFiles: true,
+      }
     }
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,8 +60,8 @@ const config = {
 
   output: {
     // CSS and JS resources added by Kiwix
-    cssResourcesCommon: ['style', 'mobile_main_page', 'footer'],
-    jsResourcesCommon: ['masonry.min', 'article_list_home', 'images_loaded.min'],
+    cssResourcesCommon: ['style.css', 'mobile_main_page.css', 'footer.css'],
+    jsResourcesCommon: ['masonry.min.js', 'article_list_home.js', 'images_loaded.min.js'],
 
     downloadErrorResources: ['article_not_found.svg', 'DMSans-Regular.ttf', 'download_error_placeholder.css'],
 

--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -11,7 +11,7 @@ import { Dump } from '../Dump.js'
 import Downloader from '../Downloader.js'
 import { rewriteUrlsOfDoc } from '../util/rewriteUrls.js'
 import { footerTemplate } from '../Templates.js'
-import { getFullUrl, getMediaBase, getRelativeFilePath, interpolateTranslationString, encodeArticleIdForZimHtmlUrl, getStaticFiles } from '../util/misc.js'
+import { getFullUrl, getMediaBase, getRelativeFilePath, interpolateTranslationString, encodeArticleIdForZimHtmlUrl } from '../util/misc.js'
 import { processStylesheetContent } from '../util/dump.js'
 import { isMainPage, isSubpage } from '../util/articles.js'
 import { buildCategoryMemberList } from '../util/categories.js'
@@ -92,26 +92,33 @@ export interface ProcessHtmlOpts {
   callback: any
 }
 
-export interface RenderSingleOutput {
+export type RenderSingleOutput = {
   articleId: string
-  displayTitle: string
-  html: string
+  zimPath: string
+  zimTitle?: string
+  htmlContent: string
+}
+
+export type RenderOutput = {
+  items: RenderSingleOutput[]
   imageDependencies: any
   videoDependencies: any
   mediaDependencies: any
   moduleDependencies: any
-  staticFiles: string[]
   subtitles: any
+  needsDownloadErrorStaticFiles: boolean
 }
 
-export type RenderOutput = RenderSingleOutput[]
-
 export abstract class Renderer {
-  public staticFilesListCommon: string[] = []
+  public staticFilesListCommon: Set<string> = new Set()
   constructor() {
-    if (this.staticFilesListCommon.length === 0) {
-      this.staticFilesListCommon = getStaticFiles(config.output.jsResourcesCommon, config.output.cssResourcesCommon)
+    if (this.staticFilesListCommon.size === 0) {
+      this.staticFilesListCommon = new Set([...config.output.jsResourcesCommon, ...config.output.cssResourcesCommon])
     }
+  }
+
+  public addDownloadErrorStaticFiles() {
+    this.staticFilesListCommon = new Set([...this.staticFilesListCommon, ...config.output.downloadErrorResources])
   }
 
   protected async treatAudioVideo(
@@ -646,7 +653,7 @@ export abstract class Renderer {
   }
 
   // TODO: The first part of this method is common for all renders
-  public async processHtml(processHtmlOpts: ProcessHtmlOpts) {
+  public async processHtml(processHtmlOpts: ProcessHtmlOpts): Promise<RenderOutput> {
     const { html, dump, articleId, articleDetail, displayTitle, categoryMembers, categoriesHtml, moduleDependencies, callback } = processHtmlOpts
     let { articleSubtitle } = processHtmlOpts
     let imageDependencies: Array<{ url: string; path: string; width?: number }> = []
@@ -809,11 +816,20 @@ export abstract class Renderer {
     const finalHTML = '<!DOCTYPE html>\n' + outHtml
 
     return {
-      finalHTML,
+      items: [
+        {
+          articleId: articleId,
+          zimPath: articleId,
+          zimTitle: articleId.replace(/_/g, ' '),
+          htmlContent: finalHTML,
+        },
+      ],
       mediaDependencies,
       imageDependencies,
       videoDependencies,
+      moduleDependencies,
       subtitles,
+      needsDownloadErrorStaticFiles: false,
     }
   }
 
@@ -1233,5 +1249,6 @@ export abstract class Renderer {
   }
 
   abstract download(downloadOpts: DownloadOpts): Promise<DownloadRes>
-  abstract render(renderOpts: RenderOpts): Promise<any>
+  abstract render(renderOpts: RenderOpts): Promise<RenderOutput>
+  abstract getStaticFilesList(): Set<string>
 }

--- a/src/renderers/action-parse.renderer.ts
+++ b/src/renderers/action-parse.renderer.ts
@@ -3,7 +3,7 @@ import { DownloadOpts, DownloadRes, Renderer, RenderOptsModules } from './abstra
 import { RenderOpts, RenderOutput } from './abstract.renderer.js'
 import * as logger from '../Logger.js'
 import { config } from '../config.js'
-import { genCanonicalLink, genHeaderScript, genHeaderCSSLink, getStaticFiles, getRelativeFilePath, jsonStringify } from '../util/misc.js'
+import { genCanonicalLink, genHeaderScript, genHeaderCSSLink, getRelativeFilePath, jsonStringify } from '../util/misc.js'
 import MediaWiki from '../MediaWiki.js'
 import { htmlVectorLegacyTemplateCode, htmlVector2022TemplateCode, htmlFallbackTemplateCode, javaScriptTemplateCode } from '../Templates.js'
 import Downloader, { DownloadError } from '../Downloader.js'
@@ -32,16 +32,15 @@ export interface ActionParseResult {
 }
 
 export class ActionParseRenderer extends Renderer {
-  public staticFilesList: string[] = []
+  #staticFilesList: Set<string> = new Set()
   #htmlTemplateCode: () => string
   constructor() {
     super()
-    if (this.staticFilesList.length === 0) {
-      let cssResourcesCommon = config.output.cssResourcesCommon
+    if (this.#staticFilesList.size === 0) {
+      this.#staticFilesList.add('external-link.svg')
       if (['vector', 'vector-2022'].includes(MediaWiki.skin)) {
-        cssResourcesCommon = cssResourcesCommon.concat(MediaWiki.skin)
+        this.#staticFilesList.add(`${MediaWiki.skin}.css`)
       }
-      this.staticFilesList = getStaticFiles(config.output.jsResourcesCommon, cssResourcesCommon).concat('external-link.svg')
     }
     this.#htmlTemplateCode = MediaWiki.skin === 'vector' ? htmlVectorLegacyTemplateCode : MediaWiki.skin === 'vector-2022' ? htmlVector2022TemplateCode : htmlFallbackTemplateCode
     if (this.#htmlTemplateCode === htmlFallbackTemplateCode) {
@@ -201,8 +200,7 @@ export class ActionParseRenderer extends Renderer {
     }
   }
 
-  public async render(renderOpts: RenderOpts): Promise<any> {
-    const result: RenderOutput = []
+  public async render(renderOpts: RenderOpts): Promise<RenderOutput> {
     const { data, articleId, articleSubtitle, moduleDependencies, categoryMembers, categoriesHtml, bodyCssClass, htmlCssClass, dump } = renderOpts
     let { displayTitle } = renderOpts
 
@@ -249,7 +247,7 @@ export class ActionParseRenderer extends Renderer {
       })
     }
 
-    const { finalHTML, mediaDependencies, videoDependencies, imageDependencies, subtitles } = await super.processHtml({
+    return super.processHtml({
       html: htmlDocument.documentElement.outerHTML,
       dump,
       articleId,
@@ -261,18 +259,9 @@ export class ActionParseRenderer extends Renderer {
       moduleDependencies,
       callback: this.templateDesktopArticle.bind(this, bodyCssClass, htmlCssClass, hideFirstHeading),
     })
+  }
 
-    result.push({
-      articleId,
-      displayTitle: articleId.replace(/_/g, ' '),
-      html: finalHTML,
-      mediaDependencies,
-      videoDependencies,
-      imageDependencies,
-      moduleDependencies,
-      staticFiles: this.staticFilesList,
-      subtitles,
-    })
-    return result
+  public getStaticFilesList(): Set<string> {
+    return new Set([...this.#staticFilesList, ...this.staticFilesListCommon])
   }
 }

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -206,12 +206,6 @@ export async function saveStaticFiles(staticFiles: Set<string>, zimCreator: Crea
   }
 }
 
-export function getStaticFiles(jsStaticFiles: string[], cssStaticFiles: string[]): string[] {
-  jsStaticFiles = jsStaticFiles.map((jsFile) => jsFile.concat('.js'))
-  cssStaticFiles = cssStaticFiles.map((cssFile) => cssFile.concat('.css'))
-  return jsStaticFiles.concat(cssStaticFiles)
-}
-
 export function anyPath(ext: string, path: string, subDirectory = '') {
   const regex = new RegExp(`(\\.${ext})?$`)
   return `${subDirectory ? `${subDirectory}/` : ''}${path.replace(regex, '')}.${ext}`

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -25,19 +25,18 @@ function getArticleRenderUrl(articleId: string, articleDetail: ArticleDetail, du
 async function getAllArticlesToKeep(articleDetailXId: RKVS<ArticleDetail>, dump: Dump, articlesRenderer: Renderer) {
   await articleDetailXId.iterateItems(Downloader.workers, async (articleKeyValuePairs) => {
     for (const [articleId, articleDetail] of Object.entries(articleKeyValuePairs)) {
-      let rets: any
       try {
         const mainPage = isMainPage(articleId)
         const articleUrl = getArticleRenderUrl(articleId, articleDetail, dump)
 
-        rets = await Downloader.getArticle(articleId, articleDetailXId, articlesRenderer, articleUrl, dump, articleDetail)
+        const rendererOutput = await Downloader.getArticle(articleId, articleDetailXId, articlesRenderer, articleUrl, dump, articleDetail)
         await new Promise((resolve) => setTimeout(resolve, Downloader.articleRequestInterval))
-        for (const { articleId, html } of rets) {
-          if (!html) {
+        for (const { articleId, htmlContent } of rendererOutput.items) {
+          if (!htmlContent) {
             continue
           }
 
-          const doc = domino.createDocument(html)
+          const doc = domino.createDocument(htmlContent)
           if (!mainPage && !(await dump.customProcessor.shouldKeepArticle(articleId, doc))) {
             articleDetailXId.delete(articleId)
           }
@@ -50,32 +49,24 @@ async function getAllArticlesToKeep(articleDetailXId: RKVS<ArticleDetail>, dump:
   })
 }
 
-function flattenPromises(promisArr: [string, Promise<Error>][]): [string, Promise<Error>] {
-  return [
-    // first articleId
-    promisArr[0][0],
-    // promise resolving to first error or void
-    (async () => {
-      const resolved = await Promise.all(promisArr.map((p) => p[1]))
-      return resolved.find((err) => err)
-    })(),
-  ]
-}
-
 /*
  * Parse fetched article HTML, store files
  * and dependencies and save in Zim
  */
-async function saveArticle(
-  zimCreator: Creator,
-  finalHTML: string,
-  mediaDependencies: any,
-  imageDependencies: any,
-  videoDependencies: any,
-  subtitles: any,
-  articleId: string,
-  articleTitle: string,
-): Promise<Error> {
+async function saveArticle(zimCreator: Creator, htmlContent: string, zimPath: string, zimTitle: string): Promise<Error> {
+  try {
+    const zimArticle = zimTitle
+      ? new StringItem(zimPath, 'text/html', truncateUtf8Bytes(zimTitle, 245), { FRONT_ARTICLE: 1 }, htmlContent)
+      : new StringItem(zimPath, 'text/html', '', {}, htmlContent)
+    await zimCreatorMutex.runExclusive(() => zimCreator.addItem(zimArticle))
+
+    return null
+  } catch (err) {
+    return err as Error
+  }
+}
+
+async function saveArticleFiles(mediaDependencies: any, imageDependencies: any, videoDependencies: any, subtitles: any): Promise<Error> {
   try {
     const articleFiles: KVS<FileDetail> = {}
 
@@ -110,9 +101,6 @@ async function saveArticle(
 
     await FileManager.addManyFilesToProcess(articleFiles)
 
-    const zimArticle = new StringItem(articleId, 'text/html', truncateUtf8Bytes(articleTitle, 245), { FRONT_ARTICLE: 1 }, finalHTML)
-    await zimCreatorMutex.runExclusive(() => zimCreator.addItem(zimArticle))
-
     return null
   } catch (err) {
     return err as Error
@@ -125,7 +113,6 @@ async function saveArticle(
 export async function saveArticles(zimCreator: Creator, dump: Dump) {
   const jsModuleDependencies = new Set<string>()
   const cssModuleDependencies = new Set<string>()
-  const staticFilesList = new Set<string>()
   let prevPercentProgress: string
   const { articleDetailXId } = RedisStore
   const articlesTotal = await articleDetailXId.len()
@@ -137,7 +124,6 @@ export async function saveArticles(zimCreator: Creator, dump: Dump) {
     await getAllArticlesToKeep(articleDetailXId, dump, RenderingContext.articlesRenderer)
   }
 
-  const stages = ['Download Article and dependencies', 'Parse and Save to ZIM', 'Await left-over promises']
   // depending on which renderer we use, we can have up to 2 requests to make to download article details
   // each request we need to make can be retried 10 times. Each retry attempttakes at most requestTimeout + retry interval
   // retry interval is an exponentional value from 1 to 60s
@@ -149,97 +135,20 @@ export async function saveArticles(zimCreator: Creator, dump: Dump) {
       /*
        * timer to detect freezes
        */
-      let curStage = 0
       let curArticle = ''
       const timer = new Timer(() => {
-        const errorMessage = `Worker timed out after ${timeout} ms at ${stages[curStage]} ${curArticle}`
+        const errorMessage = `Worker timed out after ${timeout} ms at ${curArticle}`
         logger.error(errorMessage)
         reject(new Error(errorMessage))
       }, timeout)
 
       logger.info(`Worker processing batch of article ids [${logger.logifyArray(Object.keys(articleKeyValuePairs))}] - ${runningWorkers} worker(s) running`)
 
-      const parsePromiseQueue: [string, Promise<Error>][] = []
-
       for (const [articleId, articleDetail] of Object.entries(articleKeyValuePairs)) {
         timer.reset()
-        curStage = 0
         curArticle = articleId
-        const promises: [string, Promise<Error>][] = []
 
-        let rets: any
-        try {
-          const articleUrl = getArticleRenderUrl(articleId, articleDetail, dump)
-
-          rets = await Downloader.getArticle(articleId, articleDetailXId, RenderingContext.articlesRenderer, articleUrl, dump, articleDetail)
-          await new Promise((resolve) => setTimeout(resolve, Downloader.articleRequestInterval))
-
-          curStage += 1
-          for (const {
-            articleId,
-            displayTitle: articleTitle,
-            html: finalHTML,
-            mediaDependencies,
-            imageDependencies,
-            videoDependencies,
-            moduleDependencies,
-            staticFiles,
-            subtitles,
-          } of rets) {
-            if (!finalHTML) {
-              logger.warn(`No HTML returned for article [${articleId}], skipping`)
-              continue
-            }
-
-            for (const dep of moduleDependencies.jsDependenciesList || []) {
-              jsModuleDependencies.add(dep)
-            }
-            for (const dep of moduleDependencies.styleDependenciesList || []) {
-              cssModuleDependencies.add(dep)
-            }
-
-            for (const file of staticFiles) {
-              staticFilesList.add(file)
-            }
-
-            /*
-             * downloader.getArticle is network heavy while parsing and saving is I/O.
-             * To parse and download simultaniously, we don't await on save, but instead
-             * cache the promise in a queue and check it later
-             */
-            promises.push([articleId, saveArticle(zimCreator, finalHTML, mediaDependencies, imageDependencies, videoDependencies, subtitles, articleId, articleTitle)])
-          }
-        } catch (err) {
-          logger.error(`Error downloading/rendering article ${articleId}`)
-          reject(err)
-          return
-        }
-
-        curStage += 1
-        if (parsePromiseQueue.length) {
-          const [articleId, parsePromise] = parsePromiseQueue.shift()
-          curArticle = articleId
-          /*
-           * in normal circumstances, where downloading is slower than
-           * saving, this promise will always be resolved here already
-           */
-          const err = await parsePromise
-          if (err) {
-            logger.error(err)
-
-            logger.error(`Error parsing article ${articleId}`)
-            timer.clear()
-            reject(err)
-            return
-          }
-          dump.status.articles.success += 1
-        }
-
-        if (promises.length) {
-          parsePromiseQueue.push(flattenPromises(promises))
-        }
-
-        if ((dump.status.articles.success + dump.status.articles.hardFail + dump.status.articles.softFail) % 10 === 0) {
+        if (dump.status.articles.success > 0 && (dump.status.articles.success + dump.status.articles.hardFail + dump.status.articles.softFail) % 10 === 0) {
           const percentProgress = (((dump.status.articles.success + dump.status.articles.hardFail + dump.status.articles.softFail) / articlesTotal) * 100).toFixed(1)
           if (percentProgress !== prevPercentProgress) {
             prevPercentProgress = percentProgress
@@ -250,22 +159,52 @@ export async function saveArticles(zimCreator: Creator, dump: Dump) {
             )
           }
         }
-      }
 
-      /*
-       * clear up potentially still pending promises
-       */
-      curStage += 1
-      if (parsePromiseQueue.length) {
-        const [articleId, parsePromise] = flattenPromises(parsePromiseQueue)
-        curArticle = articleId
-        const err = await parsePromise
-        if (err) {
-          timer.clear()
+        try {
+          const articleUrl = getArticleRenderUrl(articleId, articleDetail, dump)
+
+          const { items, moduleDependencies, mediaDependencies, imageDependencies, videoDependencies, subtitles, needsDownloadErrorStaticFiles } = await Downloader.getArticle(
+            articleId,
+            articleDetailXId,
+            RenderingContext.articlesRenderer,
+            articleUrl,
+            dump,
+            articleDetail,
+          )
+          await new Promise((resolve) => setTimeout(resolve, Downloader.articleRequestInterval))
+
+          if (items.length == 0) {
+            logger.warn(`No HTML items returned for article [${articleId}], skipping`)
+            continue
+          }
+
+          if (needsDownloadErrorStaticFiles) {
+            RenderingContext.articlesRenderer.addDownloadErrorStaticFiles()
+          }
+
+          for (const dep of moduleDependencies.jsDependenciesList || []) {
+            jsModuleDependencies.add(dep)
+          }
+          for (const dep of moduleDependencies.styleDependenciesList || []) {
+            cssModuleDependencies.add(dep)
+          }
+
+          saveArticleFiles(mediaDependencies, imageDependencies, videoDependencies, subtitles)
+
+          for (const { htmlContent, zimPath, zimTitle } of items) {
+            if (!htmlContent) {
+              logger.warn(`No HTML content returned for article [${articleId}] path [${zimPath}], skipping`)
+              continue
+            }
+            saveArticle(zimCreator, htmlContent, zimPath, zimTitle)
+          }
+
+          dump.status.articles.success += 1
+        } catch (err) {
+          logger.error(`Error downloading/rendering article ${articleId}`)
           reject(err)
           return
         }
-        dump.status.articles.success += parsePromiseQueue.length
       }
 
       timer.clear()
@@ -276,7 +215,7 @@ export async function saveArticles(zimCreator: Creator, dump: Dump) {
   logger.log(`Done with downloading a total of [${articlesTotal}] articles`)
 
   return {
-    staticFilesList,
+    staticFilesList: RenderingContext.articlesRenderer.getStaticFilesList(),
     jsModuleDependencies,
     cssModuleDependencies,
   }

--- a/test/unit/downloader.test.ts
+++ b/test/unit/downloader.test.ts
@@ -152,9 +152,12 @@ describe('Downloader class - wikipedia EN', () => {
           dump,
           articleDetail,
         )
-        expect(neverExistingArticleResult).toHaveLength(1)
-        expect(neverExistingArticleResult[0].articleId).toBe('NeverExistingArticle')
-        expect(neverExistingArticleResult[0].html).toContain('Oops. Article not found.')
+        expect(neverExistingArticleResult.items).toHaveLength(1)
+        expect(neverExistingArticleResult.needsDownloadErrorStaticFiles).toBe(true)
+        expect(neverExistingArticleResult.items[0].articleId).toBe('NeverExistingArticle')
+        expect(neverExistingArticleResult.items[0].zimPath).toBe('NeverExistingArticle')
+        expect(neverExistingArticleResult.items[0].zimTitle).toBe('')
+        expect(neverExistingArticleResult.items[0].htmlContent).toContain('Oops. Article not found.')
       })
     }
   })
@@ -298,9 +301,12 @@ describe('Downloader class - wikipedia ES', () => {
           dump,
           articleDetails[articleId],
         )
-        expect(articleResult).toHaveLength(1)
-        expect(articleResult[0].articleId).toBe('Alejandro_González_y_Robleto')
-        expect(articleResult[0].html).toContain('Datos biográficos')
+        expect(articleResult.items).toHaveLength(1)
+        expect(articleResult.needsDownloadErrorStaticFiles).toBe(false)
+        expect(articleResult.items[0].articleId).toBe('Alejandro_González_y_Robleto')
+        expect(articleResult.items[0].zimPath).toBe('Alejandro_González_y_Robleto')
+        expect(articleResult.items[0].zimTitle).toBe('Alejandro González y Robleto')
+        expect(articleResult.items[0].htmlContent).toContain('Datos biográficos')
 
         // Only ActionParse API gives sufficient information so that we automatically add missing redirects
         if (renderer == 'ActionParse') {
@@ -341,9 +347,12 @@ describe('Downloader class - wikipedia ES', () => {
       dump,
       articleDetails[articleId],
     )
-    expect(articleResult).toHaveLength(1)
-    expect(articleResult[0].articleId).toBe('Alejandro_González_y_Robleto')
-    expect(articleResult[0].html).toContain('Datos biográficos')
+    expect(articleResult.items).toHaveLength(1)
+    expect(articleResult.needsDownloadErrorStaticFiles).toBe(false)
+    expect(articleResult.items[0].articleId).toBe('Alejandro_González_y_Robleto')
+    expect(articleResult.items[0].zimPath).toBe('Alejandro_González_y_Robleto')
+    expect(articleResult.items[0].zimTitle).toBe('Alejandro González y Robleto')
+    expect(articleResult.items[0].htmlContent).toContain('Datos biográficos')
 
     const redirectArticleResult = await Downloader.getArticle(
       redirectArticleId,
@@ -353,9 +362,12 @@ describe('Downloader class - wikipedia ES', () => {
       dump,
       articleDetails[redirectArticleId],
     )
-    expect(redirectArticleResult).toHaveLength(1)
-    expect(redirectArticleResult[0].articleId).toBe('Vicente_Alejandro_González_y_Robleto')
-    expect(redirectArticleResult[0].html).toContain('Datos biográficos')
+    expect(redirectArticleResult.items).toHaveLength(1)
+    expect(redirectArticleResult.needsDownloadErrorStaticFiles).toBe(false)
+    expect(redirectArticleResult.items[0].articleId).toBe('Vicente_Alejandro_González_y_Robleto')
+    expect(redirectArticleResult.items[0].zimPath).toBe('Vicente_Alejandro_González_y_Robleto')
+    expect(redirectArticleResult.items[0].zimTitle).toBe('Vicente Alejandro González y Robleto')
+    expect(redirectArticleResult.items[0].htmlContent).toContain('Datos biográficos')
 
     // both redirects have been added by 'mistake' ; it will be the responsibility of code handling
     // redirects rewrite to recover from this situation

--- a/test/unit/renderers/processHtml.test.ts
+++ b/test/unit/renderers/processHtml.test.ts
@@ -11,6 +11,9 @@ describe('processHtml', () => {
     render(): Promise<any> {
       throw new Error('Method not implemented.')
     }
+    getStaticFilesList(): Set<string> {
+      throw new Error('Method not implemented.')
+    }
   }
 
   const testRenderer = new TestRender()
@@ -34,7 +37,14 @@ describe('processHtml', () => {
         return domino.createDocument('<html><head><title></title></head><body><div id="mw-content-text"></div></body></html>')
       },
     }
-    return await testRenderer.processHtml(opts)
+    const result = await testRenderer.processHtml(opts)
+    expect(result.items.length).toBe(1)
+    return {
+      // Hack to match older simpler format
+      finalHTML: result.items[0].htmlContent,
+      imageDependencies: result.imageDependencies,
+      videoDependencies: result.videoDependencies,
+    }
   }
 
   describe('audio tags', () => {

--- a/test/unit/saveArticles.test.ts
+++ b/test/unit/saveArticles.test.ts
@@ -70,7 +70,7 @@ describe('saveArticles', () => {
       articleDetailXId.setMany(articlesDetail)
       const result = await Downloader.getArticle(articleId, articleDetailXId, RenderingContext.articlesRenderer, articleUrl, dump, articleDetail)
 
-      const articleDoc = domino.createDocument(result[0].html)
+      const articleDoc = domino.createDocument(result.items[0].htmlContent)
 
       const headings = Array.from(articleDoc.querySelectorAll('.mw-heading'))
       const infoboxes = Array.from(articleDoc.querySelectorAll('table.infobox'))
@@ -92,7 +92,7 @@ describe('saveArticles', () => {
       const articleDetail = { title: articleId, timestamp: '2023-08-20T14:54:01Z' }
       articleDetailXId.setMany(articlesDetail)
       const result = await Downloader.getArticle(articleId, articleDetailXId, RenderingContext.articlesRenderer, articleUrl, dump, articleDetail)
-      const articleDoc = domino.createDocument(result[0].html)
+      const articleDoc = domino.createDocument(result.items[0].htmlContent)
       expect(articleDoc.querySelector('h1.article-header')).toBeFalsy()
     })
 
@@ -172,7 +172,7 @@ describe('saveArticles', () => {
       articleDetailXId.setMany(articlesDetail)
       const result = await Downloader.getArticle(articleId, articleDetailXId, RenderingContext.articlesRenderer, articleUrl, dump, articleDetail)
 
-      const articleDoc = domino.createDocument(result[0].html)
+      const articleDoc = domino.createDocument(result.items[0].htmlContent)
 
       // Document has scripts that we added, but shouldn't have any without a `src` (inline).
       const remainingInlineScripts = Array.from(articleDoc.querySelectorAll('script:not([src]):not(#mwoffliner-jsConfigVars)'))
@@ -190,7 +190,7 @@ describe('saveArticles', () => {
       const articleDetail = { title: articleId, timestamp: '2023-08-20T14:54:01Z' }
       articleDetailXId.setMany(articlesDetail)
       const result = await Downloader.getArticle(articleId, articleDetailXId, RenderingContext.articlesRenderer, articleUrl, dump, articleDetail)
-      const articleDoc = domino.createDocument(result[0].html)
+      const articleDoc = domino.createDocument(result.items[0].htmlContent)
       expect(articleDoc.querySelector('#Get_around')).toBeTruthy()
       expect(articleDoc.querySelector('#Do')).toBeFalsy()
       expect(articleDoc.querySelector('#Eat')).toBeTruthy()
@@ -209,7 +209,7 @@ describe('saveArticles', () => {
       const articleDetail = { title: articleId, timestamp: '2023-08-20T14:54:01Z' }
       articleDetailXId.setMany(articlesDetail)
       const result = await Downloader.getArticle(articleId, articleDetailXId, RenderingContext.articlesRenderer, articleUrl, dump, articleDetail)
-      const articleDoc = domino.createDocument(result[0].html)
+      const articleDoc = domino.createDocument(result.items[0].htmlContent)
       expect(articleDoc.querySelector('#Get_around')).toBeTruthy()
       expect(articleDoc.querySelector('#Do')).toBeTruthy()
       expect(articleDoc.querySelector('#Eat')).toBeTruthy()

--- a/test/unit/saveStaticFiles.test.ts
+++ b/test/unit/saveStaticFiles.test.ts
@@ -16,7 +16,7 @@ describe('saveStaticFiles', () => {
   for (const skin of ['vector', 'vector-2022', 'fandomdesktop']) {
     test(`Compare ${skin} skin static files list`, async () => {
       MediaWiki.skin = skin
-      const desktopAndCommonStaticFiles = [
+      const desktopAndCommonStaticFiles = new Set([
         'masonry.min.js',
         'article_list_home.js',
         'images_loaded.min.js',
@@ -26,10 +26,10 @@ describe('saveStaticFiles', () => {
         ...(skin === 'vector' ? ['vector.css'] : []),
         ...(skin === 'vector-2022' ? ['vector-2022.css'] : []),
         'external-link.svg',
-      ]
+      ])
 
       const actionParseRenderer = new ActionParseRenderer()
-      const staticFilesFromRenderer = actionParseRenderer.staticFilesList
+      const staticFilesFromRenderer = actionParseRenderer.getStaticFilesList()
 
       expect(desktopAndCommonStaticFiles).toEqual(staticFilesFromRenderer)
     })

--- a/test/unit/treatments/article.treatment.test.ts
+++ b/test/unit/treatments/article.treatment.test.ts
@@ -45,10 +45,11 @@ describe('ArticleTreatment', () => {
       // Successfully scrapped existent articles + placeholder for deleted article
       expect(addedArticles).toHaveLength(2)
 
-      expect([addedArticles[0].title, addedArticles[1].title]).toEqual(expect.arrayContaining(['London', 'non-existent-article']))
+      expect([addedArticles[0].title, addedArticles[1].title]).toEqual(expect.arrayContaining(['London', '']))
+      expect([addedArticles[0].path, addedArticles[1].path]).toEqual(expect.arrayContaining(['London', 'non-existent-article']))
 
       for (let i = 0; i <= 1; i++) {
-        if (addedArticles[i].title === 'London') {
+        if (addedArticles[i].path === 'London') {
           const articleDoc = domino.createDocument(addedArticles[i].getContentProvider().feed().toString())
 
           // Successfully scrapped existent articles
@@ -57,7 +58,7 @@ describe('ArticleTreatment', () => {
           expect(articleDoc.querySelector('meta[name="geo.position"]')?.getAttribute('content')).toEqual('51.50722222;-0.1275')
         }
 
-        if (addedArticles[i].title === 'non-existent-article') {
+        if (addedArticles[i].path === 'non-existent-article') {
           expect(addedArticles[i].getContentProvider().feed().toString()).toContain('Oops. Article not found.')
         }
       }

--- a/test/unit/treatments/media.treatment.test.ts
+++ b/test/unit/treatments/media.treatment.test.ts
@@ -12,6 +12,9 @@ describe('MediaTreatment', () => {
     public render() {
       return null
     }
+    getStaticFilesList(): Set<string> {
+      return new Set()
+    }
     public async testTreatVideo(dump: Dump, srcCache: KVS<boolean>, articleId: string, videoEl: DominoElement) {
       return this.treatAudioVideo(dump, srcCache, articleId, videoEl)
     }


### PR DESCRIPTION
This is a refactoring PR to prepare for #2620 ; the core goal is to allow the renderer to return a list of HTML files to include in the ZIM for a single article retrieved from Mediawiki instance

Changes:
- simplify static files handling: input extension directly in config + stop wasting time computing the list for every article since it is static per renderer (and Mediawiki instance)
- instead of assuming an article will return a list of outputs with each a list of dependencies (images, ...) simplify the logic by assuming an article will return a list of HTML items and list of dependencies (images, ...)
- drop complexities of deeply buried promises in `saveArticle` which was quite flawed (we are already handling a promise per article, there is no point in pushing to many promises in the queue and ending with promises overflow) and useless now

In other words, main PR goal is to move from

```ts
export interface RenderSingleOutput {
  articleId: string
  displayTitle: string
  html: string
  imageDependencies: any
  videoDependencies: any
  mediaDependencies: any
  moduleDependencies: any
  staticFiles: string[]
  subtitles: any
}

export type RenderOutput = RenderSingleOutput[]
```

to

```ts

export type RenderSingleOutput = {
  articleId: string
  zimPath: string
  zimTitle?: string
  htmlContent: string
}

export type RenderOutput = {
  items: RenderSingleOutput[]
  imageDependencies: any
  videoDependencies: any
  mediaDependencies: any
  moduleDependencies: any
  subtitles: any
}
```

Everything else is expected to be pure plumbing changes.