### PR TITLE
Use Pino log library, change log level values and CLI argument controlling log level

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -31,6 +31,7 @@ Unreleased:
 * FIX: Remove Jest stack trace decoration from E2E test logs (@triemerge #2038)
 * UPDATE: Use node-libzim 4.3.0 and Node.JS 26, update dependencies (@benoit74 #2743)
 * FIX: Remove now unused resource files (@benoit74 #2748)
+* CHANGED: *** Breaking *** Use Pino log library, change log level values and CLI argument controlling log level (@benoit74 #2122)
 
 
 1.17.5:

--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -214,17 +214,17 @@
       "required": false,
       "description": "Don't include a fulltext search index to the ZIM"
     },
-    "verbose": {
+    "logLevel": {
       "type": "string-enum",
       "required": false,
       "title": "Verbose",
-      "description": "Level of log verbosity, one of info, log, warn, error or quiet. Default is error.",
+      "description": "Set the log level. One of: \"debug\", \"info\", \"warn\", \"error\", \"silent\" (default: \"info\").",
       "choices": [
+        { "title": "DEBUG", "value": "debug " },
         { "title": "INFO", "value": "info" },
-        { "title": "LOG", "value": "log" },
         { "title": "WARN", "value": "warn" },
         { "title": "ERROR", "value": "error" },
-        { "title": "QUIET", "value": "quiet" }
+        { "title": "SILENT", "value": "silent" }
       ]
     },
     "webp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,8 @@
         "merge": "^2.1.1",
         "mkdirp": "^3.0.1",
         "p-map": "^7.0.4",
+        "pino": "^9.6.0",
+        "pino-pretty": "^13.0.0",
         "public-ip": "^8.0.0",
         "redis": "^6.0.0",
         "rimraf": "^6.1.3",
@@ -2655,6 +2657,12 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -4078,6 +4086,15 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -5583,6 +5600,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -5711,6 +5734,15 @@
       },
       "funding": {
         "url": "https://github.com/imagemin/cwebp-bin?sponsor=1"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -6826,6 +6858,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6881,6 +6919,12 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
     "node_modules/fast-uri": {
@@ -7882,6 +7926,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -10139,6 +10189,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jpegoptim-bin": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/jpegoptim-bin/-/jpegoptim-bin-7.1.0.tgz",
@@ -11379,6 +11438,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -11847,6 +11915,97 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/pirates": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
@@ -12188,6 +12347,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
@@ -12320,6 +12495,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
     "node_modules/react-is-18": {
       "name": "react-is",
       "version": "18.3.1",
@@ -12360,6 +12541,15 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
     },
     "node_modules/redis": {
       "version": "6.0.0",
@@ -12904,12 +13094,37 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/seek-bzip": {
       "version": "1.0.6",
@@ -13129,6 +13344,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -13253,6 +13477,15 @@
       "resolved": "https://registry.npmjs.org/split-by-grapheme/-/split-by-grapheme-1.0.1.tgz",
       "integrity": "sha512-aH+OtxnX+AOyWJvw2hNaQyY9wkzkG6o8URD+rRwFKWkqUduxMA+icOBJv1/aoLuKbb15f0qRHXM+rs94Q50blA==",
       "license": "ISC"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -13704,6 +13937,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/through": {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,8 @@
     "url-join": "^5.0.0",
     "utf8-binary-cutter": "^0.9.2",
     "webp-hero": "0.0.2",
+    "pino": "^9.6.0",
+    "pino-pretty": "^13.0.0",
     "yargs": "^18.0.0"
   },
   "keywords": [

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -230,21 +230,21 @@ class Downloader {
       retryIf: (err: any) => {
         const requestedUrl = err.urlCalled || err.config?.url || 'unknown'
         if (isMalformedJsonResponseError(err)) {
-          logger.log(`Retrying ${requestedUrl} due to malformed JSON response`)
+          logger.info(`Retrying ${requestedUrl} due to malformed JSON response`)
           return true
         }
 
         if (err instanceof AxiosError && err.code && !['ERR_BAD_REQUEST', 'ERR_BAD_RESPONSE'].includes(err.code)) {
-          logger.log(`Retrying ${requestedUrl} URL due to ${err.code} error`)
+          logger.info(`Retrying ${requestedUrl} URL due to ${err.code} error`)
           return true // retry all connection issues
         }
         if (err.responseData?.error?.code === 'maxlag') {
-          logger.log(`Mediawiki server is lagging ${err.responseData?.error?.lag}s; retrying in few seconds`)
+          logger.info(`Mediawiki server is lagging ${err.responseData?.error?.lag}s; retrying in few seconds`)
           return true // note that we do not honor Retry-After header value because it is not possible in current code architecture
         }
         const httpReturnCode = err.response?.status || err.httpReturnCode
         if ([429, 500, 502, 503, 504, 524].includes(httpReturnCode)) {
-          logger.log(`Retrying ${requestedUrl} URL due to HTTP ${httpReturnCode} error`)
+          logger.info(`Retrying ${requestedUrl} URL due to HTTP ${httpReturnCode} error`)
           return true // retry these HTTP status codes
         }
         if (
@@ -259,13 +259,13 @@ class Downloader {
             'internal_api_error_Wikimedia\\Parsoid\\Core\\ResourceLimitExceededException',
           ].includes(err.responseData?.error?.code)
         ) {
-          logger.log(`Retrying ${requestedUrl} URL due to ${err.responseData?.error?.code} Mediawiki error`)
+          logger.info(`Retrying ${requestedUrl} URL due to ${err.responseData?.error?.code} Mediawiki error`)
           return true // retry these Mediawiki codes which are known to be transient
         }
         return false // don't retry other errors
       },
       backoffHandler: (number: number, delay: number) => {
-        logger.info(`[backoff] #${number} after ${delay} ms`)
+        logger.debug(`[backoff] #${number} after ${delay} ms`)
       },
       ...backoffOptions,
     }
@@ -504,7 +504,7 @@ class Downloader {
     dump: Dump,
     articleDetail?: ArticleDetail,
   ): Promise<RenderOutput> {
-    logger.info(`Getting article [${articleId}] from ${articleUrl}`)
+    logger.debug(`Getting article [${articleId}] from ${articleUrl}`)
 
     try {
       const {
@@ -594,14 +594,14 @@ class Downloader {
         throw err
       }
       if (errorRule.isHardFailure) {
-        logger.log(`This is a hard ${errorRule.detailsMessageKey} error which will be replaced by a placeholder`)
+        logger.info(`This is a hard ${errorRule.detailsMessageKey} error which will be replaced by a placeholder`)
         dump.status.articles.hardFail += 1
         dump.status.articles.hardFailedArticleIds.push(articleId)
         if (dump.maxHardFailedArticles > 0 && dump.status.articles.hardFail > dump.maxHardFailedArticles) {
           throw new Error('Too many articles failed to download') // eslint-disable-line preserve-caught-error
         }
       } else {
-        logger.log(`This is a soft ${errorRule.detailsMessageKey} error which will be replaced by a placeholder`)
+        logger.info(`This is a soft ${errorRule.detailsMessageKey} error which will be replaced by a placeholder`)
         dump.status.articles.softFail += 1
         dump.status.articles.softFailedArticleIds.push(articleId)
       }
@@ -633,7 +633,7 @@ class Downloader {
       this.backoffCall(this.getJSONCb, url, 'json', undefined, (err: any, val: any) => {
         if (err) {
           const httpStatus = (err.response && err.response.status) || err.httpReturnCode
-          logger.info(`Failed to get [${url}] [status=${httpStatus}]`)
+          logger.debug(`Failed to get [${url}] [status=${httpStatus}]`)
           reject(err)
         } else {
           resolve(val)
@@ -712,7 +712,7 @@ class Downloader {
   private static handleMWWarningsAndErrors(resp: MwApiResponse): void {
     if (resp.warnings) logger.warn(`Got warning from MW Query ${JSON.stringify(resp.warnings, null, '\t')}`)
     if (resp.error?.code === DB_ERROR) throw new Error(`Got error from MW Query ${JSON.stringify(resp.error, null, '\t')}`)
-    if (resp.error) logger.log(`Got error from MW Query ${JSON.stringify(resp.warnings, null, '\t')}`)
+    if (resp.error) logger.info(`Got error from MW Query ${JSON.stringify(resp.warnings, null, '\t')}`)
   }
 
   private async getArticleQueryOpts(includePageimages = false, followRedirects = false): Promise<QueryOpts> {
@@ -726,7 +726,7 @@ class Downloader {
   }
 
   private getJSONCb = <T>(url: string, kind: DownloadKind, _requestedWidth: number | undefined, handler: (...args: any[]) => any): void => {
-    logger.info(`Getting JSON from [${url}]`)
+    logger.debug(`Getting JSON from [${url}]`)
     this.request<T>({ url, method: 'GET', ...this.jsonRequestOptions })
       .then((val) => {
         const contentType = val.headers['content-type']?.toString() || null
@@ -810,7 +810,7 @@ class Downloader {
   }
 
   private getContentCb = async (url: string, kind: DownloadKind, requestedWidth: number | undefined, handler: any): Promise<void> => {
-    logger.info(`Downloading [${url}]`)
+    logger.debug(`Downloading [${url}]`)
     try {
       if (this.optimisationCacheUrl && kind === 'image') {
         this.downloadImage(url, handler, requestedWidth)
@@ -866,7 +866,7 @@ class Downloader {
             // Proceed with image
             const data = (await this.streamToBuffer(s3Resp.Body as Readable)) as any
             const contentType = await this.getImageMimeType(data)
-            logger.info(`Using S3-cached image for ${url} (contentType: ${contentType})`)
+            logger.debug(`Using S3-cached image for ${url} (contentType: ${contentType})`)
             handler(null, {
               contentType,
               content: data,
@@ -891,9 +891,9 @@ class Downloader {
           // get contentType from image, with fallback to response headers should the image be unsupported at all (e.g. SVG)
           const contentType = (await this.getImageMimeType(compressedData)) || mwResp.headers['content-type']
           if (s3Resp) {
-            logger.info(`Using image downloaded from upstream for ${url} (S3-cached image is outdated, contentType: ${contentType})`)
+            logger.debug(`Using image downloaded from upstream for ${url} (S3-cached image is outdated, contentType: ${contentType})`)
           } else {
-            logger.info(`Using image downloaded from upstream for ${url} (no S3-cached image found, contentType: ${contentType})`)
+            logger.debug(`Using image downloaded from upstream for ${url} (no S3-cached image found, contentType: ${contentType})`)
           }
 
           // Proceed with image
@@ -911,7 +911,7 @@ class Downloader {
   }
 
   private errHandler(err: any, url: string, handler: any): void {
-    logger.info(`Error while downloading content for ${url} due to ${err} ; might be retried`)
+    logger.debug(`Error while downloading content for ${url} due to ${err} ; might be retried`)
     handler(err)
   }
 

--- a/src/Dump.ts
+++ b/src/Dump.ts
@@ -140,7 +140,7 @@ export class Dump {
     if (this.opts.resume) {
       const zimPath = this.computeZimRootPath()
       if (existsSync(zimPath)) {
-        logger.log(`${zimPath} is already done, skip dumping & ZIM file generation`)
+        logger.info(`${zimPath} is already done, skip dumping & ZIM file generation`)
         throw new Error('TODO: IMPLEMENT RESUME')
       }
     }

--- a/src/Gadgets.ts
+++ b/src/Gadgets.ts
@@ -14,7 +14,7 @@ class Gadgets {
 
   public setGadgets(gadgets: Gadget[]) {
     this.gadgets = gadgets
-    logger.info(this.gadgets === undefined ? 'Gadgets are not supported on this wiki' : `${this.gadgets.length} gadgets retrieved`)
+    logger.debug(this.gadgets === undefined ? 'Gadgets are not supported on this wiki' : `${this.gadgets.length} gadgets retrieved`)
   }
 
   /*

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,49 +1,40 @@
 import { format } from 'util'
+import pino from 'pino'
+import pinoPretty from 'pino-pretty'
 
-export const logLevels = ['info', 'log', 'warn', 'error', 'quiet']
+export const logLevels = ['debug', 'info', 'warn', 'error', 'silent'] as const
 export type LogLevel = (typeof logLevels)[number]
 
-let verboseLevel = 'error'
+// Passing process.stdout as destination makes pino-pretty write via process.stdout.write()
+// rather than via sonic-boom / fs.writeSync, which keeps jest spies working in tests.
+const stream = pinoPretty({
+  colorize: process.stdout.isTTY ?? false,
+  destination: process.stdout,
+  ignore: 'pid,hostname',
+  translateTime: 'UTC:yyyy-mm-dd HH:MM:ss.l',
+})
+const _pino = pino({ level: 'silent' }, stream)
 
-const isVerbose = (level: LogLevel) => {
-  if (!verboseLevel) {
-    return false
+export const setLogLevel = (level: LogLevel) => {
+  _pino.level = level
+}
+
+const makeLogFn = (pinoLevel: 'debug' | 'info' | 'warn' | 'error') => {
+  return (msg: string, ...args: any[]) => {
+    if (args.length === 1 && args[0] instanceof Error) {
+      _pino[pinoLevel]({ err: args[0] }, msg)
+    } else if (args.length > 0) {
+      _pino[pinoLevel](format(msg, ...args))
+    } else {
+      _pino[pinoLevel](msg)
+    }
   }
-
-  const verboseLevelIndex = logLevels.indexOf(verboseLevel)
-  const logLevelIndex = logLevels.indexOf(level)
-  return logLevelIndex >= verboseLevelIndex ? true : false
 }
 
-const doLog = (type: LogLevel, args: any[]) => {
-  if (isVerbose(type)) {
-    process.stdout.write(format(`[${type}] [${getTs()}]`, ...args) + '\n')
-  }
-}
-
-const getTs = () => {
-  return new Date().toISOString()
-}
-
-export const setVerboseLevel = (level: LogLevel | true) => {
-  verboseLevel = level === true ? 'info' : level
-}
-
-export const info = (...args: any[]) => {
-  doLog('info', args)
-}
-
-export const log = (...args: any[]) => {
-  doLog('log', args)
-}
-
-export const warn = (...args: any[]) => {
-  doLog('warn', args)
-}
-
-export const error = (...args: any[]) => {
-  doLog('error', args)
-}
+export const debug = makeLogFn('debug')
+export const info = makeLogFn('info')
+export const warn = makeLogFn('warn')
+export const error = makeLogFn('error')
 
 export const logifyArray = (arr: any[]) => {
   if (arr.length < 3) {

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -161,7 +161,7 @@ class MediaWiki {
     if (value) {
       this.#wikiPath = value
       this.webUrl = this.urlDirector.buildURL(this.#wikiPath)
-      logger.log(`webUrl: ${this.webUrl}`)
+      logger.info(`webUrl: ${this.webUrl}`)
     }
   }
 
@@ -242,7 +242,7 @@ class MediaWiki {
       this.actionParseUrlDirector = new ActionParseURLDirector(this.actionApiUrl.href, this.skin)
       const checkUrl = this.actionParseUrlDirector.buildArticleURL(this.apiCheckArticleId)
       this.#hasActionParseApi = await checkApiAvailability(checkUrl)
-      logger.log(`Checked for ActionParseApi at ${checkUrl} -- result is: ${this.#hasActionParseApi}`)
+      logger.info(`Checked for ActionParseApi at ${checkUrl} -- result is: ${this.#hasActionParseApi}`)
     }
     return this.#hasActionParseApi
   }
@@ -259,10 +259,10 @@ class MediaWiki {
       const resp = await Downloader.getJSON<MwApiResponse>(this.#apiUrlDirector.buildQueryURL(reqOpts))
       const isCoordinateWarning = JSON.stringify(resp?.warnings?.query ?? '').includes('coordinates')
       if (isCoordinateWarning) {
-        logger.log('Coordinates not available on this wiki')
+        logger.info('Coordinates not available on this wiki')
         return (this.#hasCoordinates = false)
       }
-      logger.log('Coordinates available on this wiki')
+      logger.info('Coordinates available on this wiki')
       return (this.#hasCoordinates = true)
     }
     return this.#hasCoordinates
@@ -273,7 +273,7 @@ class MediaWiki {
       // startup JS module is supposed to be available on all Mediawikis
       const checkUrl = `${this.modulePath}lang=en&modules=startup&only=scripts`
       this.#hasModuleApi = await checkApiAvailability(checkUrl)
-      logger.log('Checked for Module API at', checkUrl, '-- result is: ', this.#hasModuleApi)
+      logger.info('Checked for Module API at', checkUrl, '-- result is: ', this.#hasModuleApi)
     }
     return this.#hasModuleApi
   }
@@ -288,10 +288,10 @@ class MediaWiki {
       const resp = await Downloader.getJSON<MwApiResponse>(this.#apiUrlDirector.buildQueryURL(reqOpts))
       const isFlaggedWarning = JSON.stringify(resp?.warnings?.query ?? '').includes('flagged')
       if (isFlaggedWarning) {
-        logger.log('FlaggedRevs not available on this wiki')
+        logger.info('FlaggedRevs not available on this wiki')
         return (this.#hasFlaggedRevs = false)
       }
-      logger.log('FlaggedRevs available on this wiki')
+      logger.info('FlaggedRevs available on this wiki')
       return (this.#hasFlaggedRevs = true)
     }
     return this.#hasFlaggedRevs
@@ -335,7 +335,7 @@ class MediaWiki {
           }
           throw new Error('Login Failed')
         } else {
-          logger.log('Login Success')
+          logger.info('Login Success')
         }
       })
     }
@@ -448,7 +448,7 @@ class MediaWiki {
   }
 
   public async getSiteInfo({ addNamespaces, mwModulePath, forceSkin, langVariants }: SiteInfoArgv = {}) {
-    logger.log('Getting site info...')
+    logger.info('Getting site info...')
     const body = await Downloader.querySiteInfo()
 
     const generalEntries = body.query.general
@@ -472,7 +472,7 @@ class MediaWiki {
     const logo = generalEntries.logo
     const langMw = generalEntries.lang
     const textDir = generalEntries.rtl ? 'rtl' : 'ltr'
-    logger.log(`Text direction is [${textDir}]`)
+    logger.info(`Text direction is [${textDir}]`)
 
     // Gather languages codes (en remove the 'dialect' part)
     const langs: string[] = [langMw].concat(generalEntries.fallback.map((e: any) => e.code)).map(function (e) {

--- a/src/RedisStore.ts
+++ b/src/RedisStore.ts
@@ -87,7 +87,7 @@ class RedisStore implements RS {
 
   public async close() {
     if (this.#client.isReady && this.#storesReady) {
-      logger.log('Flushing Redis DBs')
+      logger.info('Flushing Redis DBs')
       await Promise.all([this.#filesToDownloadXPath.flush(), this.#articleDetailXId.flush(), this.#redirectsXId.flush(), ...this.#filesQueues.map((queue) => queue.flush())])
     }
     if (this.#client.isOpen) {

--- a/src/S3.ts
+++ b/src/S3.ts
@@ -116,7 +116,7 @@ class S3 {
         .catch((err: any) => {
           // For 404 error handle AWS service-specific exception
           if (err && err.name === 'NoSuchKey') {
-            logger.info(`The specified key '${key}' does not exist in the cache.`)
+            logger.debug(`The specified key '${key}' does not exist in the cache.`)
             resolve(null)
           } else {
             logger.error(`Error (${err}) while downloading the object '${key}' from the cache.`)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,11 @@ Usage: npm run mwoffliner -- --help`,
   .demandOption(requiredParams)
   .strict().argv
 
+// Set log level as early as possible so sanitize errors and fatal errors are visible.
+// If the value is not a valid level, default to 'info' and let sanitize_all report it.
+const earlyLogLevel = argv.logLevel
+logger.setLogLevel(logger.logLevels.includes(earlyLogLevel) ? earlyLogLevel : 'info')
+
 /* ***********************************/
 /* TMPDIR OVERRIDE HAS TO BE HANDLED */
 /* AT THE REALLY BEGIN               */
@@ -62,7 +67,7 @@ sanitize_all(argv)
     mwofflinerLib
       .execute(argv)
       .then(() => {
-        logger.info(`Finished running mwoffliner after [${Math.round((Date.now() - execStartTime) / 1000)}s]`)
+        logger.debug(`Finished running mwoffliner after [${Math.round((Date.now() - execStartTime) / 1000)}s]`)
         process.exit(0)
       })
       .catch((err) => {

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -67,7 +67,7 @@ async function execute(argv: any) {
   const {
     speed: _speed,
     adminEmail,
-    verbose,
+    logLevel,
     minifyHtml,
     keepEmptySections,
     mwUrl,
@@ -119,9 +119,9 @@ async function execute(argv: any) {
   /* CUSTOM VARIABLE SECTION ********* */
   /* ********************************* */
 
-  logger.setVerboseLevel(verbose ? verbose : 'log') // Default log level is 'log'
+  logger.setLogLevel(logLevel ?? 'info')
 
-  logger.log(`Starting mwoffliner v${packageJSON.version}...`)
+  logger.debug(`Starting mwoffliner v${packageJSON.version}...`)
 
   // TODO: Move it to sanitize method
   if (articleList) articleList = String(articleList)
@@ -131,7 +131,7 @@ async function execute(argv: any) {
   if (customCss) {
     Downloader.customCssUrls = parseCustomCssUrls(String(customCss))
     if (Downloader.customCssUrls.length > 0) {
-      logger.log(`Custom CSS URLs configured: ${Downloader.customCssUrls.join(', ')}`)
+      logger.info(`Custom CSS URLs configured: ${Downloader.customCssUrls.join(', ')}`)
     }
   }
   const publisher = _publisher || config.defaults.publisher
@@ -154,7 +154,7 @@ async function execute(argv: any) {
   }
 
   /* Instantiate custom flavour module */
-  logger.info(`Using custom flavour: ${customFlavour || 'no'}`)
+  logger.debug(`Using custom flavour: ${customFlavour || 'no'}`)
   const customProcessor = customFlavour ? new (await import(customFlavour))() : null
 
   let s3Obj
@@ -165,7 +165,7 @@ async function execute(argv: any) {
     const s3Url = (s3UrlObj.protocol || 'https:') + '//' + (s3UrlObj.host || '') + (s3UrlObj.pathname || '')
     s3Obj = new S3(s3Url, s3UrlObj.searchParams, requestTimeout * 1000 || config.defaults.requestTimeout, argv.insecure)
     await s3Obj.initialise().then(() => {
-      logger.log('Successfully logged in S3')
+      logger.info('Successfully logged in S3')
     })
   }
 
@@ -186,7 +186,7 @@ async function execute(argv: any) {
 
   /* HTTP user-agent string */
   const uaString = `${_userAgent || config.userAgent} (${adminEmail})`
-  logger.log(`Using User-Agent: ${uaString}`)
+  logger.info(`Using User-Agent: ${uaString}`)
 
   /* Download helpers; TODO: Merge with something else / expand this. */
   Downloader.init = {
@@ -270,25 +270,25 @@ async function execute(argv: any) {
   // Output directory
   const outputDirectory = path.isAbsolute(_outputDirectory || '') ? _outputDirectory : path.join(process.cwd(), _outputDirectory || 'out')
   await mkdirPromise(outputDirectory)
-  logger.log(`Using output directory ${outputDirectory}`)
+  logger.info(`Using output directory ${outputDirectory}`)
 
   // Temporary directory
   const tmpDirectory = await getTmpDirectory()
-  logger.log(`Using temporary directory ${tmpDirectory}`)
+  logger.info(`Using temporary directory ${tmpDirectory}`)
 
   process.on('exit', async (code) => {
-    logger.log(`Exiting with code [${code}]`)
-    logger.log(`Deleting temporary directory [${tmpDirectory}]`)
+    logger.info(`Exiting with code [${code}]`)
+    logger.info(`Deleting temporary directory [${tmpDirectory}]`)
     rimraf.sync(tmpDirectory)
   })
 
   process.on('SIGTERM', async () => {
-    logger.log('SIGTERM')
+    logger.info('SIGTERM')
     await RedisStore.close()
     process.exit(128 + 15)
   })
   process.on('SIGINT', async () => {
-    logger.log('SIGINT')
+    logger.info('SIGINT')
     await RedisStore.close()
     process.exit(128 + 2)
   })
@@ -301,7 +301,7 @@ async function execute(argv: any) {
   if (articleListToIgnore) {
     try {
       articleListToIgnoreLines = await extractArticleList(articleListToIgnore)
-      logger.info(`ArticleListToIgnore has [${articleListToIgnoreLines.length}] items`)
+      logger.debug(`ArticleListToIgnore has [${articleListToIgnoreLines.length}] items`)
     } catch (err) {
       logger.error(`Failed to read articleListToIgnore from [${articleListToIgnore}]`, err)
       throw err
@@ -315,7 +315,7 @@ async function execute(argv: any) {
       if (articleListToIgnore) {
         articleListLines = articleListLines.filter((title: string) => !articleListToIgnoreLines.includes(title))
       }
-      logger.info(`ArticleList has [${articleListLines.length}] items`)
+      logger.debug(`ArticleList has [${articleListLines.length}] items`)
     } catch (err) {
       logger.error(`Failed to read articleList from [${articleList}]`, err)
       throw err
@@ -326,21 +326,21 @@ async function execute(argv: any) {
     //(#1891)
     if (articleListLines.length === 1 && !customMainPage) {
       mainPage = articleListLines[0].replace(/ /g, '_')
-      logger.log(`Using single article list entry as main page: ${mainPage}`)
+      logger.info(`Using single article list entry as main page: ${mainPage}`)
     }
   }
 
   const allowedContentModels = ['wikitext', ...addContentModels]
 
-  logger.info('Getting article ids')
+  logger.debug('Getting article ids')
   let stime = Date.now()
   await getArticleIds(mainPage, articleList ? articleListLines : null, articleListToIgnore ? articleListToIgnoreLines : null, allowedContentModels)
-  logger.log(`Got ArticleIDs in ${(Date.now() - stime) / 1000} seconds`)
+  logger.info(`Got ArticleIDs in ${(Date.now() - stime) / 1000} seconds`)
 
   const filenameDate = new Date().toISOString().slice(0, 7)
 
   // Getting total number of articles from Redis
-  logger.log(`Total articles found in Redis: ${await articleDetailXId.len()}`)
+  logger.info(`Total articles found in Redis: ${await articleDetailXId.len()}`)
 
   const dumps: Dump[] = []
 
@@ -378,7 +378,7 @@ async function execute(argv: any) {
       let logStr = 'Doing dump:'
       if (langVar) logStr += ' variant=' + langVar
       logStr += ` format=${dumpFormat || 'all'}`
-      logger.log(`******************** ${logStr} ********************`)
+      logger.info(`******************** ${logStr} ********************`)
       let shouldSkip = false
       try {
         dump.checkResume()
@@ -386,22 +386,22 @@ async function execute(argv: any) {
         shouldSkip = true
       }
       if (shouldSkip) {
-        logger.log('Skipping dump')
+        logger.info('Skipping dump')
       } else {
         await doDump(dump)
         await filesToDownloadXPath.flush()
-        logger.log('Finished dump')
+        logger.info('Finished dump')
       }
     }
   }
 
-  logger.log('Closing HTTP agents...')
+  logger.info('Closing HTTP agents...')
 
-  logger.log('All dumping(s) finished with success.')
+  logger.info('All dumping(s) finished with success.')
 
   async function doDump(dump: Dump) {
     const outZim = path.resolve(dump.opts.outputDirectory, dump.computeFilenameRadical() + '.zim')
-    logger.log(`Writing ZIM to [${outZim}]`)
+    logger.info(`Writing ZIM to [${outZim}]`)
     dump.outFile = outZim
 
     // Reset FileManager for the new dump
@@ -418,7 +418,7 @@ async function execute(argv: any) {
     }
     validateMetadata(metadata)
 
-    const zimCreator = new Creator().configCompression(Compression.Zstd).configVerbose(verbose === 'info' || verbose === true)
+    const zimCreator = new Creator().configCompression(Compression.Zstd).configVerbose(logLevel === 'debug')
     if (!dump.opts.withoutZimFullTextIndex) {
       zimCreator.configIndexing(true, dump.mwMetaData.langIso3)
     }
@@ -446,20 +446,20 @@ async function execute(argv: any) {
     await saveFavicon(zimCreator, metaDataRequiredKeys['Illustration_48x48@1'])
 
     if (Downloader.webp) {
-      logger.log('Adding webp polyfilling JS scripts')
+      logger.info('Adding webp polyfilling JS scripts')
       await addWebpJsScripts(zimCreator)
     }
 
     await getThumbnailsData()
 
     if (!mainPage) {
-      logger.log('Checking Main Page rendering')
+      logger.info('Checking Main Page rendering')
       await createIndexPage(dump, zimCreator, true)
     }
 
     // Download and save custom CSS files
     if (Downloader.customCssUrls.length > 0) {
-      logger.log(`Downloading ${Downloader.customCssUrls.length} custom CSS file(s)`)
+      logger.info(`Downloading ${Downloader.customCssUrls.length} custom CSS file(s)`)
       const cssErrors: string[] = []
       for (const cssUrl of Downloader.customCssUrls) {
         try {
@@ -474,12 +474,12 @@ async function execute(argv: any) {
       }
     }
 
-    logger.log('Getting articles')
+    logger.info('Getting articles')
     stime = Date.now()
     const { jsModuleDependencies, cssModuleDependencies, staticFilesList } = await saveArticles(zimCreator, dump)
-    logger.log(`Fetching Articles finished in ${(Date.now() - stime) / 1000} seconds`)
+    logger.info(`Fetching Articles finished in ${(Date.now() - stime) / 1000} seconds`)
 
-    logger.info('Copying Static Resource Files')
+    logger.debug('Copying Static Resource Files')
     await saveStaticFiles(staticFilesList, zimCreator)
 
     if (javaScript === 'none') {
@@ -518,15 +518,15 @@ async function execute(argv: any) {
       })
     }
 
-    logger.log(`Found [${jsModuleDependencies.size}] js module dependencies`)
-    logger.log(`Found [${cssModuleDependencies.size}] style module dependencies`)
+    logger.info(`Found [${jsModuleDependencies.size}] js module dependencies`)
+    logger.info(`Found [${cssModuleDependencies.size}] style module dependencies`)
 
     const allDependenciesWithType = [
       { type: 'js', moduleList: Array.from(jsModuleDependencies) },
       { type: 'css', moduleList: Array.from(cssModuleDependencies) },
     ]
 
-    logger.log('Downloading module dependencies')
+    logger.info('Downloading module dependencies')
     await Promise.all(
       allDependenciesWithType.map(({ type, moduleList }) => {
         return pmap(
@@ -544,17 +544,17 @@ async function execute(argv: any) {
 
     await FileManager.startDownloading(zimCreator, dump)
 
-    logger.log('Writing Article Redirects')
+    logger.info('Writing Article Redirects')
     await writeArticleRedirects(dump, zimCreator)
 
     const mainPath = mainPage ? mainPage : await createIndexPage(dump, zimCreator, false)
     zimCreator.setMainPath(mainPath)
 
-    logger.log('Finishing ZIM Creation')
+    logger.info('Finishing ZIM Creation')
     await zimCreator.finishZimCreation()
 
-    logger.log('Summary of scrape actions:', JSON.stringify(dump.status, null, '\t'))
-    logger.log(`ZIM is ready at [${outZim}]`)
+    logger.info('Summary of scrape actions:', JSON.stringify(dump.status, null, '\t'))
+    logger.info(`ZIM is ready at [${outZim}]`)
   }
 
   /* ********************************* */
@@ -564,12 +564,12 @@ async function execute(argv: any) {
   async function writeArticleRedirects(dump: Dump, zimCreator: Creator) {
     let processed = -1
     const total = await redirectsXId.len()
-    logger.log(`${total} redirects to process`)
+    logger.info(`${total} redirects to process`)
     await redirectsXId.iterateItems(Downloader.workers, async (redirects) => {
       for (const [redirectId, { targetId, fragment }] of Object.entries(redirects)) {
         processed += 1
         if (processed > 0 && processed % 5000 === 0) {
-          logger.log(`${processed} redirects have been processed (${Math.round((processed / total) * 1000) / 10} %)`)
+          logger.info(`${processed} redirects have been processed (${Math.round((processed / total) * 1000) / 10} %)`)
         }
         if (await RedisStore.articleDetailXId.exists(redirectId)) {
           logger.warn(`Skipping redirect of '${redirectId}' because it already exists as an article`)
@@ -611,7 +611,7 @@ async function execute(argv: any) {
       const faviconIsRemote = customZimFavicon.includes('http')
       let content
       if (faviconIsRemote) {
-        logger.log(`Downloading remote ZIM favicon from [${customZimFavicon}]`)
+        logger.info(`Downloading remote ZIM favicon from [${customZimFavicon}]`)
         content = await Downloader.request({ url: customZimFavicon, method: 'GET', ...Downloader.arrayBufferRequestOptions })
           .then((a) => a.data)
           .catch(() => {
@@ -642,7 +642,7 @@ async function execute(argv: any) {
   }
 
   async function saveFavicon(zimCreator: Creator, data: Buffer): Promise<any> {
-    logger.log('Saving favicon.png...')
+    logger.info('Saving favicon.png...')
     try {
       return zimCreator.addItem(new StringItem(`${config.output.dirs.res}/favicon.png`, 'image/png', null, { FRONT_ARTICLE: 0 }, data))
     } catch {
@@ -756,7 +756,7 @@ async function execute(argv: any) {
   async function getThumbnailsData(): Promise<void> {
     if (customMainPage || !articleList || articleListLines.length <= MIN_IMAGE_THRESHOLD_ARTICLELIST_PAGE) return
 
-    logger.log('Updating article thumbnails for articles')
+    logger.info('Updating article thumbnails for articles')
 
     let articleIndex = 0
     let articlesWithImages = 0

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -29,8 +29,7 @@ export const parameterDescriptions = {
   requestTimeout: 'Request timeout in seconds (default is 120s)',
   resume: 'Skip already existing/created ZIM files',
   speed: 'Controls scraping speed. 1 is the default, 0.1 makes it ten times slower, 10 makes it ten times faster. Values above 1 must be integers (number of parallel workers).',
-  verbose:
-    'Print logging information to standard streams. To filter messages, one of the following values can be given: "info", "log", "warn", "error" or "quiet" (default level being "error"). All messages are printed from the given value and higher/worse.',
+  logLevel: 'Set the log level. One of: "debug", "info", "warn", "error", "silent" (default: "info"). All messages at the given level and above are printed.',
   withoutZimFullTextIndex: "Don't include a fulltext search index to the ZIM",
   webp: 'Convert all jpeg, png and gif images to webp format',
   addNamespaces: 'Force additional namespace (comma separated numbers)',

--- a/src/renderers/rendering.context.ts
+++ b/src/renderers/rendering.context.ts
@@ -26,7 +26,7 @@ class RenderingContext {
     } else {
       this.articlesRenderer = await rendererBuilder.createRenderer({ renderType: 'auto' })
     }
-    logger.log(`Using ${this.articlesRenderer.constructor.name} for articles renderer`)
+    logger.info(`Using ${this.articlesRenderer.constructor.name} for articles renderer`)
     Downloader.setUrlsDirectors(this.articlesRenderer)
   }
 }

--- a/src/sanitize-argument.ts
+++ b/src/sanitize-argument.ts
@@ -26,7 +26,7 @@ export async function sanitize_all(argv: any) {
     speed,
     adminEmail,
     mwUrl,
-    verbose,
+    logLevel,
     customZimLongDescription,
     customZimDescription,
     forceRender,
@@ -44,8 +44,8 @@ export async function sanitize_all(argv: any) {
 
   sanitize_articlesList_addNamespaces(articleList, addNamespaces)
 
-  // sanitizing verbose
-  sanitize_verbose(verbose)
+  // sanitizing logLevel
+  sanitize_logLevel(logLevel)
 
   // sanitizing speed
   sanitize_speed(speed)
@@ -141,9 +141,9 @@ export function sanitizeStringMaxLength(text: string, key: string, length: numbe
   }
 }
 
-export function sanitize_verbose(verbose: logger.LogLevel | true) {
-  if (verbose && verbose !== true && !logger.logLevels.includes(verbose)) {
-    throw new Error(`"${verbose}" is not a valid value for option verbose. It should be empty or one of [info, log, warn, error, quiet].`)
+export function sanitize_logLevel(logLevel: string | undefined) {
+  if (logLevel !== undefined && !logger.logLevels.includes(logLevel as logger.LogLevel)) {
+    throw new Error(`"${logLevel}" is not a valid value for option --log-level. It should be one of [${logger.logLevels.join(', ')}].`)
   }
 }
 
@@ -218,7 +218,7 @@ export function sanitize_adminEmail(adminEmail: any) {
 
 export async function check_redis() {
   await RedisStore.connect(false)
-  logger.log('closing sanitize redis DB')
+  logger.info('closing sanitize redis DB')
   await RedisStore.close()
 }
 
@@ -242,7 +242,7 @@ export async function check_s3(optimisationCacheUrl: string, insecure: boolean) 
     const s3Url = (s3UrlObj.protocol || 'https:') + '//' + (s3UrlObj.host || '') + (s3UrlObj.pathname || '')
     const s3Obj = new S3(s3Url, s3UrlObj.searchParams, 1000 * 60, insecure)
     await s3Obj.initialise().then(() => {
-      logger.log('Successfully logged in S3')
+      logger.info('Successfully logged in S3')
     })
   }
 }

--- a/src/util/FileManager.ts
+++ b/src/util/FileManager.ts
@@ -180,7 +180,7 @@ class FileManager {
         const percentProgress = (((dump.status.files.success + dump.status.files.fail) / filesTotal) * 100).toFixed(1)
         if (percentProgress !== prevPercentProgress) {
           prevPercentProgress = percentProgress
-          logger.log(`Progress downloading files [${dump.status.files.success + dump.status.files.fail}/${filesTotal}] [${percentProgress}%]`)
+          logger.info(`Progress downloading files [${dump.status.files.success + dump.status.files.fail}/${filesTotal}] [${percentProgress}%]`)
         }
         if (
           filesTotal > 0 &&
@@ -207,7 +207,7 @@ class FileManager {
       const downloadKind = latestDetail.kind
       const downloadWidth = latestDetail.width
 
-      logger.info(`Worker ${workerId} downloading ${urlHelper.deserializeUrl(downloadUrl)} (${downloadKind})`)
+      logger.debug(`Worker ${workerId} downloading ${urlHelper.deserializeUrl(downloadUrl)} (${downloadKind})`)
       await Downloader.downloadContent(downloadUrl, downloadKind, false, downloadWidth)
         .then(async (resp) => {
           if (resp && resp.content && resp.contentType) {
@@ -238,10 +238,10 @@ class FileManager {
                 const retryDate = parseRetryAfterHeader(retryAfterHeader)
                 if (retryDate) {
                   if (retryDate > Date.now() + MAXIMUM_FILE_DOWNLOAD_DELAY) {
-                    logger.log(`Received a [Retry-After=${retryAfterHeader}] on ${hostname} but this is too far away, ignoring`)
+                    logger.info(`Received a [Retry-After=${retryAfterHeader}] on ${hostname} but this is too far away, ignoring`)
                   } else {
                     hostData.notBeforeDate = retryDate
-                    logger.log(`Received a [Retry-After=${retryAfterHeader}], pausing down ${hostname} until ${hostData.notBeforeDate}`)
+                    logger.info(`Received a [Retry-After=${retryAfterHeader}], pausing down ${hostname} until ${hostData.notBeforeDate}`)
                   }
                 } else {
                   logger.warn(`Received a [Retry-After=${retryAfterHeader}] from ${hostname} but failed to interpret it`)
@@ -250,7 +250,7 @@ class FileManager {
             }
             if (err.response && [429, 503, 524].includes(err.response.status) && !urlHelper.deserializeUrl(downloadUrl).match(/^https?:\/\/upload\.wikimedia\.org\/.*\/thumb\//)) {
               hostData.requestInterval = Math.min(MAXIMUM_FILE_DOWNLOAD_DELAY, hostData.requestInterval * 1.2)
-              logger.log(`Received a [status=${err.response.status}], slowing down ${hostname} to ${hostData.requestInterval}ms interval`)
+              logger.info(`Received a [status=${err.response.status}], slowing down ${hostname} to ${hostData.requestInterval}ms interval`)
             }
             await hostData.queue.push(fileToDownload)
           }
@@ -270,7 +270,7 @@ class FileManager {
       { concurrency: Downloader.workers },
     )
 
-    logger.log(
+    logger.info(
       `Done with downloading ${filesTotal} files: ${dump.status.files.success} success, ${dump.status.files.fail} fail: `,
       JSON.stringify(Object.fromEntries([...hosts].map(([hostname, hostData]) => [hostname, { success: hostData.downloadSuccess, fail: hostData.downloadFailure }])), null, '\t'),
     )

--- a/src/util/dump.ts
+++ b/src/util/dump.ts
@@ -206,7 +206,7 @@ export async function downloadModule(module: string, type: 'js' | 'css', langVar
 
   const moduleApiUrl = encodeURI(`${MediaWiki.modulePath}lang=${moduleLang}&modules=${module}${apiParameterOnly}&skin=${MediaWiki.skin}`)
 
-  logger.info(`Getting [${type}] module [${moduleApiUrl}]`)
+  logger.debug(`Getting [${type}] module [${moduleApiUrl}]`)
 
   const { content } = await Downloader.downloadContent(moduleApiUrl, 'module')
   let text = content.toString()
@@ -274,7 +274,7 @@ export async function downloadAndSaveModule(zimCreator: Creator, module: string,
     const modulePath = type === 'js' ? jsPath(module + '.js', config.output.dirs.mediawiki) : cssPath(module + '.css', config.output.dirs.mediawiki)
     const mimetype = type === 'js' ? 'text/javascript' : 'text/css'
     await zimCreatorMutex.runExclusive(() => zimCreator.addItem(new StringItem(modulePath, mimetype, null, { FRONT_ARTICLE: 0 }, text)))
-    logger.info(`Saved module [${module}] at ${modulePath}`)
+    logger.debug(`Saved module [${module}] at ${modulePath}`)
   } catch (e) {
     logger.error(`Failed to get module with url [${moduleApiUrl}]\nYou may need to specify a custom --mwModulePath`, e)
     throw e
@@ -289,7 +289,7 @@ export async function downloadAndSaveStartupModule(zimCreator: Creator, langVar?
     const modulePath = jsPath(module, config.output.dirs.mediawiki)
     const mimetype = 'text/javascript'
     await zimCreatorMutex.runExclusive(() => zimCreator.addItem(new StringItem(modulePath, mimetype, null, { FRONT_ARTICLE: 0 }, text)))
-    logger.info(`Saved module [${module}] at ${modulePath}`)
+    logger.debug(`Saved module [${module}] at ${modulePath}`)
     return JSON.parse(text.match(/;mw\.loader\.register\((\[\[.*?\]\])\);+\s?mw\./s)[1])
   } catch (e) {
     logger.error(`Failed to get module with url [${moduleApiUrl}]\nYou may need to specify a custom --mwModulePath`, e)
@@ -310,12 +310,12 @@ export function getModuleDependencies(oneModule: ResourceLoaderModule, allModule
 
 // Download a custom CSS file and save it into the ZIM.
 export async function downloadAndSaveCustomCss(zimCreator: Creator, cssUrl: string, filename: string): Promise<void> {
-  logger.log(`Downloading custom CSS [${cssUrl}]`)
+  logger.info(`Downloading custom CSS [${cssUrl}]`)
   const { content: cssBody } = await Downloader.downloadContent(cssUrl, 'css')
   const processedCss = await processStylesheetContent(cssUrl, '', cssBody.toString())
   const zimPath = cssPath(filename, config.output.dirs.res)
   await zimCreatorMutex.runExclusive(() => zimCreator.addItem(new StringItem(zimPath, 'text/css', null, { FRONT_ARTICLE: 0 }, processedCss)))
-  logger.log(`Saved custom CSS [${cssUrl}] at ${zimPath}`)
+  logger.info(`Saved custom CSS [${cssUrl}] at ${zimPath}`)
 }
 
 // URLs should be kept the same as Kiwix JS relies on it.

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -58,7 +58,7 @@ function _decodeURIComponent(uri: string) {
   try {
     return decodeURIComponent(uri)
   } catch (error) {
-    logger.warn(error)
+    logger.warn(`Failed to decode URI component: ${uri}`, error)
     return uri
   }
 }
@@ -202,7 +202,7 @@ export async function saveStaticFiles(staticFiles: Set<string>, zimCreator: Crea
       }),
     )
   } catch (err) {
-    logger.error(err)
+    logger.error('Failed to save static files to ZIM', err)
   }
 }
 
@@ -496,7 +496,7 @@ export async function getTmpDirectory() {
   if (!tmpDirectory) {
     tmpDirectory = path.resolve(os.tmpdir(), `mwoffliner-${Date.now()}`)
     try {
-      logger.info(`Creating temporary directory [${tmpDirectory}]`)
+      logger.debug(`Creating temporary directory [${tmpDirectory}]`)
       await mkdirPromise(tmpDirectory)
     } catch (err) {
       logger.error('Failed to create temporary directory, exiting', err)

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -37,7 +37,7 @@ export async function getArticlesByIds(articleIds: string[], purpose: string, ca
         const to = from + articleIdsBatch.length
         if (log) {
           const progressPercent = Math.floor((to / articleIds.length) * 100)
-          logger.log(`Worker [${workerId}] getting article range [${from}-${to}] of [${articleIds.length}] for ${purpose} [${progressPercent}%]`)
+          logger.info(`Worker [${workerId}] getting article range [${from}-${to}] of [${articleIds.length}] for ${purpose} [${progressPercent}%]`)
         }
         from = to
 
@@ -170,7 +170,7 @@ export function getArticlesByNS(
             .filter((a) => !allowedContentModels.includes(a.contentmodel))
             .map((article) => article.title)
           if (articlesWithWrongModel.length > 0) {
-            logger.info(`Skipping articles with non-matching content model: ${articlesWithWrongModel.join(', ')}`)
+            logger.debug(`Skipping articles with non-matching content model: ${articlesWithWrongModel.join(', ')}`)
             if (!articleIdsToIgnore) {
               articleIdsToIgnore = []
             }
@@ -183,7 +183,7 @@ export function getArticlesByNS(
             const articleTitle = chunk.articleDetails[articleId].title
             if (articleIdsToIgnore.includes(articleTitle)) {
               delete chunk.articleDetails[articleId]
-              logger.info(`Excluded article ${articleTitle}`)
+              logger.debug(`Excluded article ${articleTitle}`)
             }
           })
         }
@@ -238,7 +238,7 @@ export function getArticlesByNS(
             return
           }
           totalArticles += numArticles
-          logger.log(`Got [${numArticles} / ${totalArticles}] articles chunk from namespace [${ns}]`)
+          logger.info(`Got [${numArticles} / ${totalArticles}] articles chunk from namespace [${ns}]`)
         }
 
         saveStorePromisQueue.push(newSavePromise)
@@ -265,7 +265,7 @@ export function getArticlesByNS(
       timer.clear()
     }
 
-    logger.log(`A total of [${totalArticles}] articles has been found in namespace [${ns}]`)
+    logger.info(`A total of [${totalArticles}] articles has been found in namespace [${ns}]`)
     resolve()
   })
 }
@@ -387,7 +387,7 @@ export async function checkApiAvailability(url: string, allowedMimeTypes = null)
 
     return isSuccess && validMimeType
   } catch (err) {
-    logger.info('checkApiAvailability failed: ', cleanupAxiosError(err as any))
+    logger.debug('checkApiAvailability failed: ', cleanupAxiosError(err as any))
     return false
   }
 }

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -142,7 +142,7 @@ export async function saveArticles(zimCreator: Creator, dump: Dump) {
         reject(new Error(errorMessage))
       }, timeout)
 
-      logger.info(`Worker processing batch of article ids [${logger.logifyArray(Object.keys(articleKeyValuePairs))}] - ${runningWorkers} worker(s) running`)
+      logger.debug(`Worker processing batch of article ids [${logger.logifyArray(Object.keys(articleKeyValuePairs))}] - ${runningWorkers} worker(s) running`)
 
       for (const [articleId, articleDetail] of Object.entries(articleKeyValuePairs)) {
         timer.reset()
@@ -152,7 +152,7 @@ export async function saveArticles(zimCreator: Creator, dump: Dump) {
           const percentProgress = (((dump.status.articles.success + dump.status.articles.hardFail + dump.status.articles.softFail) / articlesTotal) * 100).toFixed(1)
           if (percentProgress !== prevPercentProgress) {
             prevPercentProgress = percentProgress
-            logger.log(
+            logger.info(
               `Progress downloading articles [${
                 dump.status.articles.success + dump.status.articles.hardFail + dump.status.articles.softFail
               }/${articlesTotal}] [${percentProgress}%]`,
@@ -212,7 +212,7 @@ export async function saveArticles(zimCreator: Creator, dump: Dump) {
     })
   })
 
-  logger.log(`Done with downloading a total of [${articlesTotal}] articles`)
+  logger.info(`Done with downloading a total of [${articlesTotal}] articles`)
 
   return {
     staticFilesList: RenderingContext.articlesRenderer.getStaticFilesList(),

--- a/test/e2e/cmd.e2e.test.ts
+++ b/test/e2e/cmd.e2e.test.ts
@@ -24,9 +24,9 @@ describe('Exec Command With Bash', () => {
       )
     })
 
-    test('Exec Command With --verbose option', async () => {
-      await expect(execa(`${mwo} --verbose=anyString --mwUrl="https://en.wikipedia.org" --adminEmail="test@test.test"`, { shell: true })).rejects.toThrow(
-        /"anyString" is not a valid value for option verbose. It should be empty or one of \[info, log, warn, error, quiet\]/,
+    test('Exec Command With --log-level option', async () => {
+      await expect(execa(`${mwo} --log-level=anyString --mwUrl="https://en.wikipedia.org" --adminEmail="test@test.test"`, { shell: true })).rejects.toThrow(
+        /"anyString" is not a valid value for option --log-level. It should be one of \[debug, info, warn, error, silent\]/,
       )
     })
   })

--- a/test/unit/logger.test.ts
+++ b/test/unit/logger.test.ts
@@ -4,106 +4,100 @@ import { jest } from '@jest/globals'
 describe('Logger', () => {
   let stdoutSpy: ReturnType<typeof jest.spyOn>
 
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
-
   beforeEach(() => {
     stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true)
   })
 
-  test('logger info level', async () => {
-    logger.setVerboseLevel('info')
-
-    logger.info('test info', 'info test message')
-    logger.log('test log', 'log test message')
-    logger.warn('test warn', 'warn test message')
-    logger.error('test error', 'error test message')
-
-    expect(stdoutSpy).toHaveBeenCalledTimes(4)
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[info]'))
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[log]'))
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[warn]'))
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[error]'))
+  afterEach(() => {
+    jest.clearAllMocks()
+    logger.setLogLevel('silent')
   })
 
-  test('logger log level', async () => {
-    logger.setVerboseLevel('log')
+  test('debug level logs everything', async () => {
+    logger.setLogLevel('debug')
 
-    logger.info('test info', 'info test message')
-    logger.log('test log', 'log test message')
-    logger.warn('test warn', 'warn test message')
-    logger.error('test error', 'error test message')
+    logger.debug('msg', 'a')
+    logger.info('msg', 'b')
+    logger.warn('msg', 'c')
+    logger.error('msg', 'd')
+
+    expect(stdoutSpy).toHaveBeenCalledTimes(4)
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('DEBUG'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('INFO'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('WARN'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('ERROR'))
+  })
+
+  test('info level suppresses debug', async () => {
+    logger.setLogLevel('info')
+
+    logger.debug('msg', 'a')
+    logger.info('msg', 'b')
+    logger.warn('msg', 'c')
+    logger.error('msg', 'd')
 
     expect(stdoutSpy).toHaveBeenCalledTimes(3)
-    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('[info]'))
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[log]'))
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[warn]'))
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[error]'))
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('DEBUG'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('INFO'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('WARN'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('ERROR'))
   })
 
-  test('logger warn level', async () => {
-    logger.setVerboseLevel('warn')
+  test('warn level suppresses debug and info', async () => {
+    logger.setLogLevel('warn')
 
-    logger.info('test info', 'info test message')
-    logger.log('test log', 'log test message')
-    logger.warn('test warn', 'warn test message')
-    logger.error('test error', 'error test message')
+    logger.debug('msg', 'a')
+    logger.info('msg', 'b')
+    logger.warn('msg', 'c')
+    logger.error('msg', 'd')
 
     expect(stdoutSpy).toHaveBeenCalledTimes(2)
-    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('[info]'))
-    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('[log]'))
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[warn]'))
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[error]'))
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('DEBUG'))
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('INFO'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('WARN'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('ERROR'))
   })
 
-  test('logger error level', async () => {
-    logger.setVerboseLevel('error')
+  test('error level logs only errors', async () => {
+    logger.setLogLevel('error')
 
-    logger.info('test info', 'info test message')
-    logger.log('test log', 'log test message')
-    logger.warn('test warn', 'warn test message')
-    logger.error('test error', 'error test message')
+    logger.debug('msg', 'a')
+    logger.info('msg', 'b')
+    logger.warn('msg', 'c')
+    logger.error('msg', 'd')
 
     expect(stdoutSpy).toHaveBeenCalledTimes(1)
-    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('[info]'))
-    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('[log]'))
-    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('[warn]'))
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[error]'))
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('DEBUG'))
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('INFO'))
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('WARN'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('ERROR'))
   })
 
-  test('logger verbose true', async () => {
-    logger.setVerboseLevel('true')
+  test('silent level suppresses all output', async () => {
+    logger.setLogLevel('silent')
 
-    logger.info('test info', 'info test message')
-    logger.log('test log', 'log test message')
-    logger.warn('test warn', 'warn test message')
-    logger.error('test error', 'error test message')
-
-    expect(stdoutSpy).toHaveBeenCalledTimes(4)
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[info]'))
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[log]'))
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[warn]'))
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('[error]'))
-  })
-
-  test('logger verbose empty', async () => {
-    logger.setVerboseLevel(null)
-
-    logger.info('test info', 'info test message')
-    logger.log('test log', 'log test message')
-    logger.warn('test warn', 'warn test message')
-    logger.error('test error', 'error test message')
+    logger.debug('msg', 'a')
+    logger.info('msg', 'b')
+    logger.warn('msg', 'c')
+    logger.error('msg', 'd')
 
     expect(stdoutSpy).not.toHaveBeenCalled()
   })
 
-  test('logger message format includes args', async () => {
-    logger.setVerboseLevel('info')
+  test('message content appears in output', async () => {
+    logger.setLogLevel('debug')
 
-    logger.info('test info', 'info test message')
+    logger.debug('hello world')
 
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('test info'))
-    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('info test message'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('hello world'))
+  })
+
+  test('variadic args are concatenated in output', async () => {
+    logger.setLogLevel('debug')
+
+    logger.debug('prefix:', 'suffix')
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('prefix:'))
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('suffix'))
   })
 })

--- a/test/unit/sanitize-argument.test.ts
+++ b/test/unit/sanitize-argument.test.ts
@@ -3,7 +3,7 @@ import { sanitize_all } from '../../src/sanitize-argument.js'
 describe('Sanitize parameters', () => {
   const baseValidParams = {
     _: [],
-    verbose: true,
+    logLevel: 'info',
     mwUrl: 'https://en.wikipedia.org',
     'mw-url': 'https://en.wikipedia.org',
     adminEmail: 'test@test.test',
@@ -12,13 +12,13 @@ describe('Sanitize parameters', () => {
   }
 
   describe('Duplicate parameter validation', () => {
-    test('should throw if --verbose is used more than once', async () => {
+    test('should throw if --log-level is used more than once', async () => {
       const params = {
         ...baseValidParams,
-        verbose: [true, 'info'],
+        logLevel: ['info', 'debug'],
       }
 
-      await expect(sanitize_all(params)).rejects.toThrow(/Parameter '--verbose' can only be used once/)
+      await expect(sanitize_all(params)).rejects.toThrow(/Parameter '--logLevel' can only be used once/)
     })
 
     test('should throw if --mwUrl is used more than once', async () => {
@@ -84,7 +84,7 @@ describe('URL validation', () => {
 describe('Speed validation', () => {
   const baseValidParams = {
     _: [],
-    verbose: true,
+    logLevel: 'info',
     mwUrl: 'https://en.wikipedia.org',
     'mw-url': 'https://en.wikipedia.org',
     adminEmail: 'test@test.test',


### PR DESCRIPTION
Fix #2122 

Changes:
- introduce `pino` log library instead of custom-made library
- change log levels: INFO => DEBUG ; LOG => INFO
- drop support of `--verbose` without arg value (not standard)
- switch from unusual `--verbose <value>` to mostly standard `--log-level <value>`

This introduce a slight change a format (again to have something more "standard" in the ecosystem)

```
[log] [2025-11-13T17:32:35.758Z] Using User-Agent: MWOffliner/2.0.0-dev0 (test@test.test)
```

to 

```
[2026-06-16 07:26:28.470] INFO: Using User-Agent: MWOffliner/2.0.0-dev0 (test@test.test)
```