### PR TITLE
Login again at every dump start to workaround issue of expired logins

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -32,7 +32,7 @@ Unreleased:
 * UPDATE: Use node-libzim 4.3.0 and Node.JS 26, update dependencies (@benoit74 #2743)
 * FIX: Remove now unused resource files (@benoit74 #2748)
 * CHANGED: *** Breaking *** Use Pino log library, change log level values and CLI argument controlling log level (@benoit74 #2122)
-
+* FIX: Login again at every dump start to workaround issue of expired logins (@benoit74, related to #2761)
 
 1.17.5:
 * FIX: Ignore articles returning permissiondenied error code (@kunalsiyag #2604)

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -301,7 +301,7 @@ class MediaWiki {
     this.modulePath = this.urlDirector.buildModuleURL(this.#modulePathOpt)
   }
 
-  public async login() {
+  public async login(mightBeAlreadyLoggedIn: boolean = false) {
     if (this.#username && this.#password) {
       let url = this.actionApiUrl.href + '?'
 
@@ -331,9 +331,15 @@ class MediaWiki {
         if (resp.data.login?.result !== 'Success') {
           const reason = resp.data.login?.reason
           if (reason) {
-            logger.error(reason)
+            if (mightBeAlreadyLoggedIn && reason.includes('Cannot log in when using MediaWiki\\Session\\BotPasswordSessionProvider sessions')) {
+              logger.info('Already logged in')
+            } else {
+              logger.error(reason)
+              throw new Error('Login Failed')
+            }
+          } else {
+            throw new Error('Login Failed')
           }
-          throw new Error('Login Failed')
         } else {
           logger.info('Login Success')
         }

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -407,6 +407,10 @@ async function execute(argv: any) {
     // Reset FileManager for the new dump
     FileManager.reset()
 
+    // Check scraper is still logged-in (session from previous dump might have expired
+    // due to inactivity when downloading files)
+    await MediaWiki.login(true)
+
     const metadata = {
       ...metaDataRequiredKeys,
       Tags: dump.computeZimTags(),


### PR DESCRIPTION
Workaround for #2761 

Really fixing the issue is hard because we do not want to overwhelm the upstream with additional API calls, we have no clue what expiration could be (could be quite low actually) and we have no clue on regular call regarding whether we are still logged-in or not.

I hence propose to workaround known symptom: the problem occur only when we start a fresh dump, because inactivity period triggers. The other expiration is at 30 days and we have no scraper running that long in Zimfarm. Solution to these conditions is hence straightforward and lightweight: attempt to login again at every dump start and ignore "normal" errors saying you are already logged in.