### PR TITLE
Remove unneeded comments linked to misunderstandings

### DIFF
--- a/test/e2e/formatParams.test.ts
+++ b/test/e2e/formatParams.test.ts
@@ -92,21 +92,3 @@ await testAllRenders('format-params-novid-2', { ...parameters, format: 'novid', 
     })
   })
 })
-
-// TODO: blocked by issues/1928
-/*
-await testRenders({ ...parameters, format: 'nopdf', articleList: 'PDF' }, async (outFiles) => {
-  describe('format:pdf to check no internal links pdf files', () => {
-    test(`Test en.wikipedia.org using format:nopdf for ${outFiles[0]?.renderer} renderer`, async () => {
-      await execa('redis-cli flushall', { shell: true })
-      const articleFromDump = await zimdump(`show --url PDF ${outFiles[0].outFile}`)
-      const articleDoc = domino.createDocument(articleFromDump)
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const anchorElements = Array.from(articleDoc.querySelectorAll('a'))
-      if (!process.env.KEEP_ZIMS) {
-        rimraf.sync(`./${outFiles[0].testId}`)
-      }
-    })
-  })
-})
-*/

--- a/test/e2e/multimediaContent.test.ts
+++ b/test/e2e/multimediaContent.test.ts
@@ -50,7 +50,6 @@ await testAllRenders('multimedia-content', parameters, async (outFiles) => {
   })
 })
 
-// TODO: is this really testing all formats one by one??? I don't think so
 await testAllRenders('multimedia-content', { ...parameters, format: ['nopic', 'novid', 'nopdf', 'nodet'] }, async (outFiles) => {
   describe('Multimedia for different formats', () => {
     test(`check multimedia content from wikipedia test page with different formats for ${outFiles[0]?.renderer} renderer`, async () => {


### PR DESCRIPTION
Relates to #1928

- commented out test is irrelevant, this is not the purpose of `nopdf` option
- doubts expressed around multimedia test really testing all formats one by one is irrelevant, the test even asserts that 4 ZIMs have been created