### PR TITLE
Upgrade title truncation logic to match libzim 9.4.0 constraints

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -34,7 +34,8 @@ Unreleased:
 * CHANGED: *** Breaking *** Use Pino log library, change log level values and CLI argument controlling log level (@benoit74 #2122)
 * FIX: Login again at every dump start to workaround issue of expired logins (@benoit74, related to #2761)
 * CHANGED: Use i18next library to handle internationalization (@benoit74 #2614 #2750)
-* CHANGED: Drop imagemin dependency and use sharp for image compression (@benoit74 #xxxx)
+* CHANGED: Drop imagemin dependency and use sharp for image compression (@benoit74 #2765)
+* CHANGED: Upgrade title truncation logic to match libzim 9.4.0 constraints (@benoit74 #2318)
 
 1.17.5:
 * FIX: Ignore articles returning permissiondenied error code (@kunalsiyag #2604)

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -42,7 +42,7 @@ import {
   extractArticleList,
   getTmpDirectory,
   validateMetadata,
-  truncateUtf8Bytes,
+  truncateZimArticleTitleWords,
 } from './util/index.js'
 import S3 from './S3.js'
 import RedisStore from './RedisStore.js'
@@ -592,7 +592,7 @@ async function execute(argv: any) {
           continue
         }
         // We fake a title, by just removing the underscores
-        const redirectTitle = truncateUtf8Bytes(String(redirectId).replace(/_/g, ' '), 245)
+        const redirectTitle = truncateZimArticleTitleWords(String(redirectId).replace(/_/g, ' '))
         if (fragment) {
           // Should we have a fragment (i.e. we redirect to a section of an article), this is not (yet) supported by libzim
           // (to have such a redirect with a fragment inside the path), so we create a "fake" entry with only an HTML-based

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -481,6 +481,17 @@ export async function getTmpDirectory() {
   return tmpDirectory
 }
 
+export function truncateZimArticleTitleWords(title: string) {
+  // Truncate each title words to 240 bytes, as mandated by libzim since 9.4.0
+  // - 240 bytes = MAX_INDEXABLE_TITLE_WORD_SIZE in libzim src/constants.h
+  // - https://github.com/openzim/libzim/pull/1004
+  // - https://github.com/openzim/libzim/issues/1033
+  return title
+    .split(' ')
+    .map((word: string) => truncateUtf8Bytes(word, 240))
+    .join(' ')
+}
+
 export function truncateUtf8Bytes(text: string, maxBytes: number) {
   // Truncate text to maxBytes bytes once encoded to UTF-8 ; takes into account multi-bytes characters, avoiding to split
   // in the middle of a character, trying to do this in an efficient manner with binary search

--- a/src/util/saveArticles.ts
+++ b/src/util/saveArticles.ts
@@ -13,7 +13,7 @@ import { Renderer } from '../renderers/abstract.renderer.js'
 import RenderingContext from '../renderers/rendering.context.js'
 import { zimCreatorMutex } from '../mutex.js'
 import FileManager from './FileManager.js'
-import { truncateUtf8Bytes } from './misc.js'
+import { truncateZimArticleTitleWords } from './misc.js'
 import { isMainPage } from './articles.js'
 
 function getArticleRenderUrl(articleId: string, articleDetail: ArticleDetail, dump: Dump): string {
@@ -53,10 +53,10 @@ async function getAllArticlesToKeep(articleDetailXId: RKVS<ArticleDetail>, dump:
  * Parse fetched article HTML, store files
  * and dependencies and save in Zim
  */
-async function saveArticle(zimCreator: Creator, htmlContent: string, zimPath: string, zimTitle: string): Promise<Error> {
+export async function saveArticle(zimCreator: Creator, htmlContent: string, zimPath: string, zimTitle: string): Promise<Error> {
   try {
     const zimArticle = zimTitle
-      ? new StringItem(zimPath, 'text/html', truncateUtf8Bytes(zimTitle, 245), { FRONT_ARTICLE: 1 }, htmlContent)
+      ? new StringItem(zimPath, 'text/html', truncateZimArticleTitleWords(zimTitle), { FRONT_ARTICLE: 1 }, htmlContent)
       : new StringItem(zimPath, 'text/html', '', {}, htmlContent)
     await zimCreatorMutex.runExclusive(() => zimCreator.addItem(zimArticle))
 

--- a/test/unit/saveArticles.test.ts
+++ b/test/unit/saveArticles.test.ts
@@ -3,7 +3,7 @@ import domino from 'domino'
 import RedisStore from '../../src/RedisStore.js'
 import { startRedis, stopRedis } from './bootstrap.js'
 import { setupScrapeClasses } from '../util.js'
-import { saveArticles } from '../../src/util/saveArticles.js'
+import { saveArticles, saveArticle } from '../../src/util/saveArticles.js'
 import { StringItem } from '@openzim/libzim'
 import { mwRetToArticleDetail } from '../../src/util/index.js'
 import { jest } from '@jest/globals'
@@ -216,4 +216,29 @@ describe('saveArticles', () => {
       expect(articleDoc.querySelector('#Drink')).toBeTruthy()
     })
   }
+})
+
+describe('saveArticles', () => {
+  test('Too long article title is truncated', async () => {
+    const addedArticles: StringItem[] = []
+
+    const MAX_WORD_LENGTH = 240
+
+    await saveArticle(
+      {
+        addItem(article: StringItem) {
+          if (article.mimeType === 'text/html') {
+            addedArticles.push(article)
+          }
+          return Promise.resolve(null)
+        },
+      } as any,
+      'any content',
+      'a path',
+      `${'a'.repeat(MAX_WORD_LENGTH)} ${'f'.repeat(MAX_WORD_LENGTH - 1)}Ö ${'c'.repeat(MAX_WORD_LENGTH + 1)} ${'d'.repeat(MAX_WORD_LENGTH)}`,
+    )
+
+    expect(addedArticles.length).toBe(1)
+    expect(addedArticles[0].title).toBe(`${'a'.repeat(MAX_WORD_LENGTH)} ${'f'.repeat(MAX_WORD_LENGTH - 1)} ${'c'.repeat(MAX_WORD_LENGTH)} ${'d'.repeat(MAX_WORD_LENGTH)}`)
+  })
 })

--- a/test/unit/util/misc.test.ts
+++ b/test/unit/util/misc.test.ts
@@ -1,7 +1,7 @@
-import { truncateUtf8Bytes } from '../../../src/util/misc.js'
+import { truncateUtf8Bytes, truncateZimArticleTitleWords } from '../../../src/util/misc.js'
 
 describe('miscelenaous utility functions tests', () => {
-  const cases = [
+  const truncateUtf8BytesCases = [
     ['foo', 100, 'foo'],
     ['foo', 1, 'f'],
     ['fÖo', 1, 'f'],
@@ -9,8 +9,26 @@ describe('miscelenaous utility functions tests', () => {
     ['fÖo', 3, 'fÖ'],
     ['fÖo', 4, 'fÖo'],
   ]
-  test.each(cases)('truncateUtf8Bytes', (...args) => {
+  test.each(truncateUtf8BytesCases)('truncateUtf8Bytes', (...args) => {
     const [value, length, expected] = args as [string, number, string]
     expect(truncateUtf8Bytes(value, length)).toBe(expected)
+  })
+
+  const MAX_WORD_LENGTH = 240
+
+  const truncateZimArticleTitleWordsCases = [
+    ['f'.repeat(MAX_WORD_LENGTH), undefined],
+    ['f'.repeat(MAX_WORD_LENGTH + 1), 'f'.repeat(MAX_WORD_LENGTH)],
+    [`${'f'.repeat(MAX_WORD_LENGTH)} ${'f'.repeat(MAX_WORD_LENGTH)}`, undefined],
+    [
+      `${'a'.repeat(MAX_WORD_LENGTH)} ${'b'.repeat(MAX_WORD_LENGTH + 1)} ${'c'.repeat(MAX_WORD_LENGTH + 1)} ${'d'.repeat(MAX_WORD_LENGTH)}`,
+      `${'a'.repeat(MAX_WORD_LENGTH)} ${'b'.repeat(MAX_WORD_LENGTH)} ${'c'.repeat(MAX_WORD_LENGTH)} ${'d'.repeat(MAX_WORD_LENGTH)}`,
+    ],
+    [`${'f'.repeat(MAX_WORD_LENGTH - 2)}Ö`, undefined],
+    [`${'f'.repeat(MAX_WORD_LENGTH - 1)}Ö`, 'f'.repeat(MAX_WORD_LENGTH - 1)],
+  ]
+  test.each(truncateZimArticleTitleWordsCases)('truncateZimArticleTitleWords', (...args) => {
+    const [value, expected] = args as [string, string | undefined]
+    expect(truncateZimArticleTitleWords(value)).toBe(expected || value)
   })
 })


### PR DESCRIPTION
Fix #2318 

 Truncate each title words to 240 bytes, as mandated by libzim since 9.4.0
 - 240 bytes = MAX_INDEXABLE_TITLE_WORD_SIZE in libzim src/constants.h
 - https://github.com/openzim/libzim/pull/1004
 - https://github.com/openzim/libzim/issues/1033