### PR TITLE
Fix nested translations of category labels

### DIFF
--- a/dev/check-translations.js
+++ b/dev/check-translations.js
@@ -90,6 +90,23 @@ function walkDir(dir, ext) {
   return results
 }
 
+function extractNestedTranslationKeys(data) {
+  const keys = new Set()
+  function scanValues(obj) {
+    for (const value of Object.values(obj)) {
+      if (typeof value === 'string') {
+        for (const match of value.matchAll(/\$t\(([a-zA-Z0-9_]+)/g)) {
+          keys.add(match[1])
+        }
+      } else if (value && typeof value === 'object') {
+        scanValues(value)
+      }
+    }
+  }
+  scanValues(data)
+  return keys
+}
+
 function extractKeysFromCode(dir) {
   const files = walkDir(dir, '.ts')
   const usedKeys = new Set()
@@ -200,6 +217,8 @@ function main() {
   // Code Usage Check
   printHeader('3. Checking Code Usage')
   const { usedKeys, keyLocations, foundPrefixes } = extractKeysFromCode(CONFIG.SRC_DIR)
+  // Also treat keys referenced via $t() nesting inside translation values as "used"
+  extractNestedTranslationKeys(sourceData).forEach((k) => usedKeys.add(k))
   console.log(`Found ${C.Bold}${usedKeys.size}${C.Reset} unique translation keys in source code.`)
 
   // Check 1: Keys in Code but missing in Source

--- a/translation/de.json
+++ b/translation/de.json
@@ -12,17 +12,29 @@
 	"categoryHeaderNumerals": "0–9",
 	"categoryFileCount": {
 		"one": "Diese Kategorie enthält nur folgende Datei.",
-		"other": "Folgende {{curPageCount}} Dateien sind in dieser Kategorie, von {{count}} insgesamt."
+		"other": "Die $t(categoryCurrentPageFileCount, {\"count\": {{curPageCount}} }) in dieser Kategorie, von {{count}} insgesamt."
+	},
+	"categoryCurrentPageFileCount": {
+		"one": "folgende Datei ist",
+		"other": "folgenden {{count}} Dateien sind"
 	},
 	"categoryMediaHeader": "Medien in der Kategorie „{{pageName}}“",
 	"categoryArticleCount": {
 		"one": "Diese Kategorie enthält nur die folgende Seite.",
-		"other": "Folgende {{curPageCount}} Seiten sind in dieser Kategorie, von {{count}} insgesamt."
+		"other": "Folgende $t(categoryCurrentPageArticleCount, {\"count\": {{curPageCount}} }) in dieser Kategorie, von {{count}} insgesamt."
+	},
+	"categoryCurrentPageArticleCount": {
+		"one": "Seite ist",
+		"other": "{{count}} Seiten sind"
 	},
 	"categoryHeader": "Seiten in der Kategorie „{{pageName}}“",
 	"categorySubcatCount": {
 		"one": "Diese Kategorie enthält nur die folgende Unterkategorie:",
-		"other": "Diese Kategorie enthält die folgenden {{curPageCount}} Unterkategorien ({{count}} insgesamt):"
+		"other": "Diese Kategorie enthält die $t(categoryCurrentPageSubcatCount, {\"count\": {{curPageCount}} }) ({{count}} insgesamt):"
+	},
+	"categoryCurrentPageSubcatCount": {
+		"one": "folgende Unterkategorie",
+		"other": "folgenden {{count}} Unterkategorien"
 	},
 	"subcategories": "Unterkategorien",
 	"categoryEmpty": "<em>Diese Kategorie enthält zurzeit keine Seiten oder Medien.</em>",

--- a/translation/en.json
+++ b/translation/en.json
@@ -2,17 +2,29 @@
 	"categoryHeaderNumerals": "0–9",
 	"categoryFileCount": {
 		"one": "This category contains only the following file.",
-		"other": "The following {{curPageCount}} files are in this category, out of {{count}} total."
+		"other": "The following $t(categoryCurrentPageFileCount, {\"count\": {{curPageCount}} }) in this category, out of {{count}} total."
+	},
+	"categoryCurrentPageFileCount": {
+		"one": "file is",
+		"other": "{{count}} files are"
 	},
 	"categoryMediaHeader": "Media in category \"{{pageName}}\"",
 	"categoryArticleCount": {
 		"one": "This category contains only the following page.",
-		"other": "The following {{curPageCount}} pages are in this category, out of {{count}} total."
+		"other": "The following $t(categoryCurrentPageArticleCount, {\"count\": {{curPageCount}} }) in this category, out of {{count}} total."
+	},
+	"categoryCurrentPageArticleCount": {
+		"one": "page is",
+		"other": "{{count}} pages are"
 	},
 	"categoryHeader": "Pages in category \"{{pageName}}\"",
 	"categorySubcatCount": {
 		"one": "This category has only the following subcategory.",
-		"other": "This category has the following {{curPageCount}} subcategories, out of {{count}} total."
+		"other": "This category has the following $t(categoryCurrentPageSubcatCount, {\"count\": {{curPageCount}} }), out of {{count}} total."
+	},
+	"categoryCurrentPageSubcatCount": {
+		"one": "subcategory",
+		"other": "{{count}} subcategories"
 	},
 	"subcategories": "Subcategories",
 	"categoryEmpty": "<em>This category currently contains no pages or media.</em>",

--- a/translation/ko.json
+++ b/translation/ko.json
@@ -10,17 +10,29 @@
 	"categoryHeaderNumerals": "0–9",
 	"categoryFileCount": {
 		"one": "이 분류에는 다음 파일만이 속해 있습니다.",
-		"other": "다음은 이 분류에 속하는 파일 {{curPageCount}}개 가운데 {{curPageCount}}개입니다."
+		"other": "다음은 이 분류에 속하는 $t(categoryCurrentPageFileCount, {\"count\": {{curPageCount}} }) 가운데 {{count}}개입니다."
+	},
+	"categoryCurrentPageFileCount": {
+		"one": "파일",
+		"other": "파일 {{count}}개"
 	},
 	"categoryMediaHeader": "\"{{pageName}}\" 분류에 속하는 미디어",
 	"categoryArticleCount": {
 		"one": "이 분류에는 다음 문서만이 속해 있습니다.",
-		"other": "다음은 이 분류에 속하는 문서 {{curPageCount}}개 가운데 {{curPageCount}}개입니다."
+		"other": "다음은 이 분류에 속하는 $t(categoryCurrentPageArticleCount, {\"count\": {{curPageCount}} }) 가운데 {{count}}개입니다."
+	},
+	"categoryCurrentPageArticleCount": {
+		"one": "문서",
+		"other": "문서 {{count}}개"
 	},
 	"categoryHeader": "\"{{pageName}}\" 분류에 속하는 문서",
 	"categorySubcatCount": {
 		"one": "이 분류에는 다음 하위 분류만이 속해 있습니다.",
-		"other": "다음은 이 분류에 속하는 하위 분류 {{curPageCount}}개 가운데 {{curPageCount}}개입니다."
+		"other": "다음은 이 분류에 속하는 $t(categoryCurrentPageSubcatCount, {\"count\": {{curPageCount}} }) 가운데 {{count}}개입니다."
+	},
+	"categoryCurrentPageSubcatCount": {
+		"one": "하위 분류",
+		"other": "하위 분류 {{count}}개"
 	},
 	"subcategories": "하위 분류",
 	"categoryEmpty": "현재 이 분류에는 문서나 미디어가 하나도 없습니다.",

--- a/translation/nl.json
+++ b/translation/nl.json
@@ -9,17 +9,29 @@
 	"categoryHeaderNumerals": "0–9",
 	"categoryFileCount": {
 		"one": "Deze categorie bevat alleen het volgende bestand.",
-		"other": "De volgende {{curPageCount}} bestanden zijn onderdeel van deze categorie, van totaal {{count}}."
+		"other": "$t(categoryCurrentPageFileCount, {\"count\": {{curPageCount}} }) onderdeel van deze categorie, van totaal {{count}}."
+	},
+	"categoryCurrentPageFileCount": {
+		"one": "Het volgende bestand is",
+		"other": "De volgende {{count}} bestanden zijn"
 	},
 	"categoryMediaHeader": "Media in categorie \"{{pageName}}\"",
 	"categoryArticleCount": {
 		"one": "Deze categorie bevat alleen de volgende pagina.",
-		"other": "De volgende {{curPageCount}} pagina zijn onderdeel van deze categorie, van totaal {{count}}."
+		"other": "$t(categoryCurrentPageArticleCount, {\"count\": {{curPageCount}} }) onderdeel van deze categorie, van totaal {{count}}."
+	},
+	"categoryCurrentPageArticleCount": {
+		"one": "De volgende pagina is",
+		"other": "De volgende {{count}} pagina zijn"
 	},
 	"categoryHeader": "Pagina's in categorie \"{{pageName}}\"",
 	"categorySubcatCount": {
 		"one": "Deze categorie heeft slechts de volgende subcategorie.",
-		"other": "Deze categorie heeft de volgende {{curPageCount}} subcategorieën, van in totaal {{count}}."
+		"other": "Deze categorie heeft de volgende $t(categoryCurrentPageSubcatCount, {\"count\": {{curPageCount}} }), van in totaal {{count}}."
+	},
+	"categoryCurrentPageSubcatCount": {
+		"one": "subcategorie",
+		"other": "{{count}} subcategorieën"
 	},
 	"subcategories": "Ondercategorieën",
 	"categoryEmpty": "<em>Deze categorie bevat geen pagina's of media.</em>",

--- a/translation/qqq.json
+++ b/translation/qqq.json
@@ -7,17 +7,29 @@
 	"categoryHeaderNumerals": "A header for all pages whose titles start with a number. This is used on category pages. This should only be translated if your language uses a different method to indicate a range of numbers.",
 	"categoryFileCount": {
 		"one": "This message is displayed at the top of a category page showing the number of pages in the category (singular form, for count=1).",
-		"other": "This message is displayed at the top of a category page showing the number of pages in the category (plural form, for count>1)."
+		"other": "This message is displayed at the top of a category page showing the number of pages in the category (plural form, for count>1). Uses $t(categoryCurrentPageFileCount) to agree with {{curPageCount}}."
+	},
+	"categoryCurrentPageFileCount": {
+		"one": "Nested translation used inside categoryFileCount (plural form) when curPageCount=1. Should read as \"[one file] is\".",
+		"other": "Nested translation used inside categoryFileCount (plural form) when curPageCount>1. Should read as \"[N files] are\"."
 	},
 	"categoryMediaHeader": "In category description page. Note that \"media\" is short for \"multimedia\". It doesn't mean \"journalism\".",
 	"categoryArticleCount": {
 		"one": "This message is used on category pages (singular form, for count=1).",
-		"other": "This message is used on category pages (plural form, for count>1)."
+		"other": "This message is used on category pages (plural form, for count>1). Uses $t(categoryCurrentPageArticleCount) to agree with {{curPageCount}}."
+	},
+	"categoryCurrentPageArticleCount": {
+		"one": "Nested translation used inside categoryArticleCount (plural form) when curPageCount=1. Should read as \"[one page] is\".",
+		"other": "Nested translation used inside categoryArticleCount (plural form) when curPageCount>1. Should read as \"[N pages] are\"."
 	},
 	"categoryHeader": "In category description page, be aware that this is not about biology, but about bibliography.",
 	"categorySubcatCount": {
-		"one": "This message is displayed at the top of a category page showing the number of pages in the category (singular form, for count=1)",
-		"other": "This message is displayed at the top of a category page showing the number of pages in the category (plural form, for count>1)."
+		"one": "This message is displayed at the top of a category page showing the number of subcategories (singular form, for count=1)",
+		"other": "This message is displayed at the top of a category page showing the number of subcategories (plural form, for count>1). Uses $t(categoryCurrentPageSubcatCount) to agree with {{curPageCount}}."
+	},
+	"categoryCurrentPageSubcatCount": {
+		"one": "Nested translation used inside categorySubcatCount (plural form) when curPageCount=1. Should read as \"[one subcategory]\".",
+		"other": "Nested translation used inside categorySubcatCount (plural form) when curPageCount>1. Should read as \"[N subcategories]\"."
 	},
 	"subcategories": "Used as a header on category pages that have subcategories.",
 	"categoryEmpty": "The text displayed in category page when that category is empty.",


### PR DESCRIPTION
https://github.com/openzim/mwoffliner/pull/2764 broke some pluralization details; this PR fixes the issue

It also introduces support for nested translations in translation check script.