### PR TITLE
Fix failing test and adapt to new metaData expectations

### DIFF
--- a/test/unit/util/pages.test.ts
+++ b/test/unit/util/pages.test.ts
@@ -51,14 +51,14 @@ describe('pages utility', () => {
     expect(isSubpage(pageTitle)).toBe(true)
   })
 
-  test.each(['Foo_Bar', 'Foo Bar'])('page is main page', (pageTitle) => {
-    MediaWiki.metaData = { mainPage: 'Foo_Bar' } as any
-    expect(isMainPage(pageTitle)).toBe(true)
+  test.each(['Foo Bar'])('page is main page', (pageTitle) => {
+    MediaWiki.metaData = { mainPage: 'Foo Bar' } as any
+    expect(isMainPage(pageTitle as PageTitle)).toBe(true)
   })
 
-  test.each(['Foo:Bar/Alix', 'Talk:Foo/Bar', 'Talk:Foo/Bar Alix'])('page is not main page', (pageTitle) => {
-    MediaWiki.metaData = { mainPage: 'Foo_Bar' } as any
-    expect(isMainPage(pageTitle)).toBe(false)
+  test.each(['Foo_Bar', 'Foo:Bar/Alix', 'Talk:Foo/Bar', 'Talk:Foo/Bar Alix'])('page is not main page', (pageTitle) => {
+    MediaWiki.metaData = { mainPage: 'Foo Bar' } as any
+    expect(isMainPage(pageTitle as PageTitle)).toBe(false)
   })
 
   test.each([


### PR DESCRIPTION
Looks like I broke `main` branch in last PR merge. This is what happens when you do not trust the CI anymore ^^

I've fixed the test + fixed the expectation (Mediawiki.metaData.mainPage is now the page title, so with space, not underscore).