### PR TITLE
Fix detection of image size in URL

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -44,6 +44,7 @@ Unreleased:
 * CHANGED: *** Breaking *** Drop --filenamePrefix and add --customZimName and --customZimFilename with support for placeholders to better control ZIM Name and Filename (@anuragagrawal17 @benoit74 #2710)
 * CHANGED: Reintroduce support of --customFlavour option (beware API has changed due to #2380) (@benoit74 #2707)
 * CHANGED: Drop webp polyfill (@benoit74 #2758)
+* FIX: Fix detection of image size in URL (@benoit74 #2788)
 
 1.17.5:
 * FIX: Ignore articles returning permissiondenied error code (@kunalsiyag #2604)

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -70,9 +70,9 @@ export function getFullUrl(url: string, baseUrl: URL | string) {
 export function getSizeFromUrl(url: string) {
   let mult
   let width
-  const widthMatch = url.match(/[/-]([0-9]+)px-/)
-  if (widthMatch) {
-    width = Number(widthMatch[1])
+  const widthMatches = [...url.matchAll(/[/-]([0-9]+)px-/g)]
+  if (widthMatches.length) {
+    width = Number(widthMatches[widthMatches.length - 1][1])
   } else {
     const multMatch = url.match(/-([0-9.]+)x\./)
     if (multMatch) {

--- a/test/unit/util/misc.test.ts
+++ b/test/unit/util/misc.test.ts
@@ -1,4 +1,4 @@
-import { truncateUtf8Bytes, truncateZimEntryTitleWords } from '../../../src/util/misc.js'
+import { getSizeFromUrl, truncateUtf8Bytes, truncateZimEntryTitleWords } from '../../../src/util/misc.js'
 
 describe('miscelenaous utility functions tests', () => {
   const truncateUtf8BytesCases = [
@@ -30,5 +30,28 @@ describe('miscelenaous utility functions tests', () => {
   test.each(truncateZimEntryTitleWordsCases)('truncateZimEntryTitleWords', (...args) => {
     const [value, expected] = args as [string, string | undefined]
     expect(truncateZimEntryTitleWords(value)).toBe(expected || value)
+  })
+
+  const getSizeFromUrlWidthCases = [
+    ['https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/396px-foo.png/60px-396px-foo.png', 60],
+    ['https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/foo.jpg/60px-foo.jpg', 60],
+    ['https://upload.wikimedia.org/wikipedia/commons/foo.webp/250px-foo.webp', 250],
+    ['https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/foo-250px.jpg/60px-foo-250px.jpg', 60],
+  ]
+  test.each(getSizeFromUrlWidthCases)('getSizeFromUrl width', (url, expectedWidth) => {
+    expect(getSizeFromUrl(url as string)).toEqual({ mult: undefined, width: expectedWidth })
+  })
+
+  const getSizeFromUrlMultCases = [
+    ['https://upload.wikimedia.org/wikipedia/commons/foo-2x.png', 2],
+    ['https://upload.wikimedia.org/wikipedia/commons/foo-1.5x.png', 1.5],
+    ['https://upload.wikimedia.org/wikipedia/commons/12x-foo-1.5x.png', 1.5],
+  ]
+  test.each(getSizeFromUrlMultCases)('getSizeFromUrl mult', (url, expectedMult) => {
+    expect(getSizeFromUrl(url as string)).toEqual({ mult: expectedMult, width: undefined })
+  })
+
+  test('getSizeFromUrl returns empty object when neither width nor mult can be detected', () => {
+    expect(getSizeFromUrl('https://upload.wikimedia.org/wikipedia/commons/foo.png')).toEqual({ mult: undefined, width: undefined })
   })
 })


### PR DESCRIPTION
Fix #2788 

Changes:
- fix algorithm for width detection
- add unit tests as harness for future changes

Nota: since we had no unit tests so far, I consider there is a significant chance I've not correctly considered all image URLs we can encounter. Especially since I'm quite sure I miss the big picture on all URL kinds we can encounter in the wild. The addition of unit tests will help to stop introducing regression every time we fix things for a new kind of URL formatting.