### PR TITLE
Fix again support of --customFlavour

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -44,7 +44,7 @@ Unreleased:
 * CHANGED: *** Breaking *** Drop --filenamePrefix and add --customZimName and --customZimFilename with support for placeholders to better control ZIM Name and Filename (@anuragagrawal17 @benoit74 #2710)
 * CHANGED: Reintroduce support of --customFlavour option (beware API has changed due to #2380) (@benoit74 #2707)
 * CHANGED: Drop webp polyfill (@benoit74 #2758)
-* FIX: Fix detection of image size in URL (@benoit74 #2788)
+* FIX: Fix detection of image size in URL (@benoit74 #2788, #2795)
 
 1.17.5:
 * FIX: Ignore articles returning permissiondenied error code (@kunalsiyag #2604)

--- a/extensions/wiktionary_fr.js
+++ b/extensions/wiktionary_fr.js
@@ -1,4 +1,4 @@
-module.exports = class WiktionaryFR {
+export default class WiktionaryFR {
   // implements CustomProcessor
   async shouldKeepPage(pageTitle, doc) {
     const frenchTitle = doc.querySelector(`#fr.sectionlangue`)

--- a/src/Dump.ts
+++ b/src/Dump.ts
@@ -145,7 +145,6 @@ export class Dump {
   }
 
   private formatTemplate(template: string, placeholders: KVS<string>, optionName: string) {
-    logger.warn(template)
     const formatted = template.replace(/\{([^{}]+)\}/g, (match, key) => {
       if (typeof placeholders[key] !== 'string') {
         const validPlaceholders = Object.keys(placeholders).sort().join(', ')

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -158,7 +158,7 @@ async function execute(argv: any) {
 
   /* Instantiate custom flavour module */
   logger.debug(`Using custom flavour: ${customFlavour || 'no'}`)
-  const customProcessor = customFlavour ? new (await import(customFlavour))() : null
+  const customProcessor = customFlavour ? new (await import(customFlavour)).default() : null
 
   let s3Obj
   // Check for S3 creds


### PR DESCRIPTION
Fix #2795 

Tested with a path (e.g. `--customFlavour /output/wiktionary_fr.js`) and direct in-repo resource (`--customFlavour wiktionary_fr`)