### PR TITLE
Add `--onlyNamespaces` CLI option to include only pages of provided namespaces

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -48,6 +48,7 @@ Unreleased:
 * FIX: Fix bug when listing empty namespaces (@benoit74 #2801)
 * NEW: Add MathJax support (@benoit74 #1371)
 * NEW: Add `--customJs` CLI option to inject custom scripts (@benoit74 #2805)
+* NEW: Add `--onlyNamespaces` CLI option to include only pages of provided namespaces (@benoit74 #2805)
 
 1.17.5:
 * FIX: Ignore articles returning permissiondenied error code (@kunalsiyag #2604)

--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -131,13 +131,19 @@
       "type": "string",
       "required": false,
       "title": "Add Namespaces",
-      "description": "Force addional namespaces (comma separated numbers)"
+      "description": "Force additional namespaces (comma separated numbers)"
     },
     "addContentModels": {
       "type": "string",
       "required": false,
       "title": "Add Content Models",
       "description": "Include additional content models besides wikitext (comma separated, e.g 'Scribunto,json'). By default, only wikitext pages are scraped."
+    },
+    "onlyNamespaces": {
+      "type": "string",
+      "required": false,
+      "title": "Only Namespaces",
+      "description": "Include only pages of provided namespaces (comma separated numbers)"
     },
     "getCategories": {
       "type": "boolean",

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -344,7 +344,7 @@ class MediaWiki {
     }
   }
 
-  public setNamespaces(json: SiteInfoQueryResponse, addNamespaces: number[]) {
+  public setNamespaces(json: SiteInfoQueryResponse, addNamespaces: number[], onlyNamespaces: number[]) {
     ;['namespaces', 'namespacealiases'].forEach((type) => {
       const entries = json[type]
       Object.keys(entries).forEach((key) => {
@@ -352,10 +352,8 @@ class MediaWiki {
         const name = type === 'namespaces' ? entry.name : entry.alias
         const num = entry.id
         const allowedSubpages = 'subpages' in entry
-        const isContent = type === 'namespaces' ? !!(entry.content || util.contains(addNamespaces, num)) : !!(entry.content !== undefined || util.contains(addNamespaces, num))
-        const isBlacklisted = BLACKLISTED_NS.includes(name)
         const canonical = entry.canonical ? entry.canonical : ''
-        const details = { num, allowedSubpages, isContent }
+        const details: MWNamespaceData = { num, allowedSubpages }
 
         /* Namespaces in local language */
         this.namespaces[util.lcFirst(name)] = details
@@ -367,9 +365,17 @@ class MediaWiki {
           this.namespaces[util.ucFirst(canonical)] = details
         }
 
-        /* Is content to mirror */
-        if (isContent && !isBlacklisted) {
-          this.namespacesToMirror.push(name)
+        /* Is namespace to mirror */
+        if (onlyNamespaces.length) {
+          if (util.contains(onlyNamespaces, num)) {
+            this.namespacesToMirror.push(name)
+          }
+        } else {
+          const isContent = type === 'namespaces' ? !!entry.content : !!(entry.content !== undefined)
+          const isBlacklisted = BLACKLISTED_NS.includes(name)
+          if ((isContent || util.contains(addNamespaces, num)) && !isBlacklisted) {
+            this.namespacesToMirror.push(name)
+          }
         }
       })
     })
@@ -454,7 +460,7 @@ class MediaWiki {
     return defaultSkins[0]
   }
 
-  public async getSiteInfo({ addNamespaces, mwModulePath, forceSkin, langVariants }: SiteInfoArgv = {}) {
+  public async getSiteInfo({ addNamespaces, onlyNamespaces, mwModulePath, forceSkin, langVariants }: GetSiteInfoArgv = {}) {
     logger.info('Getting site info...')
     const body = await Downloader.querySiteInfo()
 
@@ -467,7 +473,7 @@ class MediaWiki {
       throw new Error(`Mediawiki version ${mwVersion} not supported should be >=${mwMinimalVersion}`)
     }
 
-    this.setNamespaces(body.query, addNamespaces || [])
+    this.setNamespaces(body.query, addNamespaces || [], onlyNamespaces || [])
     Gadgets.setGadgets(body.query.gadgets)
 
     const { url: licenseUrl, text: licenseName } = body.query.rightsinfo
@@ -544,7 +550,7 @@ class MediaWiki {
     }
   }
 
-  public async getMwMetaData(argvOpts: SiteInfoArgv = {}): Promise<MWMetaData> {
+  public async getMwMetaData(argvOpts: GetSiteInfoArgv = {}): Promise<MWMetaData> {
     if (this.metaData) {
       return this.metaData
     }

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -95,6 +95,7 @@ async function execute(argv: any) {
     publisher: _publisher,
     outputDirectory: _outputDirectory,
     addNamespaces: _addNamespaces,
+    onlyNamespaces: _onlyNamespaces,
     addContentModels: _addContentModels,
     javaScript: _javaScript,
     addModules: _addModules,
@@ -254,10 +255,16 @@ async function execute(argv: any) {
         .map((a: string) => a.trim())
     : []
 
+  const onlyNamespaces = _onlyNamespaces
+    ? String(_onlyNamespaces)
+        .split(',')
+        .map((a: string) => Number(a))
+    : []
+
   /* Get MediaWiki Info */
   let mwMetaData
   try {
-    mwMetaData = await MediaWiki.getMwMetaData({ addNamespaces, mwModulePath, forceSkin, langVariants })
+    mwMetaData = await MediaWiki.getMwMetaData({ addNamespaces, onlyNamespaces, mwModulePath, forceSkin, langVariants })
   } catch (err) {
     logger.error('FATAL - Failed to get MediaWiki Metadata')
     throw err

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -36,7 +36,7 @@ export const parameterDescriptions = {
   webp: 'Convert all jpeg, png and gif images to webp format',
   addNamespaces: 'Force additional namespace (comma separated numbers)',
   addContentModels: 'Include additional content models besides wikitext (comma separated, e.g. "Scribunto,json"). By default, only wikitext pages are scraped.',
-
+  onlyNamespaces: 'Include only pages of provided namespaces (comma separated numbers)',
   javaScript: 'Amount of JavaScript being allowed in pages, one of the following values can be given: "none", "trusted" or "all" (default being "trusted").',
   addModules: 'Add additional ResourceLoader modules for dynamic loading (comma separated list)',
   osTmpDir: 'Override default operating system temporary directory path environment variable',

--- a/src/sanitize-argument.ts
+++ b/src/sanitize-argument.ts
@@ -23,6 +23,7 @@ export async function sanitize_all(argv: any) {
   const {
     pageList,
     addNamespaces,
+    onlyNamespaces,
     speed,
     adminEmail,
     mwUrl,
@@ -47,7 +48,7 @@ export async function sanitize_all(argv: any) {
 
   sanitize_customName_langVariant(customZimName, customZimFilename, langVariant)
 
-  sanitize_pageList_addNamespaces(pageList, addNamespaces)
+  sanitizePageSelection(pageList, addNamespaces, onlyNamespaces)
 
   // sanitizing logLevel
   sanitize_logLevel(logLevel)
@@ -166,9 +167,15 @@ export function sanitize_customName_langVariant(customZimName: string, customZim
   }
 }
 
-export function sanitize_pageList_addNamespaces(pageList: string, addNamespaces: string) {
+export function sanitizePageSelection(pageList: string, addNamespaces: string, onlyNamespaces: string) {
   if (pageList && addNamespaces) {
     throw new Error('options --pageList and --addNamespaces cannot be used together')
+  }
+  if (pageList && onlyNamespaces) {
+    throw new Error('options --pageList and --onlyNamespaces cannot be used together')
+  }
+  if (addNamespaces && onlyNamespaces) {
+    throw new Error('options --addNamespaces and --onlyNamespaces cannot be used together')
   }
 }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -224,12 +224,13 @@ interface MWMetaData {
   modulePathOpt: string
 }
 
+interface MWNamespaceData {
+  num: number
+  allowedSubpages: boolean
+}
+
 interface MWNamespaces {
-  [namespace: string]: {
-    num: number
-    allowedSubpages: boolean
-    isContent: boolean
-  }
+  [namespace: string]: MWNamespaceData
 }
 
 interface MWConfig {
@@ -301,8 +302,9 @@ type RenderOutput = {
   needsDownloadErrorStaticFiles: boolean
 }
 
-interface SiteInfoArgv {
+interface GetSiteInfoArgv {
   addNamespaces?: number[]
+  onlyNamespaces?: number[]
   mwModulePath?: string
   forceSkin?: string
   langVariants?: string[]

--- a/test/e2e/bm.e2e.test.ts
+++ b/test/e2e/bm.e2e.test.ts
@@ -87,6 +87,25 @@ await testAllRenders('bm-wikipedia-with-ns-1', { ...parameters, addNamespaces: 1
     const discussionPagesStr = await zimdump(`list ${outFiles[0].outFile}`)
     const discussionPagesList = discussionPagesStr.match(/Discussion:/g)
     expect(discussionPagesList.length).toBeGreaterThan(30)
+    expect(discussionPagesStr).toContain('Mali')
+  })
+  afterAll(() => {
+    if (!process.env.KEEP_ZIMS) {
+      rimraf.sync(`./${outFiles[0].testId}`)
+    }
+  })
+})
+
+await testAllRenders('bm-wikipedia-only-ns-12', { ...parameters, onlyNamespaces: 12 }, async (outFiles) => {
+  test(`Articles with "Discussion" namespace for ${outFiles[0]?.renderer} renderer for bm.wikipedia.org`, async () => {
+    await execa('redis-cli flushall', { shell: true })
+
+    // Created 1 output
+    expect(outFiles).toHaveLength(1)
+    const discussionPagesStr = await zimdump(`list ${outFiles[0].outFile}`)
+    const discussionPagesList = discussionPagesStr.match(/Aide:/g)
+    expect(discussionPagesList.length).toBeGreaterThan(8)
+    expect(discussionPagesStr).not.toContain('Mali')
   })
   afterAll(() => {
     if (!process.env.KEEP_ZIMS) {

--- a/test/e2e/cmd.e2e.test.ts
+++ b/test/e2e/cmd.e2e.test.ts
@@ -24,6 +24,18 @@ describe('Exec Command With Bash', () => {
       )
     })
 
+    test('Exec Command With --pageList and --onlyNamespaces together', async () => {
+      await expect(execa(`${mwo} --adminEmail=test@test.test --pageList=Portal:Biology --mwUrl=https://en.wikipedia.org/ --onlyNamespaces=100`, { shell: true })).rejects.toThrow(
+        /options --pageList and --onlyNamespaces cannot be used together/,
+      )
+    })
+
+    test('Exec Command With --addNamespaces and --onlyNamespaces together', async () => {
+      await expect(execa(`${mwo} --adminEmail=test@test.test --addNamespaces=101 --mwUrl=https://en.wikipedia.org/ --onlyNamespaces=100`, { shell: true })).rejects.toThrow(
+        /options --addNamespaces and --onlyNamespaces cannot be used together/,
+      )
+    })
+
     test('Exec Command With --log-level option', async () => {
       await expect(execa(`${mwo} --log-level=anyString --mwUrl="https://en.wikipedia.org" --adminEmail="test@test.test"`, { shell: true })).rejects.toThrow(
         /"anyString" is not a valid value for option --log-level. It should be one of \[debug, info, warn, error, silent\]/,

--- a/test/testRenders.ts
+++ b/test/testRenders.ts
@@ -10,6 +10,7 @@ interface Parameters {
   adminEmail: string
   outputDirectory?: string
   addNamespaces?: number
+  onlyNamespaces?: number
   pageList?: string
   pageListToIgnore?: string
   redis?: string

--- a/test/unit/mwApi.test.ts
+++ b/test/unit/mwApi.test.ts
@@ -82,7 +82,7 @@ describe('mwApi', () => {
 
     let keysAreValid = true
     Object.values(MediaWiki.namespaces).forEach((item) => {
-      if (!Object.keys(item).includes('num') || !Object.keys(item).includes('allowedSubpages') || !Object.keys(item).includes('isContent')) keysAreValid = false
+      if (!Object.keys(item).includes('num') || !Object.keys(item).includes('allowedSubpages')) keysAreValid = false
     })
     // Namespaces have valid keys
     expect(keysAreValid).toBeTruthy()


### PR DESCRIPTION
Fix #2803 

Changes:
- adds a `--onlyNamespaces` CLI option to specify we wanna ZIM pages only from (few) given namespaces 
- option is exclusive to `--addNamespaces` and `--pageList`