### PR TITLE
Check typing issues in pre-commit and in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,9 @@ jobs:
       - name: Running ESLint
         run: npm run lint
 
+      - name: Running TypeScript typecheck
+        run: npm run typecheck
+
       - name: Validate Translations
         run: npm run test:i18n
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,11 @@ repos:
         language: system
         types: [file]
         files: \.[jt]sx?$
+  - repo: local
+    hooks:
+      - id: typecheck
+        name: typecheck (system)
+        entry: npm run typecheck
+        language: system
+        pass_filenames: false
+        files: \.[jt]sx?$

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "codecov": "rm -rf coverage && npm run test:unit-coverage && npm run test:e2e-coverage && npm run codecov:merge",
     "lint": "eslint .",
     "lint-fix": "eslint --fix .",
+    "typecheck": "tsc --noEmit",
     "format": "prettier --write './**/*.ts' 'translation/*'",
     "format-check": "prettier --check './**/*.ts' 'translation/*'",
     "prebuild": "node -p \"'export const LIB_VERSION = \\'' + require('./package.json').version + '\\''\" > src/version.ts",

--- a/test/unit/util/pages.test.ts
+++ b/test/unit/util/pages.test.ts
@@ -22,22 +22,18 @@ describe('pages utility', () => {
     MediaWiki.namespaces = {
       '': {
         num: 0,
-        isContent: true,
         allowedSubpages: false,
       },
       Talk: {
         num: 1,
-        isContent: false,
         allowedSubpages: true,
       },
       User: {
         num: 2,
-        isContent: false,
         allowedSubpages: true,
       },
       Foo: {
         num: 100,
-        isContent: true,
         allowedSubpages: true,
       },
     }
@@ -66,7 +62,7 @@ describe('pages utility', () => {
     [1, 'Bar'],
     [999, undefined],
   ])('getNamespaceName', (namespaceNumber, expectedNamespaceName) => {
-    MediaWiki.namespaces = { Foo: { num: 0, allowedSubpages: false, isContent: true }, Bar: { num: 1, allowedSubpages: false, isContent: false } }
+    MediaWiki.namespaces = { Foo: { num: 0, allowedSubpages: false }, Bar: { num: 1, allowedSubpages: false } }
     expect(getNamespaceName(namespaceNumber)).toBe(expectedNamespaceName)
   })
 


### PR DESCRIPTION
I don't know how we oversight this, but this repo was not doing any type checking, not in CI and not in pre-commit hooks.

This PR fixes this:
- add script to typecheck in `package.json`
- call script in Github CI
- call script in pre-commit hook: run typecheck on whole repo (mandatory) but only when a JS/TS file is staged for commit
- fix minor type issues in tests