### PR TITLE
Ensure externally-retrieved string content is replaced as-is, no special replacement meaning

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -51,6 +51,7 @@ Unreleased:
 * NEW: Add `--onlyNamespaces` CLI option to include only pages of provided namespaces (@benoit74 #2805)
 * FIX: Add ability to set MathJax scripts on all pages (@benoit74 #2816)
 * FIX: Walk the category tree up to find all parent categories (@benoit74 #2813)
+* FIX: Ensure externally-retrieved string content is replaced as-is, no special replacement meaning (@benoit74 #2821)
 
 1.17.5:
 * FIX: Ignore articles returning permissiondenied error code (@kunalsiyag #2604)

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -45,6 +45,7 @@ import {
   validateMetadata,
   truncateZimEntryTitleWords,
   makeZimPath,
+  replaceSafe,
 } from './util/index.js'
 import S3 from './S3.js'
 import RedisStore from './RedisStore.js'
@@ -664,11 +665,12 @@ async function execute(argv: any) {
           // Should we have a fragment (i.e. we redirect to a section of a page), this is not (yet) supported by libzim
           // (to have such a redirect with a fragment inside the path), so we create a "fake" entry with only an HTML-based
           // redirect inside
-          const htmlTemplateString = htmlRedirectTemplateCode()
+          const htmlTemplateString = replaceSafe(htmlRedirectTemplateCode())
             .replace(/__TITLE__/g, redirectTitle)
             // we have to replace space in fragment with underscores, see https://phabricator.wikimedia.org/T398724
             .replace(/__TARGET__/g, `${makeZimPath(to)}#${fragment.replace(/ /g, '_')}`)
             .replace(/__RELATIVE_FILE_PATH__/g, getRelativeFilePath(makeZimPath(from), ''))
+            .toString()
           await zimCreatorMutex.runExclusive(() => zimCreator.addItem(new StringItem(makeZimPath(from), 'text/html', redirectTitle, { FRONT_ARTICLE: 1 }, htmlTemplateString)))
         } else {
           // Otherwise we simply add a "regular" libzim redirect

--- a/src/renderers/action-parse.renderer.ts
+++ b/src/renderers/action-parse.renderer.ts
@@ -3,7 +3,7 @@ import { DownloadOpts, DownloadRes, Renderer, RenderOptsModules } from './abstra
 import { RenderOpts } from './abstract.renderer.js'
 import * as logger from '../Logger.js'
 import { config } from '../config.js'
-import { genCanonicalLink, genHeaderScript, genHeaderCSSLink, getRelativeFilePath, jsonStringify } from '../util/misc.js'
+import { genCanonicalLink, genHeaderScript, genHeaderCSSLink, getRelativeFilePath, jsonStringify, replaceSafe } from '../util/misc.js'
 import MediaWiki from '../MediaWiki.js'
 import { htmlVectorLegacyTemplateCode, htmlVector2022TemplateCode, htmlFallbackTemplateCode, javaScriptTemplateCode } from '../Templates.js'
 import Downloader, { DownloadError } from '../Downloader.js'
@@ -108,7 +108,7 @@ export class ActionParseRenderer extends Renderer {
           ].join('\n    ')
         : ''
 
-    const htmlTemplateString = this.#htmlTemplateCode()
+    const htmlTemplateString = replaceSafe(this.#htmlTemplateCode())
       .replace(/__PAGE_LANG_DIR__/g, pageLangDir)
       .replace('__PAGE_CANONICAL_LINK__', genCanonicalLink(config, MediaWiki.webUrl.href, pagePath))
       .replace('__PAGE_JAVASCRIPT__', javaScriptTemplateString)
@@ -126,6 +126,7 @@ export class ActionParseRenderer extends Renderer {
       .replace('__PAGE_BODY_CSS_CLASS__', bodyCssClass)
       .replace('__PAGE_HTML_CSS_CLASS__', htmlCssClass)
       .replace('__PAGE_FIRST_HEADING_STYLE__', hideFirstHeading ? 'style="display: none;"' : '')
+      .toString()
 
     return domino.createDocument(htmlTemplateString)
   }

--- a/src/util/dump.ts
+++ b/src/util/dump.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import * as logger from '../Logger.js'
 import Downloader from '../Downloader.js'
 import FileManager from './FileManager.js'
-import { getFullUrl, jsPath, cssPath, getRelativeFilePath, getMediaBase } from './index.js'
+import { getFullUrl, jsPath, cssPath, getRelativeFilePath, getMediaBase, replaceSafe } from './index.js'
 import { config } from '../config.js'
 import MediaWiki from '../MediaWiki.js'
 import { Creator, StringItem } from '@openzim/libzim'
@@ -242,7 +242,7 @@ export async function downloadModule(module: string, type: 'js' | 'css', langVar
             }),
           ),
         ).replace(/__RELATIVE_FILE_PATH__/g, '"+RLCONF.zimRelativeFilePath+"')
-        text = text.replace(embeddedCss[0], `,{"css":${processedCss}}`)
+        text = replaceSafe(text).replace(embeddedCss[0], `,{"css":${processedCss}}`).toString()
       } catch (e) {
         logger.warn(`Unable to rewrite embedded CSS in JS module [${module}]`, e)
       }

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -45,6 +45,29 @@ export function ucFirst(str: string) {
   return f + str.substr(1)
 }
 
+/**
+ * Chainable wrapper around String.replace() which treats the replacement value as a plain string,
+ * ignoring special patterns like $&, $`, $', $$ and $<n> which String.replace would otherwise interpret.
+ * Use this whenever the replacement value is external/dynamic content (wiki text, downloaded JS/CSS, ...)
+ * which we do not control and must not be given any special meaning.
+ */
+class SafeStringReplacer {
+  constructor(private value: string) {}
+
+  replace(pattern: string | RegExp, replacement: string): this {
+    this.value = this.value.replace(pattern, () => replacement)
+    return this
+  }
+
+  toString(): string {
+    return this.value
+  }
+}
+
+export function replaceSafe(str: string): SafeStringReplacer {
+  return new SafeStringReplacer(str)
+}
+
 function _decodeURIComponent(uri: string) {
   try {
     return decodeURIComponent(uri)


### PR DESCRIPTION
Fix #2821

## Summary

`String.replace()` gives special meaning to certain sequences in the *replacement* string (`$&`, `` $` ``, `$'`, `$$`, `$<n>`), which caused corrupted output when replacing template placeholders with externally-retrieved content (MathJax config script, wiki page titles/fragments, downloaded CSS) that happened to contain one of these sequences (e.g. MathJax `'$'` mark).

- Add `replaceSafe()` in `src/util/misc.ts`, a chainable wrapper around `String.replace()` that always treats the replacement value as a literal string (via an internal function callback), so it can be dropped into existing `.replace().replace()...` chains without adding nesting.
- Apply it to the placeholder-replacement chains that splice in external/dynamic content:
  - `ActionParseRenderer` page template (MathJax scripts, custom CSS/JS, etc.)
  - Fragment-redirect HTML template (wiki page title)
  - Embedded CSS splice in `downloadModule`

Intentional uses of regex backreferences (e.g. `$1` in `hackStartUpModule`) and replacements with static/hardcoded values were left untouched.
