### PR TITLE
Fix computation of relative file paths

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -52,6 +52,7 @@ Unreleased:
 * FIX: Add ability to set MathJax scripts on all pages (@benoit74 #2816)
 * FIX: Walk the category tree up to find all parent categories (@benoit74 #2813)
 * FIX: Ensure externally-retrieved string content is replaced as-is, no special replacement meaning (@benoit74 #2821)
+* FIX: Fix computation of relative file paths (@benoit74 #2809)
 
 1.17.5:
 * FIX: Ignore articles returning permissiondenied error code (@kunalsiyag #2604)

--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -394,9 +394,7 @@ export abstract class Renderer {
     const src = getFullUrl(img.getAttribute('src'), MediaWiki.baseUrl)
     let newSrc: string
     try {
-      const slashesInUrl = zimPath.split('/').length - 1
-      const upStr = slashesInUrl ? '../'.repeat(slashesInUrl) : './'
-      newSrc = upStr + getMediaBase(src, true)
+      newSrc = getRelativeFilePath(zimPath, getMediaBase(src, true))
       /* Download image, but avoid duplicate calls */
       // eslint-disable-next-line no-prototype-builtins
       if (!srcCache.hasOwnProperty(src)) {
@@ -872,7 +870,7 @@ export abstract class Renderer {
           const isParentMirrored = await RedisStore.pagesStore.exists(`${pageTitle.split(parent)[0]}${parent}`)
           subpages += `&lt; ${
             isParentMirrored
-              ? `<a href="${'../'.repeat(parents.length)}${encodePageTitleForZimHtmlUrl(`${pageTitle.split(parent)[0]}${parent}` as PageTitle)}" title="${label}">`
+              ? `<a href="${getRelativeFilePath(makeZimPath(pageTitle), encodePageTitleForZimHtmlUrl(`${pageTitle.split(parent)[0]}${parent}` as PageTitle))}" title="${label}">`
               : ''
           }${label}${isParentMirrored ? '</a> ' : ' '}`
         }),

--- a/src/util/categories.ts
+++ b/src/util/categories.ts
@@ -2,6 +2,7 @@ import MediaWiki from '../MediaWiki.js'
 import { Dump } from '../Dump.js'
 import { config } from '../config.js'
 import { rewriteUrlsOfDoc } from './rewriteUrls.js'
+import { getRelativeFilePath } from './misc.js'
 
 export function buildCategoryMemberList(
   type: 'subcats' | 'pages' | 'files',
@@ -198,9 +199,7 @@ function buildPaginationDiv(doc: Document, page: number, isLastPage: boolean, pa
   spanNoJS.textContent = dump.t('categoryNoPagination')
   section.appendChild(spanNoJS)
 
-  const slashesInUrl = pathPath.split('/').length - 1
-  const upStr = slashesInUrl ? '../'.repeat(slashesInUrl) : './'
-  const partialUrl = `${upStr}${config.output.dirs.categories_partials}${pathPath}_${type}`
+  const partialUrl = getRelativeFilePath(pathPath as ZimPath, `${config.output.dirs.categories_partials}${pathPath}_${type}`)
 
   const spanWithJS = doc.createElement('span')
   spanWithJS.classList.add('mwo-js')

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -207,15 +207,11 @@ export function jsPath(js: string, subDirectory = '') {
   return `${subDirectory ? `${subDirectory}/` : ''}${path.replace(/(\.js)?$/, '')}.js`
 }
 export function genHeaderCSSLink(config: Config, css: string, pagePath: ZimPath, subDirectory = '') {
-  const slashesInUrl = pagePath.split('/').length - 1
-  const upStr = slashesInUrl ? '../'.repeat(slashesInUrl) : './'
-  return `<link href="${upStr}${cssPath(css, subDirectory)}" rel="stylesheet" type="text/css"/>`
+  return `<link href="${getRelativeFilePath(pagePath, cssPath(css, subDirectory))}" rel="stylesheet" type="text/css"/>`
 }
 export function genHeaderScript(config: Config, js: string, pagePath: ZimPath, subDirectory = '', attributes = '') {
-  const slashesInUrl = pagePath.split('/').length - 1
-  const upStr = slashesInUrl ? '../'.repeat(slashesInUrl) : './'
   const path = isNodeModule(js) ? normalizeModule(js) : js
-  return `<script ${attributes} src="${upStr}${jsPath(path, subDirectory)}"></script>`
+  return `<script ${attributes} src="${getRelativeFilePath(pagePath, jsPath(path, subDirectory))}"></script>`
 }
 export function genCanonicalLink(config: Config, webUrl: string, pagePath: ZimPath) {
   return `<link rel="canonical" href="${webUrl}${encodeURIComponent(pagePath)}" />`
@@ -352,7 +348,9 @@ export function deDup<T>(_arr: T[], getter: (o: T) => any) {
 }
 
 export function getRelativeFilePath(parentPagePath: ZimPath, fileBase: string) {
-  const slashesInUrl = parentPagePath.split('/').length - 1
+  // leading slashes carry no subfolder (nothing precedes the first segment), and consecutive
+  // slashes must count as a single subfolder separator, not one per slash
+  const slashesInUrl = (parentPagePath.replace(/^\/+/, '').match(/\/+/g) || []).length
   const upStr = slashesInUrl ? '../'.repeat(slashesInUrl) : './'
   return upStr + fileBase
 }

--- a/src/util/rewriteUrls.ts
+++ b/src/util/rewriteUrls.ts
@@ -227,12 +227,10 @@ export async function rewriteUrls(pagePath: ZimPath, dump: Dump, linkNodes: Domi
   }
 
   if (pagePath.includes('/')) {
-    const slashesInUrl = pagePath.split('/').length - 1
-    const upStr = slashesInUrl ? '../'.repeat(slashesInUrl) : './'
     Object.values(wikilinkMappings).forEach((linkNodes: DominoElement[]) => {
       for (const linkNode of linkNodes) {
         const href = linkNode.getAttribute('href')
-        linkNode.setAttribute('href', `${upStr}${href}`)
+        linkNode.setAttribute('href', getRelativeFilePath(pagePath, href))
       }
     })
   }

--- a/test/unit/util/misc.test.ts
+++ b/test/unit/util/misc.test.ts
@@ -1,4 +1,4 @@
-import { getSizeFromUrl, truncateUtf8Bytes, truncateZimEntryTitleWords } from '../../../src/util/misc.js'
+import { getRelativeFilePath, getSizeFromUrl, truncateUtf8Bytes, truncateZimEntryTitleWords } from '../../../src/util/misc.js'
 
 describe('miscelenaous utility functions tests', () => {
   const truncateUtf8BytesCases = [
@@ -53,5 +53,26 @@ describe('miscelenaous utility functions tests', () => {
 
   test('getSizeFromUrl returns empty object when neither width nor mult can be detected', () => {
     expect(getSizeFromUrl('https://upload.wikimedia.org/wikipedia/commons/foo.png')).toEqual({ mult: undefined, width: undefined })
+  })
+
+  const getRelativeFilePathCases = [
+    ['', 'foo.css', './foo.css'],
+    ['A', 'foo.css', './foo.css'],
+    ['A/B', 'foo.css', '../foo.css'],
+    ['A/B/C', 'foo.css', '../../foo.css'],
+    // consecutive slashes must count as a single subfolder separator, not one per slash
+    ['A//B', 'foo.css', '../foo.css'],
+    ['A///B', 'foo.css', '../foo.css'],
+    ['A//B//C', 'foo.css', '../../foo.css'],
+    ['A//B/C', 'foo.css', '../../foo.css'],
+    // leading slashes are ignored entirely, no matter how many
+    ['/A/B', 'foo.css', '../foo.css'],
+    ['//A/B', 'foo.css', '../foo.css'],
+    ['///A', 'foo.css', './foo.css'],
+    // trailing slashes still count as a separator
+    ['A/B/', 'foo.css', '../../foo.css'],
+  ]
+  test.each(getRelativeFilePathCases)('getRelativeFilePath(%p, %p)', (parentPagePath, fileBase, expected) => {
+    expect(getRelativeFilePath(parentPagePath as ZimPath, fileBase as string)).toBe(expected)
   })
 })


### PR DESCRIPTION
Fix #2809

## Summary

`getRelativeFilePath()` computes how many `../` are needed to get back to the ZIM root from a page's path, by counting `/` in `parentPagePath`. Two bugs made this miscount, and the same buggy logic was duplicated in five other places instead of calling this function:

- Consecutive slashes (e.g. `A//B`) were counted once per `/` instead of once per separator, inflating the `../` count.
- Leading slashes (e.g. `/A/B`) were also counted as a separator, even though nothing precedes the first segment.

Either bug produces relative paths pointing to the wrong directory, potentially breaking asset/link resolution on affected pages. Rarely seen an impact because going "too high" in the ZIM path means nothing so it rarely broke something (beside zimcheck which complained for good reasons).
