### PR TITLE
Fix parsing of jsConfigVars using new line characters

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -53,6 +53,7 @@ Unreleased:
 * FIX: Walk the category tree up to find all parent categories (@benoit74 #2813)
 * FIX: Ensure externally-retrieved string content is replaced as-is, no special replacement meaning (@benoit74 #2821)
 * FIX: Fix computation of relative file paths (@benoit74 #2809)
+* FIX: Fix parsing of jsConfigVars using new line characters (@benoit74 #2808)
 
 1.17.5:
 * FIX: Ignore articles returning permissiondenied error code (@kunalsiyag #2604)

--- a/src/util/pages.ts
+++ b/src/util/pages.ts
@@ -47,7 +47,7 @@ export function extractJsConfigVars(headHtml: string, extraJsConfigVars: KVS<any
     try {
       let jsonString = match[1]
       if (jsonString.includes('"wgBreakFrames":!')) {
-        jsonString = jsonString.replace(/":!0([,}])/g, '":true$1').replace(/":!1([,}])/g, '":false$1')
+        jsonString = jsonString.replace(/":\s*!0([,}])/g, '":true$1').replace(/":\s*!1([,}])/g, '":false$1')
       }
       jsConfigVars = JSON.parse(jsonString)
     } catch (e) {

--- a/test/unit/util/pages.test.ts
+++ b/test/unit/util/pages.test.ts
@@ -218,4 +218,12 @@ describe('pages utility', () => {
     }
     expect(extractJsConfigVars(fakeHeadHtml)).toEqual(result[mwVersion])
   })
+
+  test('extractJsConfigVars handles !0/!1 markers separated from the colon by whitespace (e.g. spanning multiple lines)', () => {
+    const headHtml = `<script>;RLCONF={"wgBreakFrames":!0,"wgIsArticle":\n!1,"wgIsRedirect":\t!0,"wgCanonicalSpecialPageName":!1};RLSTATE={};</script>`
+    const result = extractJsConfigVars(headHtml)
+    expect(result.wgIsArticle).toBe(false)
+    expect(result.wgIsRedirect).toBe(true)
+    expect(result.wgCanonicalSpecialPageName).toBe(false)
+  })
 })


### PR DESCRIPTION
Fix #2808 

MediaWiki minifies JS config booleans as `!0`/`!1` instead of `true`/`false`. `extractJsConfigVars()` rewrites these to valid JSON before parsing, but the regex required `!0`/`!1` to immediately follow the `:` — when the minified script happened to wrap across lines (e.g. `"tchlist":\n!1,...`), the rewrite was skipped and `JSON.parse` failed, dropping all `jsConfigVars` for that page.
