### PR TITLE
HTML page title should not contain HTML code

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -54,6 +54,7 @@ Unreleased:
 * FIX: Ensure externally-retrieved string content is replaced as-is, no special replacement meaning (@benoit74 #2821)
 * FIX: Fix computation of relative file paths (@benoit74 #2809)
 * FIX: Fix parsing of jsConfigVars using new line characters (@benoit74 #2808)
+* FIX: HTML page title should not contain HTML code (@benoit74 #2814)
 
 1.17.5:
 * FIX: Ignore articles returning permissiondenied error code (@kunalsiyag #2604)

--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -845,8 +845,18 @@ export abstract class Renderer {
     mwContentText.innerHTML = parsoidDoc.getElementsByTagName('body')[0].innerHTML
 
     /* Title */
-    const htmlTitle = htmlTemplateDoc.getElementById('title_0') ? htmlTemplateDoc.getElementById('title_0').textContent : displayTitle ? displayTitle : pageTitle
-    htmlTemplateDoc.getElementsByTagName('title')[0].innerHTML = htmlTitle
+    let htmlTitle: string
+    if (htmlTemplateDoc.getElementById('title_0')) {
+      htmlTitle = htmlTemplateDoc.getElementById('title_0').innerText
+    } else if (displayTitle) {
+      // displayTitle may contain HTML markup (e.g. italics), which has no place in the <title> tag
+      const titleDiv = htmlTemplateDoc.createElement('div')
+      titleDiv.innerHTML = displayTitle
+      htmlTitle = titleDiv.textContent
+    } else {
+      htmlTitle = pageTitle
+    }
+    htmlTemplateDoc.getElementsByTagName('title')[0].textContent = htmlTitle
     // Set inline page title when missing
     const inlineTitle = htmlTemplateDoc.getElementById('firstHeading')
     if (inlineTitle && !inlineTitle.innerHTML) {

--- a/test/e2e/displayTitle.e2e.test.ts
+++ b/test/e2e/displayTitle.e2e.test.ts
@@ -44,6 +44,13 @@ await testRenders(
         expect(pageTitle).toBeTruthy()
         expect(pageTitle.innerHTML).toBe('<i>Giraffe</i> (album)')
       })
+
+      test(`test html <title> for ${outFiles[0].renderer} renderer`, async () => {
+        const htmlTitle = giraffePageDoc.querySelector('title')
+        expect(htmlTitle).toBeTruthy()
+        expect(htmlTitle.textContent).toBe('Giraffe (album)')
+        expect(htmlTitle.innerHTML).not.toMatch(/[<>]/)
+      })
     })
 
     describe('main page display title', () => {


### PR DESCRIPTION
Fix #2814 

The HTML `<title>` element must contain plain text only, but `mergeTemplateDoc()` was setting it via `.innerHTML` from a value that can itself contain markup (`displayTitle`, e.g. `<i>Giraffe</i> (album)`). This leaked HTML tags into the `<title>` tag content. Existing coverage only checked the ZIM entry title metadata and the visible `<h1>` heading (which legitimately keeps the markup) — not the `<head><title>` tag itself, so this went unnoticed.
