### PR TITLE
Concurrent image download headers were leaking across workers

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -55,6 +55,7 @@ Unreleased:
 * FIX: Fix computation of relative file paths (@benoit74 #2809)
 * FIX: Fix parsing of jsConfigVars using new line characters (@benoit74 #2808)
 * FIX: HTML page title should not contain HTML code (@benoit74 #2814)
+* FIX: Concurrent image download headers were leaking across workers (@benoit74 #2810 #2811)
 
 1.17.5:
 * FIX: Ignore articles returning permissiondenied error code (@kunalsiyag #2604)

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -816,12 +816,18 @@ class Downloader {
           // 'Versioning' of image is made via HTTP ETag. We should
           // check if we have the proper version by requesting proper
           // ETag from upstream MediaWiki.
+          // Headers are cloned per-request: concurrent downloads share this.arrayBufferRequestOptions,
+          // so mutating its headers in place would leak one image's If-None-Match onto another's request.
+          const requestOptions = {
+            ...this.arrayBufferRequestOptions,
+            headers: { ...this.arrayBufferRequestOptions.headers },
+          }
           if (s3Resp?.Metadata?.etag) {
-            this.arrayBufferRequestOptions.headers['If-None-Match'] = this.removeEtagWeakPrefix(s3Resp.Metadata.etag)
+            requestOptions.headers['If-None-Match'] = this.removeEtagWeakPrefix(s3Resp.Metadata.etag)
           }
           // Use the base domain of the wiki being scraped as the Referer header, so that we can
           // successfully scrape WMF map tiles.
-          const mwResp = await this.request({ url, method: 'GET', ...this.arrayBufferRequestOptions })
+          const mwResp = await this.request({ url, method: 'GET', ...requestOptions })
 
           // Most of the images, after having been uploaded once to the
           // cache, will always have 304 status, until modified. If cache


### PR DESCRIPTION
Fix #2810 
Fix #2811

## Summary

`arrayBufferRequestOptions.headers` is a single object shared across the whole `Downloader` instance. `downloadImage()` mutated it in place to set `If-None-Match` before each conditional GET, but never cleared it afterward. With images downloading concurrently, one image's `If-None-Match` value could leak onto a different, concurrent image's request — causing upstream to spuriously answer `304` for a URL with no (or a version-mismatched) S3 cache entry. The code then trusted its own invariant ("we always have an s3 response when mwResp is 304") and read a missing/stale cached body

## Changes

- `src/Downloader.ts`: build a per-request headers object (shallow clone) in `downloadImage()` instead of mutating `this.arrayBufferRequestOptions.headers` in place, so concurrent downloads can no longer see each other's `If-None-Match` value.