### PR TITLE
Fix animated images support

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -56,6 +56,7 @@ Unreleased:
 * FIX: Fix parsing of jsConfigVars using new line characters (@benoit74 #2808)
 * FIX: HTML page title should not contain HTML code (@benoit74 #2814)
 * FIX: Concurrent image download headers were leaking across workers (@benoit74 #2810 #2811)
+* FIX: Add support for animated PNGs (do not always recompress to static PNG) + compress GIF to WEBP (they do support animation) (@benoit74 #2830)
 
 1.17.5:
 * FIX: Ignore articles returning permissiondenied error code (@kunalsiyag #2604)

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -735,7 +735,8 @@ class Downloader {
 
   private async compressDefault(data: Buffer, contentType: string): Promise<Buffer> {
     if (contentType === 'image/png') {
-      return await sharp(data).png({ palette: true, quality: 60, effort: 7 }).toBuffer()
+      // { animated: true } reads all frames of an animated PNG (APNG); it is a no-op for static PNGs
+      return await sharp(data, { animated: true }).png({ palette: true, quality: 60, effort: 7 }).toBuffer()
     } else if (contentType === 'image/jpeg') {
       return await sharp(data).jpeg({ quality: 60, mozjpeg: true }).toBuffer()
     } else if (contentType === 'image/gif') {
@@ -746,14 +747,15 @@ class Downloader {
   private async getCompressedBody(input: CompressionData, requestedWidth?: number): Promise<CompressionData> {
     const contentType = await this.getImageMimeType(input.data)
     if (isBitmapImageMimeType(contentType)) {
-      // Resize down with sharp before compression when the source is wider
-      // than the requested display width. Skip GIFs to avoid breaking animations.
+      // Resize down with sharp before compression when the source is wider than the requested
+      // display width. { animated: true } reads all frames so animated GIFs/APNGs are resized
+      // frame-by-frame and stay animated, instead of only keeping their first frame.
       let dataToCompress = input.data
-      if (requestedWidth && contentType !== 'image/gif') {
+      if (requestedWidth) {
         try {
-          const metadata = await sharp(input.data).metadata()
+          const metadata = await sharp(input.data, { animated: true }).metadata()
           if (metadata.width && metadata.width > requestedWidth) {
-            dataToCompress = await sharp(input.data).resize({ width: requestedWidth, withoutEnlargement: true }).toBuffer()
+            dataToCompress = await sharp(input.data, { animated: true }).resize({ width: requestedWidth, withoutEnlargement: true }).toBuffer()
           }
         } catch (err) {
           logger.warn(`Failed to resize image to ${requestedWidth}px, proceeding without resize: ${(err as any).message}`)
@@ -762,7 +764,7 @@ class Downloader {
 
       if (this.webp && isWebpCandidateImageMimeType(contentType)) {
         try {
-          return { data: await sharp(dataToCompress).webp({ quality: 50, effort: 6 }).toBuffer() }
+          return { data: await sharp(dataToCompress, { animated: true }).webp({ quality: 50, effort: 6 }).toBuffer() }
         } catch {
           return { data: await this.compressDefault(dataToCompress, contentType) }
         }

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -10,7 +10,7 @@ export const DB_ERROR = 'internal_api_error_DBQueryError'
 export const DELETED_PAGE_ERROR = 'Page has been deleted.'
 export const WEAK_ETAG_REGEX = /^(W\/)/
 export const BITMAP_IMAGE_MIME_REGEX = /^image+[/-\w.]+(jpeg|png|gif)$/
-export const WEBP_CANDIDATE_IMAGE_MIME_TYPE = /image+[/]+(jpeg|png)/
+export const WEBP_CANDIDATE_IMAGE_MIME_TYPE = /image+[/]+(jpeg|png|gif)/
 export const RULE_TO_REDIRECT = /window\.top!==window\.self/
 export const MAX_FILE_DOWNLOAD_RETRIES = 5
 export const FILES_DOWNLOAD_FAILURE_MINIMUM_FOR_CHECK = 50 // minimum number of files failing download before starting to consider for failing the scrape

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -246,7 +246,7 @@ describe('Utils', () => {
   test('isWebpCandidate by mime type', async () => {
     expect(isWebpCandidateImageMimeType('image/jpeg')).toBeTruthy()
     expect(isWebpCandidateImageMimeType('image/png')).toBeTruthy()
-    expect(isWebpCandidateImageMimeType('image/gif')).toBeFalsy()
+    expect(isWebpCandidateImageMimeType('image/gif')).toBeTruthy()
     expect(isWebpCandidateImageMimeType('application/json')).toBeFalsy()
     expect(isWebpCandidateImageMimeType('image/svg+xml')).toBeFalsy()
     expect(isWebpCandidateImageMimeType('image/svg')).toBeFalsy()


### PR DESCRIPTION
## Summary

Animated images were losing their animation, or missing a compression opportunity, in three places in `Downloader.ts`'s image pipeline:

- `compressDefault()`'s PNG branch didn't pass `{ animated: true }` to `sharp()` (unlike the GIF branch), so animated PNGs (APNG) were flattened to their first frame during compression.
- The pre-compression resize step skipped GIF entirely to avoid the same first-frame-only problem — meaning animated images were never actually downsized, even when much wider than needed.
- `WEBP_CANDIDATE_IMAGE_MIME_TYPE` excluded GIF, so animated GIFs never benefited from WebP's generally better compression (WebP supports animation just like GIF/APNG) even when `--webp` is enabled.

## Changes

- `src/Downloader.ts`: pass `{ animated: true }` everywhere `sharp()` touches potentially-animated content (`compressDefault`'s PNG branch, the resize step, and the WebP conversion branch) — reads/writes all frames instead of just the first. This also let us remove the GIF-only resize-skip guard: since resize now correctly preserves animation, animated images get properly downsized instead of skipped.
- `src/util/const.ts`: `WEBP_CANDIDATE_IMAGE_MIME_TYPE` now includes `gif`, so animated GIFs are converted to (animated) WebP like JPEG/PNG already were.
- `test/unit/util.test.ts`: update `isWebpCandidate by mime type` expectation for `image/gif` (now a candidate).
