### PR TITLE
Fix crash rendering category pages without loaded members

### DIFF
--- a/src/renderers/abstract.renderer.ts
+++ b/src/renderers/abstract.renderer.ts
@@ -666,7 +666,7 @@ export abstract class Renderer {
 
     /* The content of a category page, listing all its members */
     if (pageDetail.categoryinfo) {
-      const categoryinfo = categoryMembers.categoryinfo
+      const categoryinfo = categoryMembers ? categoryMembers.categoryinfo : pageDetail.categoryinfo
       const categoryContent = doc.createElement('div')
       categoryContent.lang = pageDetail.pagelang
       categoryContent.dir = pageDetail.pagedir

--- a/test/unit/renderers/processHtml.test.ts
+++ b/test/unit/renderers/processHtml.test.ts
@@ -284,4 +284,33 @@ describe('processHtml', () => {
       expect(link?.getAttribute('aria-label')).toBe('View this content externally')
     })
   })
+
+  describe('category pages', () => {
+    it('renders an empty category page without category members', async () => {
+      MediaWiki.webUrl = new URL('https://en.wikipedia.org')
+      MediaWiki.baseUrl = MediaWiki.webUrl
+      MediaWiki.metaData = { mainPage: 'Main_Page' } as any
+      const t = await createTranslator('en')
+      const pageTitle = 'Category:Empty' as PageTitle
+      const pageDetail = {
+        title: pageTitle,
+        timestamp: '2023-09-10T17:36:04Z',
+        categoryinfo: { size: 0, pages: 0, files: 0, subcats: 0, hidden: false, nogallery: false },
+      }
+      const opts: ProcessHtmlOpts = {
+        html: '<div id="mw-content-text"></div>',
+        dump: new Dump('', '', {} as any, MediaWiki.metaData, undefined, t),
+        pageTitle,
+        pageDetail,
+        moduleDependencies: { styleDependenciesList: [] },
+        callback: () => {
+          return domino.createDocument('<html><head><title></title></head><body><div id="mw-content-text"></div></body></html>')
+        },
+      }
+      const result = await testRenderer.processHtml(opts)
+      expect(result.items.length).toBe(1)
+      const finalDoc = domino.createDocument(result.items[0].htmlContent)
+      expect(finalDoc.querySelector('.mw-category-generated')).not.toBeNull()
+    })
+  })
 })


### PR DESCRIPTION
Fix #2833

## Summary

Rendering a category page could crash with `TypeError: Cannot read properties of null (reading 'categoryinfo')` at `abstract.renderer.ts`.

The renderer enters the category block whenever `pageDetail.categoryinfo` is present, then reads `categoryMembers.categoryinfo`. But `Downloader` only populates `categoryMembers` when `pageDetail.categoryinfo?.size` is truthy (`Downloader.ts` ~518) and leaves it `null` otherwise. So a category page that has `categoryinfo` but a falsy `size` (e.g. an empty category) reaches the renderer with `categoryMembers === null` and throws.

This sources the local `categoryinfo` from `pageDetail.categoryinfo` when `categoryMembers` is null, so the existing empty-category path (which already renders the `categoryEmpty` message) is taken instead of crashing. When members are loaded, behaviour is unchanged.

## Test

Added a unit test in `processHtml.test.ts` that renders a category page whose `categoryinfo.size` is 0 with no `categoryMembers`, which threw before the change. I could not run the full suite locally because building the native `@openzim/libzim` binding needs a toolchain I don't have set up here; `eslint` on the changed files passes.
