### PR TITLE
Animated images fixes

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -56,7 +56,7 @@ Unreleased:
 * FIX: Fix parsing of jsConfigVars using new line characters (@benoit74 #2808)
 * FIX: HTML page title should not contain HTML code (@benoit74 #2814)
 * FIX: Concurrent image download headers were leaking across workers (@benoit74 #2810 #2811)
-* FIX: Add support for animated PNGs (do not always recompress to static PNG) + compress GIF to WEBP (they do support animation) (@benoit74 #2830)
+* FIX: Add support for animated PNGs (do not always recompress to static PNG) + compress GIF to WEBP (they do support animation) (@benoit74 #2830, #2843)
 
 1.17.5:
 * FIX: Ignore articles returning permissiondenied error code (@kunalsiyag #2604)

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "rimraf": "^6.1.3",
         "semver": "^7.8.5",
         "sharp": "^0.35.3",
+        "sharp-apng": "^0.1.5",
         "split-by-grapheme": "^1.0.1",
         "swig-templates": "^2.0.3",
         "tough-cookie": "^6.0.2",
@@ -5356,6 +5357,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gifenc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gifenc/-/gifenc-1.0.3.tgz",
+      "integrity": "sha512-xdr6AdrfGBcfzncONUOlXMBuc5wJDtOueE3c5rdG0oNgtINLD+f2iFZltrBRZYzACRbKr+mSVU/x98zv2u3jmw==",
+      "license": "MIT"
+    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -7875,6 +7882,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -8653,6 +8666,17 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/sharp-apng": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/sharp-apng/-/sharp-apng-0.1.5.tgz",
+      "integrity": "sha512-aMXP090X2joAloTyLfhCX3OXQYDRga4lxt3fxYvz4/d6zzuIHDc5QjL+TbIeebunD/jOhdeG8lUHAof4SRdK0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "gifenc": "*",
+        "sharp": "*",
+        "upng-js": "*"
       }
     },
     "node_modules/shebang-command": {
@@ -9790,6 +9814,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/upng-js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/upng-js/-/upng-js-2.1.0.tgz",
+      "integrity": "sha512-d3xzZzpMP64YkjP5pr8gNyvBt7dLk/uGI67EctzDuVp4lCZyVMo0aJO6l/VDlgbInJYDY6cnClLoBp29eKWI6g==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.5"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "rimraf": "^6.1.3",
     "semver": "^7.8.5",
     "sharp": "^0.35.3",
+    "sharp-apng": "^0.1.5",
     "split-by-grapheme": "^1.0.1",
     "swig-templates": "^2.0.3",
     "tough-cookie": "^6.0.2",

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -4,7 +4,8 @@ import { filterRedirects, DB_ERROR, WEAK_ETAG_REGEX, stripHttpFromUrl, isBitmapI
 import { Readable } from 'stream'
 import type { BackoffStrategy } from 'backoff'
 import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios'
-import sharp from 'sharp'
+import sharp, { Sharp } from 'sharp'
+import apng from 'sharp-apng'
 import { fileTypeFromBuffer } from 'file-type'
 import { HttpCookieAgent, HttpsCookieAgent } from 'http-cookie-agent/http'
 import { CookieJar } from 'tough-cookie'
@@ -43,7 +44,8 @@ interface BackoffOptions {
 }
 
 interface CompressionData {
-  data: any
+  data: Buffer
+  context: string
 }
 
 function isJsonContentType(contentType: string | null): boolean {
@@ -733,48 +735,67 @@ class Downloader {
     return fileType ? fileType.mime : null
   }
 
-  private async compressDefault(data: Buffer, contentType: string): Promise<Buffer> {
-    if (contentType === 'image/png') {
-      // { animated: true } reads all frames of an animated PNG (APNG); it is a no-op for static PNGs
-      return await sharp(data, { animated: true }).png({ palette: true, quality: 60, effort: 7 }).toBuffer()
-    } else if (contentType === 'image/jpeg') {
-      return await sharp(data).jpeg({ quality: 60, mozjpeg: true }).toBuffer()
-    } else if (contentType === 'image/gif') {
-      return await sharp(data, { animated: true }).gif({ colours: 64, effort: 7 }).toBuffer()
+  private async getSharpObject(input: CompressionData, contentType: string): Promise<Sharp> {
+    if (contentType == 'image/apng') {
+      try {
+        // resolveWithObject is not passed, so sharpFromApng always resolves to a Sharp instance, never ImageData
+        return (await apng.sharpFromApng(input.data)) as Sharp
+      } catch {
+        logger.warn(`Failed to read animated PNG at ${input.context}: static image will be used instead of animation`)
+        return sharp(input.data, { animated: true })
+      }
+    } else {
+      // { animated: true } reads all frames of an animated pictures; it is a no-op for static images
+      return sharp(input.data, { animated: true })
     }
   }
 
-  private async getCompressedBody(input: CompressionData, requestedWidth?: number): Promise<CompressionData> {
+  private async compressDefault(sharpObject: Sharp, context: string, contentType: string): Promise<Buffer> {
+    if (contentType == 'image/png') {
+      return sharpObject.png({ palette: true, quality: 60, effort: 7 }).toBuffer()
+    } else if (contentType == 'image/apng') {
+      logger.warn(`Cannot compress image at ${context}: recompressing APNG to APNG is not supported ATM, using original data`)
+      return sharpObject.toBuffer()
+    } else if (contentType === 'image/jpeg') {
+      return sharpObject.jpeg({ quality: 60, mozjpeg: true }).toBuffer()
+    } else if (contentType === 'image/gif') {
+      return sharpObject.gif({ colours: 64, effort: 7 }).toBuffer()
+    } else {
+      logger.warn(`Cannot compress image at ${context}: unknown content-type ${contentType}, using original data`)
+      return sharpObject.toBuffer()
+    }
+  }
+
+  private async getCompressedBody(input: CompressionData, requestedWidth?: number): Promise<Buffer> {
     const contentType = await this.getImageMimeType(input.data)
     if (isBitmapImageMimeType(contentType)) {
       // Resize down with sharp before compression when the source is wider than the requested
       // display width. { animated: true } reads all frames so animated GIFs/APNGs are resized
       // frame-by-frame and stay animated, instead of only keeping their first frame.
-      let dataToCompress = input.data
+      let sharpData = await this.getSharpObject(input, contentType)
       if (requestedWidth) {
         try {
-          const metadata = await sharp(input.data, { animated: true }).metadata()
+          const metadata = await sharpData.metadata()
           if (metadata.width && metadata.width > requestedWidth) {
-            dataToCompress = await sharp(input.data, { animated: true }).resize({ width: requestedWidth, withoutEnlargement: true }).toBuffer()
+            sharpData = sharpData.resize({ width: requestedWidth, withoutEnlargement: true })
           }
         } catch (err) {
-          logger.warn(`Failed to resize image to ${requestedWidth}px, proceeding without resize: ${(err as any).message}`)
+          logger.warn(`Failed to resize image from ${input.context} to ${requestedWidth}px, proceeding without resize: ${(err as any).message}`)
         }
       }
 
       if (this.webp && isWebpCandidateImageMimeType(contentType)) {
         try {
-          return { data: await sharp(dataToCompress, { animated: true }).webp({ quality: 50, effort: 6 }).toBuffer() }
+          return await sharpData.webp({ quality: 50, effort: 6 }).toBuffer()
         } catch {
-          return { data: await this.compressDefault(dataToCompress, contentType) }
+          logger.warn(`Failed to compress ${input.context} to WEBP as requested, falling back to simple recompression of original format`)
+          return await this.compressDefault(sharpData, input.context, contentType)
         }
       } else {
-        return { data: await this.compressDefault(dataToCompress, contentType) }
+        return await this.compressDefault(sharpData, input.context, contentType)
       }
     }
-    return {
-      data: input.data,
-    }
+    return input.data
   }
 
   private getContentCb = async (url: string, kind: DownloadKind, requestedWidth: number | undefined, handler: any): Promise<void> => {
@@ -785,7 +806,11 @@ class Downloader {
       } else {
         const resp = await this.request({ url, method: 'GET', ...this.arrayBufferRequestOptions })
         // If content is an image, we might benefit from compressing it
-        const content = kind === 'image' ? (await this.getCompressedBody({ data: resp.data }, requestedWidth)).data : resp.data
+        const content = kind === 'image' ? await this.getCompressedBody({ data: resp.data, context: url }, requestedWidth) : resp.data
+        // Check content really exists
+        if (!content?.length) {
+          logger.warn(`Content for ${url} is missing or empty (${typeof content})`)
+        }
         // compute content-type from content, since getCompressedBody might have modified it
         const contentType = kind === 'image' ? (await this.getImageMimeType(content)) || resp.headers['content-type'] : resp.headers['content-type']
         handler(null, {
@@ -854,7 +879,12 @@ class Downloader {
           }
 
           // Compress content because image blob comes from upstream MediaWiki
-          const compressedData = (await this.getCompressedBody({ data: mwResp.data }, requestedWidth)).data
+          const compressedData = await this.getCompressedBody({ data: mwResp.data, context: url }, requestedWidth)
+
+          // Check content really exists
+          if (!compressedData?.length) {
+            throw new Error(`Content for ${url} is missing or empty (${typeof compressedData})`)
+          }
 
           // Check for the ETag and upload to cache
           const etag = this.removeEtagWeakPrefix(mwResp.headers.etag)

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -9,8 +9,8 @@ export const FIND_HTTP_REGEX = /^(?:https?:\/\/)?/i
 export const DB_ERROR = 'internal_api_error_DBQueryError'
 export const DELETED_PAGE_ERROR = 'Page has been deleted.'
 export const WEAK_ETAG_REGEX = /^(W\/)/
-export const BITMAP_IMAGE_MIME_REGEX = /^image+[/-\w.]+(jpeg|png|gif)$/
-export const WEBP_CANDIDATE_IMAGE_MIME_TYPE = /image+[/]+(jpeg|png|gif)/
+export const BITMAP_IMAGE_MIME_REGEX = /^image+[/-\w.]+(jpeg|png|apng|gif)$/
+export const WEBP_CANDIDATE_IMAGE_MIME_TYPE = /image+[/]+(jpeg|png|apng|gif)/
 export const RULE_TO_REDIRECT = /window\.top!==window\.self/
 export const MAX_FILE_DOWNLOAD_RETRIES = 5
 export const FILES_DOWNLOAD_FAILURE_MINIMUM_FOR_CHECK = 50 // minimum number of files failing download before starting to consider for failing the scrape


### PR DESCRIPTION
Fix #2836 

Changes:
- subtle fixes around APNG image mime-type and handling of errors
- add `sharp-apng` to really supported APNG decoding
- add some useful warnings + more verbose logs with context (URL) of image being processed
- add failsafe check before proceeding with empty content should something bad have happened