### PR TITLE
Solve issues around empty categories

### DIFF
--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -924,22 +924,27 @@ class Downloader {
     handler(err)
   }
 
-  private async getCategoryMembers(pageTitle: PageTitle, categoryMembers: GroupedCategoryMembers, continueStr = ''): Promise<void> {
+  private async getCategoryMembers(pageTitle: PageTitle, categoryMembers: GroupedCategoryMembers): Promise<void> {
     const apiUrlDirector = new ApiURLDirector(MediaWiki.actionApiUrl.href)
 
-    const { query, continue: cont } = await this.getJSON<any>(apiUrlDirector.buildCategoryMembersURL(pageTitle, continueStr))
-    const items: Array<CategoryMember> = query.categorymembers.filter((a: CategoryMember) => {
-      const sortkey = a.sortkeyprefix + ((a.ns && a.title.split(':').slice(1).join(':')) || a.title)
-      a.sortkeyprefix = [...sortkey][0]
-      return a && a.title
-    })
-    const pagesInZim = MediaWiki.getCategories ? await RedisStore.pagesStore.existsMany(items.map((a) => a.title)) : null
-    categoryMembers.subcats.push(...items.filter((a) => a.type === 'subcat' && (pagesInZim ? pagesInZim[a.title] : true)))
-    categoryMembers.pages.push(...items.filter((a) => a.type === 'page' && (pagesInZim ? pagesInZim[a.title] : true)))
-    categoryMembers.files.push(...items.filter((a) => a.type === 'file' && (pagesInZim ? pagesInZim[a.title] : true)))
+    let continueStr = ''
+    while (true) {
+      const { query, continue: cont } = await this.getJSON<any>(apiUrlDirector.buildCategoryMembersURL(pageTitle, continueStr))
+      const items: Array<CategoryMember> = query.categorymembers.filter((a: CategoryMember) => {
+        const sortkey = a.sortkeyprefix + ((a.ns && a.title.split(':').slice(1).join(':')) || a.title)
+        a.sortkeyprefix = [...sortkey][0]
+        return a && a.title
+      })
+      const pagesInZim = MediaWiki.getCategories ? await RedisStore.pagesStore.existsMany(items.map((a) => a.title)) : null
+      categoryMembers.subcats.push(...items.filter((a) => a.type === 'subcat' && (pagesInZim ? pagesInZim[a.title] : true)))
+      categoryMembers.pages.push(...items.filter((a) => a.type === 'page' && (pagesInZim ? pagesInZim[a.title] : true)))
+      categoryMembers.files.push(...items.filter((a) => a.type === 'file' && (pagesInZim ? pagesInZim[a.title] : true)))
 
-    if (cont && cont.cmcontinue) {
-      await this.getCategoryMembers(pageTitle, categoryMembers, cont.cmcontinue)
+      if (cont && cont.cmcontinue) {
+        continueStr = cont.cmcontinue
+      } else {
+        break
+      }
     }
   }
 

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -517,9 +517,14 @@ class Downloader {
         }
       }
 
-      let categoryMembers: GroupedCategoryMembers = null
+      const categoryMembers: GroupedCategoryMembers = {
+        categoryinfo: pageDetail.categoryinfo,
+        subcats: [],
+        pages: [],
+        files: [],
+      }
       if (pageDetail.categoryinfo?.size) {
-        categoryMembers = await this.getCategoryMembers(pageTitle, { ...pageDetail.categoryinfo })
+        await this.getCategoryMembers(pageTitle, categoryMembers)
         if (MediaWiki.getCategories) {
           categoryMembers.categoryinfo.subcats = categoryMembers.subcats.length
           categoryMembers.categoryinfo.pages = categoryMembers.pages.length
@@ -919,7 +924,7 @@ class Downloader {
     handler(err)
   }
 
-  private async getCategoryMembers(pageTitle: PageTitle, categoryinfo: CategoryInfo, continueStr = ''): Promise<GroupedCategoryMembers> {
+  private async getCategoryMembers(pageTitle: PageTitle, categoryMembers: GroupedCategoryMembers, continueStr = ''): Promise<void> {
     const apiUrlDirector = new ApiURLDirector(MediaWiki.actionApiUrl.href)
 
     const { query, continue: cont } = await this.getJSON<any>(apiUrlDirector.buildCategoryMembersURL(pageTitle, continueStr))
@@ -929,20 +934,12 @@ class Downloader {
       return a && a.title
     })
     const pagesInZim = MediaWiki.getCategories ? await RedisStore.pagesStore.existsMany(items.map((a) => a.title)) : null
-    const subcats = items.filter((a) => a.type === 'subcat' && (pagesInZim ? pagesInZim[a.title] : true))
-    const pages = items.filter((a) => a.type === 'page' && (pagesInZim ? pagesInZim[a.title] : true))
-    const files = items.filter((a) => a.type === 'file' && (pagesInZim ? pagesInZim[a.title] : true))
+    categoryMembers.subcats.push(...items.filter((a) => a.type === 'subcat' && (pagesInZim ? pagesInZim[a.title] : true)))
+    categoryMembers.pages.push(...items.filter((a) => a.type === 'page' && (pagesInZim ? pagesInZim[a.title] : true)))
+    categoryMembers.files.push(...items.filter((a) => a.type === 'file' && (pagesInZim ? pagesInZim[a.title] : true)))
 
     if (cont && cont.cmcontinue) {
-      const nextItems = await this.getCategoryMembers(pageTitle, categoryinfo, cont.cmcontinue)
-      return {
-        subcats: subcats.concat(nextItems.subcats),
-        pages: pages.concat(nextItems.pages),
-        files: files.concat(nextItems.files),
-        categoryinfo,
-      }
-    } else {
-      return { subcats, pages, files, categoryinfo }
+      await this.getCategoryMembers(pageTitle, categoryMembers, cont.cmcontinue)
     }
   }
 

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -369,14 +369,14 @@ class Downloader {
     return this.getJSON<SiteInfoResponse>(this.apiUrlDirector.buildSiteInfoURL())
   }
 
-  public async getPagesByTitle(pageTitles: PageTitle[], shouldGetThumbnail = false): Promise<QueryMwRet> {
+  public async getPagesByTitle(pageTitles: PageTitle[], shouldGetThumbnail = false, followRedirects = true): Promise<QueryMwRet> {
     let continuation: ContinueOpts
     let allPages: { [key: string]: PageInfo & QueryRet } = {}
     const visitedUrls = new Set<string>()
 
     while (true) {
       const queryOpts: KVS<any> = {
-        ...(await this.getPageQueryOpts(shouldGetThumbnail, true)),
+        ...(await this.getPageQueryOpts(shouldGetThumbnail, followRedirects)),
         titles: pageTitles.join('|'),
         ...((await MediaWiki.hasCoordinates()) ? { colimit: 'max' } : {}),
         ...(MediaWiki.getCategories

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -48,7 +48,7 @@ export async function getPagesByTitle(
         }
 
         // Retrieve the details and save them in Redis
-        const allMwPages = await Downloader.getPagesByTitle(pageTitlesBatch, numThumbnails < 100)
+        const allMwPages = await Downloader.getPagesByTitle(pageTitlesBatch, numThumbnails < 100, purpose !== 'categories')
         const { numThumbnails: iterThumbnails } = await processPagesAndSaveToRedis(allMwPages, pagesToIgnore, allowedContentModels, categoryTitles)
         numThumbnails += iterThumbnails
       }


### PR DESCRIPTION
Fix #2833 

Three fixes:
- do not follow redirects when listing categories since we can have pages attached both to redirect source and target
- always populate categoryMembers (with empty lists at start) so that it can't be undefined, and populate arrays on-the-fly
- prefer infinite loop to list all members instead of recursion (which might ultimately go too deep and is a nightmare in logs stacktraces)

This is meant to superseed https://github.com/openzim/mwoffliner/pull/2840 which was far incomplete

@SAY-5 feedback is welcomed on this PR if any