### PR TITLE
Correctly detect SVG mime-types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "GPL-3.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1090.0",
+        "@file-type/xml": "^1.1.1",
         "@ladjs/country-language": "^1.0.3",
         "@openzim/libzim": "4.5.0",
         "@types/async": "^3.2.25",
@@ -1094,6 +1095,16 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@file-type/xml": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@file-type/xml/-/xml-1.1.1.tgz",
+      "integrity": "sha512-kBGlafpgT5n6Uv3eUhrbyX9Lm85Lbwd7IWrOlsWxGCzUSkG17xsr/fO4CU4AUnYgeEZJqmAFX2eshlU3RDZ55g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.6.0",
+        "strtok3": "^10.3.5"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2522,7 +2533,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
@@ -8584,6 +8594,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
@@ -9049,7 +9068,6 @@
       "version": "10.3.5",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
       "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tokenizer/token": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1090.0",
+    "@file-type/xml": "^1.1.1",
     "@ladjs/country-language": "^1.0.3",
     "@openzim/libzim": "4.5.0",
     "@types/async": "^3.2.25",
@@ -113,8 +114,8 @@
     "@types/jest": "^30.0.0",
     "@types/tape-promise": "^4.0.7",
     "@types/tmp": "^0.2.6",
-    "@typescript-eslint/parser": "^8.64.0",
     "@types/unzipper": "^0.10.11",
+    "@typescript-eslint/parser": "^8.64.0",
     "dotenv": "^17.4.2",
     "eslint": "^10.7.0",
     "file-type": "^22.0.1",

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -6,7 +6,8 @@ import type { BackoffStrategy } from 'backoff'
 import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios'
 import sharp, { Sharp } from 'sharp'
 import apng from 'sharp-apng'
-import { fileTypeFromBuffer } from 'file-type'
+import { FileTypeParser } from 'file-type'
+import { detectXml } from '@file-type/xml'
 import { HttpCookieAgent, HttpsCookieAgent } from 'http-cookie-agent/http'
 import { CookieJar } from 'tough-cookie'
 
@@ -22,6 +23,11 @@ import { Renderer } from './renderers/abstract.renderer.js'
 import { findFirstMatchingRule, renderDownloadError } from './error.manager.js'
 import RedisStore from './RedisStore.js'
 import deepmerge from 'deepmerge'
+
+// create file-type parser with add-on to detect XML documents content (typically SVG)
+// Nota: file-type is capable to detect only binary content mime-type without the custom
+// detector
+const fileTypeParser = new FileTypeParser({ customDetectors: [detectXml] })
 
 interface DownloaderOpts {
   uaString: string
@@ -731,13 +737,9 @@ class Downloader {
       })
   }
 
-  private async getImageMimeType(data: any): Promise<string | null> {
-    const fileType = await fileTypeFromBuffer(data)
-    if (fileType && fileType.mime === 'application/xml') {
-      // File type is known to be wrong, might be SVG
-      return null
-    }
-    return fileType ? fileType.mime : null
+  private async getImageMimeType(data: any): Promise<string> {
+    // get mime-type of a binary file, with XML addon to detect SVGs
+    return (await fileTypeParser.fromBuffer(data)).mime
   }
 
   private async getSharpObject(input: CompressionData, contentType: string): Promise<Sharp> {

--- a/src/util/FileManager.ts
+++ b/src/util/FileManager.ts
@@ -224,7 +224,7 @@ class FileManager {
             dump.status.files.success += 1
             hostData.downloadSuccess += 1
           } else {
-            throw new Error(`Bad response received: ${resp}`)
+            throw new Error(`Bad response received: ${JSON.stringify(resp)}`)
           }
         })
         .catch(async (err) => {


### PR DESCRIPTION
## Context

Terraria wiki last run showed that we have issues with SVG files: https://farm.openzim.org/pipeline/5b12417a-273d-4d2f-845c-931b978ccb92/debug

Analyzing the issue, it became clear the problem occurs only when we use the optimization cache and the file to retrieve is in the cache.

The root cause is that by default we prefer to detect mime-type from content, and if not available we fallback to the server content-type return in response headers.

The problem is that for SVG the file-type library we are using is not capable to detect from content (it detects only binary formats) and when using S3 cache and file is in the cache, then the server returns a 304 and does not returns the content-type header.

We hence end-up with no content-type, and this is correctly making the scraper ignore the given image.

## Change

This PR adds `@file-type/xml` library which is an addon to `file-type` to also detect XML-based document file types.