### PR TITLE
Ignore redirects to fragment in 'nodet'

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -57,6 +57,7 @@ Unreleased:
 * FIX: HTML page title should not contain HTML code (@benoit74 #2814)
 * FIX: Concurrent image download headers were leaking across workers (@benoit74 #2810 #2811)
 * FIX: Add support for animated PNGs (do not always recompress to static PNG) + compress GIF to WEBP (they do support animation) (@benoit74 #2830, #2843)
+* FIX: Ignore redirects to fragment in 'nodet' since there is mostly no chance the section does exists (@benoit74 #2839)
 
 1.17.5:
 * FIX: Ignore articles returning permissiondenied error code (@kunalsiyag #2604)

--- a/src/Dump.ts
+++ b/src/Dump.ts
@@ -53,6 +53,7 @@ export class Dump {
     },
     redirects: {
       written: 0,
+      ignored: 0,
     },
   }
 

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -662,6 +662,11 @@ async function execute(argv: any) {
         }
         const redirectTitle = truncateZimEntryTitleWords(from)
         if (fragment) {
+          // Ignore redirects to fragment in 'nodet' since there is mostly no chance the section does exists
+          if (dump.nodet) {
+            dump.status.redirects.ignored += 1
+            continue
+          }
           // Should we have a fragment (i.e. we redirect to a section of a page), this is not (yet) supported by libzim
           // (to have such a redirect with a fragment inside the path), so we create a "fake" entry with only an HTML-based
           // redirect inside

--- a/test/e2e/en.e2e.test.ts
+++ b/test/e2e/en.e2e.test.ts
@@ -1,4 +1,4 @@
-import { testAllRenders } from '../testRenders.js'
+import { testAllRenders, TestDump } from '../testRenders.js'
 import domino from 'domino'
 import { zimdump, zimcheck } from '../util.js'
 import 'dotenv/config.js'
@@ -23,115 +23,136 @@ const parameters = {
   mwUrl: 'https://en.wikipedia.org',
   pageList: 'Providence/Stoughton Line', // use page with a slash in its name to check relative links are properly handled
   adminEmail: 'test@kiwix.org',
+  format: ['', 'nopic,nodet:mini'],
+  //format: ['nopic,nodet:mini'],
+}
+
+const dumpName = (dump: TestDump) => {
+  return dump.nodet ? 'mini' : 'full'
 }
 
 await testAllRenders('en-wikipedia', parameters, async (outFiles) => {
-  const pageFromDump = await zimdump(`show --url ${parameters.pageList.replace(' ', '_')} ${outFiles[0].outFile}`)
+  const pagesFromDump = await Promise.all(outFiles.map((dump) => zimdump(`show --url ${parameters.pageList.replace(' ', '_')} ${dump.outFile}`)))
+  const filesInDump = await Promise.all(outFiles.map(async (dump) => (await zimdump(`list ${dump.outFile}`)).split('\n')))
+
   describe('e2e test for en.wikipedia.org', () => {
-    const pageDoc = domino.createDocument(pageFromDump)
-
-    test(`test ZIM integrity for ${outFiles[0]?.renderer} renderer`, async () => {
-      await expect(zimcheck(outFiles[0].outFile)).resolves.not.toThrow()
+    test(`test number of ZIMs for ${outFiles[0]?.renderer} renderer`, async () => {
+      await expect(outFiles.length).toBe(2)
     })
 
-    test(`test page header for ${outFiles[0]?.renderer} renderer`, async () => {
-      expect(pageDoc.querySelector('h1#firstHeading, h1.page-header, h1.pcs-edit-section-title')).toBeTruthy()
-    })
+    for (const [index, dump] of outFiles.entries()) {
+      const pageDoc = domino.createDocument(pagesFromDump[index])
+      const allFilesArr = filesInDump[index]
 
-    test(`test page <body> CSS class for ${outFiles[0]?.renderer} renderer`, async () => {
-      // This is implemented correctly only with ActionParse renderer for now
-      if (outFiles[0]?.renderer !== 'ActionParse') {
-        return
+      test(`test ZIM integrity for ${outFiles[0]?.renderer} renderer and ${dumpName(dump)} ZIM`, async () => {
+        await expect(zimcheck(dump.outFile)).resolves.not.toThrow()
+      })
+
+      test(`test page header for ${outFiles[0]?.renderer} renderer and ${dumpName(dump)} ZIM`, async () => {
+        expect(pageDoc.querySelector('h1#firstHeading, h1.page-header, h1.pcs-edit-section-title')).toBeTruthy()
+      })
+
+      test(`test page <body> CSS class for ${outFiles[0]?.renderer} renderer and ${dumpName(dump)} ZIM`, async () => {
+        // This is implemented correctly only with ActionParse renderer for now
+        if (dump.renderer !== 'ActionParse') {
+          return
+        }
+        const expectedClasses = [
+          'action-view',
+          'ltr',
+          'mediawiki',
+          'mw-hide-empty-elt',
+          'ns-0',
+          'ns-subject',
+          'page-Providence_Stoughton_Line',
+          'rootpage-Providence_Stoughton_Line',
+          'sitedir-ltr',
+          'skin--responsive',
+          'skin-vector',
+          'skin-vector-2022',
+          'skin-vector-search-vue',
+        ].sort()
+        expect(pageDoc.body.className.split(' ').sort()).toEqual(expectedClasses)
+      })
+
+      test(`test page <html> CSS class for ${outFiles[0]?.renderer} renderer and ${dumpName(dump)} ZIM`, async () => {
+        // This is implemented correctly only with ActionParse renderer for now
+        if (dump.renderer !== 'ActionParse') {
+          return
+        }
+        const expectedClasses = [
+          'client-nojs',
+          'skin-theme-clientpref-os',
+          'skin-thumbsize-clientpref-standard',
+          'vector-feature-appearance-pinned-clientpref-0',
+          'vector-feature-custom-font-size-clientpref-1',
+          'vector-feature-language-in-header-enabled',
+          'vector-feature-language-in-main-menu-disabled',
+          'vector-feature-language-in-main-page-header-disabled',
+          'vector-feature-limited-width-clientpref-1',
+          'vector-feature-limited-width-content-enabled',
+          'vector-feature-main-menu-pinned-disabled',
+          'vector-feature-navigation-update-disabled',
+          'vector-feature-page-tools-pinned-disabled',
+          'vector-feature-toc-pinned-clientpref-0',
+          'vector-sticky-header-enabled',
+          'vector-toc-not-available',
+        ].sort()
+        expect(pageDoc.documentElement.className.split(' ').sort()).toEqual(expectedClasses)
+      })
+
+      if (!dump.nopic) {
+        test(`test page image integrity for ${outFiles[0]?.renderer} renderer and ${dumpName(dump)} ZIM`, async () => {
+          const imgFilesArr = allFilesArr.filter((elem) => elem.endsWith('pdf') || elem.endsWith('png') || elem.endsWith('jpg'))
+          const imgElements = Array.from(pageDoc.querySelectorAll('img'))
+          expect(verifyImgElements(imgFilesArr, imgElements)).toBe(true)
+        })
       }
-      const expectedClasses = [
-        'action-view',
-        'ltr',
-        'mediawiki',
-        'mw-hide-empty-elt',
-        'ns-0',
-        'ns-subject',
-        'page-Providence_Stoughton_Line',
-        'rootpage-Providence_Stoughton_Line',
-        'sitedir-ltr',
-        'skin--responsive',
-        'skin-vector',
-        'skin-vector-2022',
-        'skin-vector-search-vue',
-      ].sort()
-      expect(pageDoc.body.className.split(' ').sort()).toEqual(expectedClasses)
-    })
 
-    test(`test page <html> CSS class for ${outFiles[0]?.renderer} renderer`, async () => {
-      // This is implemented correctly only with ActionParse renderer for now
-      if (outFiles[0]?.renderer !== 'ActionParse') {
-        return
-      }
-      const expectedClasses = [
-        'client-nojs',
-        'skin-theme-clientpref-os',
-        'skin-thumbsize-clientpref-standard',
-        'vector-feature-appearance-pinned-clientpref-0',
-        'vector-feature-custom-font-size-clientpref-1',
-        'vector-feature-language-in-header-enabled',
-        'vector-feature-language-in-main-menu-disabled',
-        'vector-feature-language-in-main-page-header-disabled',
-        'vector-feature-limited-width-clientpref-1',
-        'vector-feature-limited-width-content-enabled',
-        'vector-feature-main-menu-pinned-disabled',
-        'vector-feature-navigation-update-disabled',
-        'vector-feature-page-tools-pinned-disabled',
-        'vector-feature-toc-pinned-clientpref-0',
-        'vector-sticky-header-enabled',
-        'vector-toc-not-available',
-      ].sort()
-      expect(pageDoc.documentElement.className.split(' ').sort()).toEqual(expectedClasses)
-    })
+      test(`test redirect without fragment ${outFiles[0]?.renderer} renderer and ${dumpName(dump)} ZIM`, async () => {
+        // "Providence_Line" should be a redirect to "Providence/Stoughton_Line"
+        const redirectInfo = await zimdump(`list --details --url Providence_Line ${dump.outFile}`)
 
-    test(`test page image integrity for ${outFiles[0]?.renderer} renderer`, async () => {
-      const allFiles = await zimdump(`list ${outFiles[0].outFile}`)
-      const allFilesArr = allFiles.split('\n')
-      const imgFilesArr = allFilesArr.filter((elem) => elem.endsWith('pdf') || elem.endsWith('png') || elem.endsWith('jpg'))
-      const imgElements = Array.from(pageDoc.querySelectorAll('img'))
-      expect(verifyImgElements(imgFilesArr, imgElements)).toBe(true)
-    })
+        expect(redirectInfo).toMatch(/path:\s*Providence_Line/)
+        expect(redirectInfo).toMatch(/title:\s*Providence Line/)
+        expect(redirectInfo).toMatch(/type:\s*redirect/)
+        const redirectIndexMatch = redirectInfo.match(/redirect index:\s*(\d+)/)
+        expect(redirectIndexMatch).not.toBe(null)
+        const redirectIndex = redirectIndexMatch ? parseInt(redirectIndexMatch[1], 10) : null
+        expect(redirectIndex).not.toBeNull()
 
-    test(`test redirect without fragment ${outFiles[0]?.renderer} renderer`, async () => {
-      // "Providence_Line" should be a redirect to "Providence/Stoughton_Line"
-      const redirectInfo = await zimdump(`list --details --url Providence_Line ${outFiles[0].outFile}`)
+        const redirectTargetInfo = await zimdump(`list --details --idx ${redirectIndex} ${dump.outFile}`)
+        expect(redirectTargetInfo).toMatch(/path:\s*Providence\/Stoughton_Line/)
+        expect(redirectTargetInfo).toMatch(/title:\s*Providence\/Stoughton Line/)
+        expect(redirectTargetInfo).toMatch(/type:\s*item/)
+      })
 
-      expect(redirectInfo).toMatch(/path:\s*Providence_Line/)
-      expect(redirectInfo).toMatch(/title:\s*Providence Line/)
-      expect(redirectInfo).toMatch(/type:\s*redirect/)
-      const redirectIndexMatch = redirectInfo.match(/redirect index:\s*(\d+)/)
-      expect(redirectIndexMatch).not.toBe(null)
-      const redirectIndex = redirectIndexMatch ? parseInt(redirectIndexMatch[1], 10) : null
-      expect(redirectIndex).not.toBeNull()
+      test(`test redirect with fragment ${outFiles[0]?.renderer} renderer and ${dumpName(dump)} ZIM`, async () => {
+        if (dump.nodet) {
+          // Redirect with fragment are ignored in nodet
+          expect(allFilesArr).not.toContain('Attleboro_Line')
+        } else {
+          // "Attleboro_Line" should be an HTML item which will redirect to "Providence/Stoughton_Line#Ownership_and_financing"
+          // through http-equiv="refresh"
+          expect(allFilesArr).toContain('Attleboro_Line')
+          const redirectInfo = await zimdump(`list --details --url Attleboro_Line ${dump.outFile}`)
 
-      const redirectTargetInfo = await zimdump(`list --details --idx ${redirectIndex} ${outFiles[0].outFile}`)
-      expect(redirectTargetInfo).toMatch(/path:\s*Providence\/Stoughton_Line/)
-      expect(redirectTargetInfo).toMatch(/title:\s*Providence\/Stoughton Line/)
-      expect(redirectTargetInfo).toMatch(/type:\s*item/)
-    })
+          expect(redirectInfo).toMatch(/path:\s*Attleboro_Line/)
+          expect(redirectInfo).toMatch(/title:\s*Attleboro Line/)
+          expect(redirectInfo).toMatch(/type:\s*item/)
 
-    test(`test redirect with fragment ${outFiles[0]?.renderer} renderer`, async () => {
-      // "Attleboro_Line" should be an HTML item which will redirect to "Providence/Stoughton_Line#Ownership_and_financing"
-      // through http-equiv="refresh"
-      const redirectInfo = await zimdump(`list --details --url Attleboro_Line ${outFiles[0].outFile}`)
+          const redirectFromDump = await zimdump(`show --url Attleboro_Line ${dump.outFile}`)
+          expect(redirectFromDump).toContain('<title>Attleboro Line</title>')
+          expect(redirectFromDump).toContain('<meta http-equiv="refresh" content="0;URL=\'./Providence/Stoughton_Line#Ownership_and_financing\'" />')
+          expect(redirectFromDump).toContain('<a href="./Providence/Stoughton_Line#Ownership_and_financing">Attleboro Line</a>')
+        }
+      })
 
-      expect(redirectInfo).toMatch(/path:\s*Attleboro_Line/)
-      expect(redirectInfo).toMatch(/title:\s*Attleboro Line/)
-      expect(redirectInfo).toMatch(/type:\s*item/)
-
-      const redirectFromDump = await zimdump(`show --url Attleboro_Line ${outFiles[0].outFile}`)
-      expect(redirectFromDump).toContain('<title>Attleboro Line</title>')
-      expect(redirectFromDump).toContain('<meta http-equiv="refresh" content="0;URL=\'./Providence/Stoughton_Line#Ownership_and_financing\'" />')
-      expect(redirectFromDump).toContain('<a href="./Providence/Stoughton_Line#Ownership_and_financing">Attleboro Line</a>')
-    })
-
-    afterAll(() => {
-      if (!process.env.KEEP_ZIMS) {
-        rimraf.sync(`./${outFiles[0].testId}`)
-      }
-    })
+      afterAll(() => {
+        if (!process.env.KEEP_ZIMS) {
+          rimraf.sync(`./${dump.testId}`)
+        }
+      })
+    }
   })
 })

--- a/test/e2e/en10.e2e.test.ts
+++ b/test/e2e/en10.e2e.test.ts
@@ -35,8 +35,16 @@ await testAllRenders('en10-wikipedia', parameters, async (outFiles) => {
           expect(dump.status.files.success).toBeLessThan(700)
         }
         // has enough redirects
-        expect(dump.status.redirects.written).toBeGreaterThan(600)
-        expect(dump.status.redirects.written).toBeLessThan(650)
+        if (dump.nodet) {
+          expect(dump.status.redirects.written).toBeGreaterThan(420)
+          expect(dump.status.redirects.written).toBeLessThan(470)
+          expect(dump.status.redirects.ignored).toBeGreaterThan(150)
+          expect(dump.status.redirects.ignored).toBeLessThan(200)
+        } else {
+          expect(dump.status.redirects.written).toBeGreaterThan(600)
+          expect(dump.status.redirects.written).toBeLessThan(650)
+          expect(dump.status.redirects.ignored).toBe(0)
+        }
         // has 10 pages
         expect(dump.status.pages.success).toEqual(10)
         // No page and files error

--- a/test/testRenders.ts
+++ b/test/testRenders.ts
@@ -54,7 +54,7 @@ async function getOutFiles(renderName: string, testId: string, parameters: Param
   return outFiles
 }
 
-interface TestDump extends Dump {
+export interface TestDump extends Dump {
   testId: string
   renderer: string
   error?: Error


### PR DESCRIPTION
Fix #2839 

Changes:
- do not add redirects to fragments in `nodet` since there is mostly no chance these redirects make sense: section is (mostly?) always missing so adding a redirect gives a false sense of information availability while it is not