### PR TITLE
Compute and check ZIM metadata as early as possible for quickest feeback

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -58,6 +58,7 @@ Unreleased:
 * FIX: Concurrent image download headers were leaking across workers (@benoit74 #2810 #2811)
 * FIX: Add support for animated PNGs (do not always recompress to static PNG) + compress GIF to WEBP (they do support animation) (@benoit74 #2830, #2843)
 * FIX: Ignore redirects to fragment in 'nodet' since there is mostly no chance the section does exists (@benoit74 #2839)
+* CHANGED: Compute and check ZIM metadata as early as possible for quickest feedback (@benoit74 #2838)
 
 1.17.5:
 * FIX: Ignore articles returning permissiondenied error code (@kunalsiyag #2604)

--- a/src/Dump.ts
+++ b/src/Dump.ts
@@ -28,6 +28,7 @@ interface DumpOpts {
 }
 
 export class Dump {
+  public format: string
   public customProcessor?: CustomProcessor
   public nopic: boolean
   public novid: boolean
@@ -38,6 +39,7 @@ export class Dump {
   public t: Translator
   public mwMetaData: MWMetaData
   public outFile: string
+  public zimMetadata: KVS<string | Buffer>
   public maxHardFailedPages: number = 0
   public status = {
     files: {
@@ -60,6 +62,7 @@ export class Dump {
   private formatFlavour: string
 
   constructor(format: string, langVar: string, opts: DumpOpts, mwMetaData: MWMetaData, customProcessor: CustomProcessor | undefined, t: Translator) {
+    this.format = format
     this.mwMetaData = mwMetaData
     this.opts = opts
     this.customProcessor = customProcessor

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -332,6 +332,10 @@ async function execute(argv: any) {
     process.exit(128 + 2)
   })
 
+  const filenameDate = new Date().toISOString().slice(0, 7)
+
+  const dumps: Dump[] = []
+
   /* ********************************* */
   /* GET CONTENT ********************* */
   /* ********************************* */
@@ -365,24 +369,6 @@ async function execute(argv: any) {
     mainPage = pages[0]
     logger.info(`Using single page list entry as main page: ${mainPage}`)
   }
-
-  const allowedContentModels = ['wikitext', ...addContentModels]
-
-  logger.debug('Getting pages details')
-  let stime = Date.now()
-  await getPages(mainPage, pages, pagesToIgnore, allowedContentModels)
-  logger.info(`Got pages details in ${(Date.now() - stime) / 1000} seconds`)
-
-  const filenameDate = new Date().toISOString().slice(0, 7)
-
-  // Getting total number of pages from Redis
-  logger.info(`Total pages found in Redis: ${await RedisStore.pagesStore.len()}`)
-
-  if (mainPage && !(await RedisStore.pagesStore.exists(mainPage)) && !(await RedisStore.redirectsStore.exists(mainPage))) {
-    throw new Error(`mainPage '${mainPage}' was not found`)
-  }
-
-  const dumps: Dump[] = []
 
   const t = await createTranslator(mwMetaData.langIso2 || 'en', 'en')
 
@@ -418,23 +404,51 @@ async function execute(argv: any) {
         t,
       )
       dumps.push(dump)
-      let logStr = 'Doing dump:'
-      if (langVar) logStr += ' variant=' + langVar
-      logStr += ` format=${dumpFormat || 'all'}`
-      logger.info(`******************** ${logStr} ********************`)
-      let shouldSkip = false
-      try {
-        dump.checkResume()
-      } catch {
-        shouldSkip = true
-      }
-      if (shouldSkip) {
-        logger.info('Skipping dump')
-      } else {
-        await doDump(dump)
-        await RedisStore.filesStore.flush()
-        logger.info('Finished dump')
-      }
+
+      // compute ZIM metadata early to fail early in case of issue ; we do that check
+      // for each dump, even if it will probably pass on all or fail on first one
+      computeZimMetadata(dump)
+    }
+  }
+
+  const allowedContentModels = ['wikitext', ...addContentModels]
+
+  logger.debug('Getting pages details')
+  let stime = Date.now()
+  await getPages(mainPage, pages, pagesToIgnore, allowedContentModels)
+  logger.info(`Got pages details in ${(Date.now() - stime) / 1000} seconds`)
+
+  // Getting total number of pages from Redis
+  logger.info(`Total pages found in Redis: ${await RedisStore.pagesStore.len()}`)
+
+  if (mainPage && !(await RedisStore.pagesStore.exists(mainPage)) && !(await RedisStore.redirectsStore.exists(mainPage))) {
+    throw new Error(`mainPage '${mainPage}' was not found`)
+  }
+
+  for (const dump of dumps) {
+    let logStr = 'Doing dump:'
+    if (dump.langVar) logStr += ' variant=' + dump.langVar
+    logStr += ` format=${dump.format || 'all'}`
+    logger.info(`******************** ${logStr} ********************`)
+    let shouldSkip = false
+    try {
+      dump.checkResume()
+    } catch {
+      shouldSkip = true
+    }
+    if (shouldSkip) {
+      logger.info('Skipping dump')
+    } else {
+      // Reset FileManager for the new dump
+      FileManager.reset()
+
+      // Check scraper is still logged-in (session from previous dump might have expired
+      // due to inactivity when downloading files)
+      await MediaWiki.login(true)
+
+      await doDump(dump)
+      await RedisStore.filesStore.flush()
+      logger.info('Finished dump')
     }
   }
 
@@ -442,18 +456,11 @@ async function execute(argv: any) {
 
   logger.info('All dumping(s) finished with success.')
 
-  async function doDump(dump: Dump) {
+  function computeZimMetadata(dump: Dump) {
     dump.outFile = dump.computeZimFullPath()
     logger.info(`Writing ZIM to ${dump.outFile}`)
 
-    // Reset FileManager for the new dump
-    FileManager.reset()
-
-    // Check scraper is still logged-in (session from previous dump might have expired
-    // due to inactivity when downloading files)
-    await MediaWiki.login(true)
-
-    const metadata = {
+    dump.zimMetadata = {
       ...metaDataRequiredKeys,
       Tags: dump.computeZimTags(),
       Name: dump.computeZimName(),
@@ -462,8 +469,10 @@ async function execute(argv: any) {
       Source: MediaWiki.webUrl.hostname,
       ...(dump.opts.customZimLongDescription ? { LongDescription: `${dump.opts.customZimLongDescription}` } : {}),
     }
-    validateMetadata(metadata)
+    validateMetadata(dump.zimMetadata)
+  }
 
+  async function doDump(dump: Dump) {
     const zimCreator = new Creator().configCompression(Compression.Zstd).configVerbose(logLevel === 'debug')
     if (!dump.opts.withoutZimFullTextIndex) {
       zimCreator.configIndexing(true, dump.mwMetaData.langIso3)
@@ -485,7 +494,7 @@ async function execute(argv: any) {
       }
     }
 
-    Object.entries(metadata).forEach(([key, value]) => {
+    Object.entries(dump.zimMetadata).forEach(([key, value]) => {
       zimCreator.addMetadata(key, Buffer.isBuffer(value) ? createBufferContentProvider(value) : value, key.startsWith('Illustration_') ? 'image/png' : 'text/plain')
     })
 

--- a/test/e2e/en.e2e.test.ts
+++ b/test/e2e/en.e2e.test.ts
@@ -1,4 +1,4 @@
-import { testAllRenders, TestDump } from '../testRenders.js'
+import { testAllRenders } from '../testRenders.js'
 import domino from 'domino'
 import { zimdump, zimcheck } from '../util.js'
 import 'dotenv/config.js'
@@ -24,11 +24,6 @@ const parameters = {
   pageList: 'Providence/Stoughton Line', // use page with a slash in its name to check relative links are properly handled
   adminEmail: 'test@kiwix.org',
   format: ['', 'nopic,nodet:mini'],
-  //format: ['nopic,nodet:mini'],
-}
-
-const dumpName = (dump: TestDump) => {
-  return dump.nodet ? 'mini' : 'full'
 }
 
 await testAllRenders('en-wikipedia', parameters, async (outFiles) => {
@@ -44,15 +39,15 @@ await testAllRenders('en-wikipedia', parameters, async (outFiles) => {
       const pageDoc = domino.createDocument(pagesFromDump[index])
       const allFilesArr = filesInDump[index]
 
-      test(`test ZIM integrity for ${outFiles[0]?.renderer} renderer and ${dumpName(dump)} ZIM`, async () => {
+      test(`test ZIM integrity for ${outFiles[0]?.renderer} renderer and ${dump.format} ZIM`, async () => {
         await expect(zimcheck(dump.outFile)).resolves.not.toThrow()
       })
 
-      test(`test page header for ${outFiles[0]?.renderer} renderer and ${dumpName(dump)} ZIM`, async () => {
+      test(`test page header for ${outFiles[0]?.renderer} renderer and ${dump.format} ZIM`, async () => {
         expect(pageDoc.querySelector('h1#firstHeading, h1.page-header, h1.pcs-edit-section-title')).toBeTruthy()
       })
 
-      test(`test page <body> CSS class for ${outFiles[0]?.renderer} renderer and ${dumpName(dump)} ZIM`, async () => {
+      test(`test page <body> CSS class for ${outFiles[0]?.renderer} renderer and ${dump.format} ZIM`, async () => {
         // This is implemented correctly only with ActionParse renderer for now
         if (dump.renderer !== 'ActionParse') {
           return
@@ -75,7 +70,7 @@ await testAllRenders('en-wikipedia', parameters, async (outFiles) => {
         expect(pageDoc.body.className.split(' ').sort()).toEqual(expectedClasses)
       })
 
-      test(`test page <html> CSS class for ${outFiles[0]?.renderer} renderer and ${dumpName(dump)} ZIM`, async () => {
+      test(`test page <html> CSS class for ${outFiles[0]?.renderer} renderer and ${dump.format} ZIM`, async () => {
         // This is implemented correctly only with ActionParse renderer for now
         if (dump.renderer !== 'ActionParse') {
           return
@@ -102,14 +97,14 @@ await testAllRenders('en-wikipedia', parameters, async (outFiles) => {
       })
 
       if (!dump.nopic) {
-        test(`test page image integrity for ${outFiles[0]?.renderer} renderer and ${dumpName(dump)} ZIM`, async () => {
+        test(`test page image integrity for ${outFiles[0]?.renderer} renderer and ${dump.format} ZIM`, async () => {
           const imgFilesArr = allFilesArr.filter((elem) => elem.endsWith('pdf') || elem.endsWith('png') || elem.endsWith('jpg'))
           const imgElements = Array.from(pageDoc.querySelectorAll('img'))
           expect(verifyImgElements(imgFilesArr, imgElements)).toBe(true)
         })
       }
 
-      test(`test redirect without fragment ${outFiles[0]?.renderer} renderer and ${dumpName(dump)} ZIM`, async () => {
+      test(`test redirect without fragment ${outFiles[0]?.renderer} renderer and ${dump.format} ZIM`, async () => {
         // "Providence_Line" should be a redirect to "Providence/Stoughton_Line"
         const redirectInfo = await zimdump(`list --details --url Providence_Line ${dump.outFile}`)
 
@@ -127,7 +122,7 @@ await testAllRenders('en-wikipedia', parameters, async (outFiles) => {
         expect(redirectTargetInfo).toMatch(/type:\s*item/)
       })
 
-      test(`test redirect with fragment ${outFiles[0]?.renderer} renderer and ${dumpName(dump)} ZIM`, async () => {
+      test(`test redirect with fragment ${outFiles[0]?.renderer} renderer and ${dump.format} ZIM`, async () => {
         if (dump.nodet) {
           // Redirect with fragment are ignored in nodet
           expect(allFilesArr).not.toContain('Attleboro_Line')


### PR DESCRIPTION
Fix #2838

Changes:
- store `format` in Dump for convenience (display in logs / tests typically)
- compute ZIM metadata (including filename) and validate them as early as possible for quick feedback in case of problem
- store computed ZIM metadata in Dump for later usage (few KBs at most in general)