### PR TITLE
Workaround bug when filtering hidden categories at API-level on MediaWiki >=1.46

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -60,6 +60,7 @@ Unreleased:
 * CHANGED: Compute and check ZIM metadata as early as possible for quickest feedback (@benoit74 #2838)
 * CHANGED: Do not show inaccessible categories which do not have content on pages categories list (@benoit74 #2831)
 * CHANGED: Better error message when site logo fails to be fetched (@benoit74 #2834)
+* FIX: Workaround bug when filtering categories at API-level on MediaWiki >=1.46 (@benoit74 #2819)
 
 1.17.5:
 * FIX: Ignore articles returning permissiondenied error code (@kunalsiyag #2604)

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -23,6 +23,7 @@ import { Renderer } from './renderers/abstract.renderer.js'
 import { findFirstMatchingRule, renderDownloadError } from './error.manager.js'
 import RedisStore from './RedisStore.js'
 import deepmerge from 'deepmerge'
+import semver from 'semver'
 
 // create file-type parser with add-on to detect XML documents content (typically SVG)
 // Nota: file-type is capable to detect only binary content mime-type without the custom
@@ -433,10 +434,14 @@ class Downloader {
         ...(await this.getPageQueryOpts()),
         ...((await MediaWiki.hasCoordinates()) ? { colimit: 'max' } : {}),
         ...(MediaWiki.getCategories
-          ? {
-              cllimit: 'max',
-              clshow: '!hidden',
-            }
+          ? semver.satisfies(MediaWiki.metaData.versionMw, '>=1.46')
+            ? {
+                cllimit: 'max',
+              }
+            : {
+                cllimit: 'max',
+                clshow: '!hidden',
+              }
           : {}),
         rawcontinue: 'true',
         generator: 'allpages',

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -547,6 +547,7 @@ class MediaWiki {
       licenseUrl,
       subTitle,
       categoryCollation,
+      versionMw: mwVersion,
     }
   }
 
@@ -557,7 +558,7 @@ class MediaWiki {
 
     const creator = this.getCreatorName() || 'Kiwix'
 
-    const { langIso2, langIso3, mainPage, mainPageIsDomainRoot, siteName, logo, langMw, textDir, licenseName, licenseUrl, subTitle, categoryCollation } =
+    const { langIso2, langIso3, mainPage, mainPageIsDomainRoot, siteName, logo, langMw, textDir, licenseName, licenseUrl, subTitle, categoryCollation, versionMw } =
       await this.getSiteInfo(argvOpts)
 
     const mwMetaData: MWMetaData = {
@@ -585,6 +586,7 @@ class MediaWiki {
       licenseName,
       licenseUrl,
       categoryCollation,
+      versionMw,
     }
 
     this.metaData = mwMetaData

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -207,6 +207,7 @@ interface MWMetaData {
   mainPageIsDomainRoot: boolean
   textDir: TextDirection
   langMw: string
+  versionMw: string
   logo: string
   licenseName: string
   licenseUrl: string


### PR DESCRIPTION
Fix #2819 

Changes:
- do not filter hidden categories at API level when Mediawiki >= 1.46 (performance impact of not filtering could be significant, so better to still filter on Mediawikis which do not have the bug)
- filtering at software level was already implemented at https://github.com/openzim/mwoffliner/blob/933bea31ce212a3fb75743896d6573eadfdd9338/src/util/mw-api.ts#L103