### PR TITLE
Add --keepPageLanguages to scrape only pages in given languages

### DIFF
--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -98,6 +98,7 @@ async function execute(argv: any) {
     addNamespaces: _addNamespaces,
     onlyNamespaces: _onlyNamespaces,
     addContentModels: _addContentModels,
+    keepPageLanguages: _keepPageLanguages,
     javaScript: _javaScript,
     addModules: _addModules,
     customZimFavicon,
@@ -261,6 +262,13 @@ async function execute(argv: any) {
         .map((a: string) => a.trim())
     : []
 
+  const keepPageLanguages = _keepPageLanguages
+    ? String(_keepPageLanguages)
+        .split(',')
+        .map((a: string) => a.trim())
+        .filter((a: string) => a.length > 0)
+    : []
+
   const onlyNamespaces = _onlyNamespaces
     ? String(_onlyNamespaces)
         .split(',')
@@ -415,7 +423,7 @@ async function execute(argv: any) {
 
   logger.debug('Getting pages details')
   let stime = Date.now()
-  await getPages(mainPage, pages, pagesToIgnore, allowedContentModels)
+  await getPages(mainPage, pages, pagesToIgnore, allowedContentModels, keepPageLanguages)
   logger.info(`Got pages details in ${(Date.now() - stime) / 1000} seconds`)
 
   // Getting total number of pages from Redis
@@ -673,6 +681,20 @@ async function execute(argv: any) {
         if (fragment) {
           // Ignore redirects to fragment in 'nodet' since there is mostly no chance the section does exists
           if (dump.nodet) {
+            dump.status.redirects.ignored += 1
+            continue
+          }
+          // Ignore them under --keepPageLanguages too. libzim cannot express a
+          // redirect to an anchor, so the fallback below writes a real HTML
+          // entry whose only text is the redirect's own title. A redirect can
+          // carry a translated title while the wiki still reports it in the
+          // default language. Measured on wiki.archlinux.org, "X11 转发" and
+          // "Záloha celého systému pomocí rsync" both report pagelanguage=en,
+          // so filtering by language cannot remove them, and they would be the
+          // only text in the archive outside the requested languages. The
+          // target article stays; what is lost is a shortcut to a section of
+          // it, exactly as for 'nodet'.
+          if (keepPageLanguages.length) {
             dump.status.redirects.ignored += 1
             continue
           }

--- a/src/parameterList.ts
+++ b/src/parameterList.ts
@@ -36,6 +36,7 @@ export const parameterDescriptions = {
   webp: 'Convert all jpeg, png and gif images to webp format',
   addNamespaces: 'Force additional namespace (comma separated numbers)',
   addContentModels: 'Include additional content models besides wikitext (comma separated, e.g. "Scribunto,json"). By default, only wikitext pages are scraped.',
+  keepPageLanguages: 'Include only pages whose MediaWiki page language matches (comma separated ISO codes, e.g. "en,simple"). By default, pages of every language are scraped.',
   onlyNamespaces: 'Include only pages of provided namespaces (comma separated numbers)',
   javaScript: 'Amount of JavaScript being allowed in pages, one of the following values can be given: "none", "trusted" or "all" (default being "trusted").',
   addModules: 'Add additional ResourceLoader modules for dynamic loading (comma separated list)',

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -23,6 +23,7 @@ export async function getPagesByTitle(
   pagesToIgnore?: PageTitle[],
   allowedContentModels: string[] = ['wikitext'],
   categoryTitles: Set<PageTitle> = new Set(),
+  keepPageLanguages: string[] = [],
 ): Promise<void> {
   let from = 0
   let numThumbnails = 0
@@ -49,7 +50,7 @@ export async function getPagesByTitle(
 
         // Retrieve the details and save them in Redis
         const allMwPages = await Downloader.getPagesByTitle(pageTitlesBatch, numThumbnails < 100, purpose !== 'categories')
-        const { numThumbnails: iterThumbnails } = await processPagesAndSaveToRedis(allMwPages, pagesToIgnore, allowedContentModels, categoryTitles)
+        const { numThumbnails: iterThumbnails } = await processPagesAndSaveToRedis(allMwPages, pagesToIgnore, allowedContentModels, categoryTitles, keepPageLanguages)
         numThumbnails += iterThumbnails
       }
     },
@@ -57,7 +58,7 @@ export async function getPagesByTitle(
   )
 }
 
-export function filterPages(pages: QueryMwRet, pagesToIgnore: PageTitle[], allowedContentModels: string[]) {
+export function filterPages(pages: QueryMwRet, pagesToIgnore: PageTitle[], allowedContentModels: string[], keepPageLanguages: string[] = []) {
   function revisionFilter(page: PageInfo & QueryRet): boolean {
     return !page.revisions
   }
@@ -68,6 +69,24 @@ export function filterPages(pages: QueryMwRet, pagesToIgnore: PageTitle[], allow
 
   function ignoredPagesFilter(page: PageInfo & QueryRet): boolean {
     return pagesToIgnore.includes(page.title) || pagesToIgnore.includes((page.title as string).replace(/ /g, '_') as PageTitle)
+  }
+
+  // Filter pages written in an unwanted language.
+  //
+  // Many wikis keep their translations in the main namespace rather than on a
+  // separate language wiki, so scraping such a wiki yields a ZIM whose declared
+  // language is a small minority of its contents. MediaWiki records the
+  // authoritative language per page, which prop=info already returns here, so
+  // this needs no heuristic on titles or on the text.
+  //
+  // A page reporting no language at all is KEPT: the field is absent rather
+  // than empty on wikis that do not set it, and dropping those would silently
+  // empty the scrape instead of failing visibly.
+  function pageLanguageFilter(page: PageInfo & QueryRet): boolean {
+    if (!keepPageLanguages.length || !page.pagelanguagehtmlcode) {
+      return false
+    }
+    return !keepPageLanguages.includes(page.pagelanguagehtmlcode)
   }
 
   // Filter pages without revisions (#2091)
@@ -88,16 +107,29 @@ export function filterPages(pages: QueryMwRet, pagesToIgnore: PageTitle[], allow
     logger.debug(`Ignoring pages in list: ${ignoreListIssues.join(', ')}`)
   }
 
+  // Filter pages in an unwanted language (--keepPageLanguages)
+  const pageLanguageIssues = pages.filter(pageLanguageFilter)
+  if (pageLanguageIssues.length > 0) {
+    logger.debug(`Ignoring pages in other languages: ${pageLanguageIssues.join(', ')}`)
+  }
+
   return pages
     .filter((p) => !revisionFilter(p))
     .filter((p) => !contentModelFilter(p))
     .filter((p) => !ignoredPagesFilter(p))
+    .filter((p) => !pageLanguageFilter(p))
 }
 
-async function processPagesAndSaveToRedis(pages: QueryMwRet, pagesToIgnore: PageTitle[], allowedContentModels: string[], categoryTitles: Set<PageTitle> = new Set()) {
+async function processPagesAndSaveToRedis(
+  pages: QueryMwRet,
+  pagesToIgnore: PageTitle[],
+  allowedContentModels: string[],
+  categoryTitles: Set<PageTitle> = new Set(),
+  keepPageLanguages: string[] = [],
+) {
   const redirects: PageRedirect[] = []
   const pagesToRemove: (PageInfo & QueryRet)[] = []
-  const filteredPages = filterPages(pages, pagesToIgnore, allowedContentModels)
+  const filteredPages = filterPages(pages, pagesToIgnore, allowedContentModels, keepPageLanguages)
   for (const page of filteredPages) {
     page.categories?.forEach((category) => {
       if (!category.hidden) categoryTitles.add(category.title)
@@ -128,9 +160,11 @@ async function processPagesAndSaveToRedis(pages: QueryMwRet, pagesToIgnore: Page
     filteredPages.splice(filteredPages.indexOf(page), 1)
   }
 
+  const keptRedirects = await filterRedirectsByLanguage(redirects, keepPageLanguages)
+
   const numPages = await RedisStore.pagesStore.setMany(mwRetToPageDetail(filteredPages))
   const numRedirects = await RedisStore.redirectsStore.setMany(
-    redirects.reduce((acc, redirect) => {
+    keptRedirects.reduce((acc, redirect) => {
       acc[redirect.from] = { from: redirect.from, to: redirect.to, fragment: redirect.fragment || '' }
       return acc
     }, {}),
@@ -140,12 +174,57 @@ async function processPagesAndSaveToRedis(pages: QueryMwRet, pagesToIgnore: Page
   return { numPages, numRedirects, numThumbnails }
 }
 
+/**
+ * Drop redirects whose own page language is not wanted.
+ *
+ * A redirect needs its own lookup: it reaches this code through prop=redirects,
+ * which returns only {pageid, ns, title, fragment} and no language. So when the
+ * filter is active the redirect titles are queried directly, with
+ * followRedirects disabled so the API describes each redirect rather than its
+ * target.
+ *
+ * A redirect whose language the API does not report is KEPT, for the same
+ * reason an undeclared page is: this must narrow a scrape, never empty one.
+ * Note that a redirect can carry a translated TITLE and still report the wiki
+ * default language, because the wiki considers it untranslated and there is no
+ * other authoritative signal, so this narrows the set rather than guaranteeing
+ * every title is in the wanted language.
+ */
+export async function filterRedirectsByLanguage(redirects: PageRedirect[], keepPageLanguages: string[]): Promise<PageRedirect[]> {
+  if (!keepPageLanguages.length || !redirects.length) {
+    return redirects
+  }
+
+  const titles = [...new Set(redirects.map((r) => r.from))] as PageTitle[]
+  const languages = new Map<string, string>()
+  for (let i = 0; i < titles.length; i += 50) {
+    const batch = titles.slice(i, i + 50)
+    // followRedirects=false: describe each redirect, not what it points at.
+    const infos = await Downloader.getPagesByTitle(batch, false, false)
+    for (const info of infos) {
+      if (info.pagelanguagehtmlcode) {
+        languages.set(info.title as string, info.pagelanguagehtmlcode)
+      }
+    }
+  }
+
+  const kept = redirects.filter((r) => {
+    const lang = languages.get(r.from as string)
+    return !lang || keepPageLanguages.includes(lang)
+  })
+  if (kept.length !== redirects.length) {
+    logger.debug(`Ignoring ${redirects.length - kept.length} redirects in other languages`)
+  }
+  return kept
+}
+
 export async function getPagesByNamespace(
   namespace: number,
   pagesToIgnore?: PageTitle[],
   allowedContentModels: string[] = ['wikitext'],
   categoryTitles: Set<PageTitle> = new Set(),
   continueLimit?: number,
+  keepPageLanguages: string[] = [],
 ): Promise<void> {
   let totalPages = 0
   let gapContinue = ''
@@ -179,7 +258,7 @@ export async function getPagesByNamespace(
         }
         seenGapContinueValues.push(gapContinue)
       }
-      const { numPages } = await processPagesAndSaveToRedis(resp.pages, pagesToIgnore, allowedContentModels, categoryTitles)
+      const { numPages } = await processPagesAndSaveToRedis(resp.pages, pagesToIgnore, allowedContentModels, categoryTitles, keepPageLanguages)
       totalPages += numPages
       logger.info(`Got [${numPages} / ${totalPages}] pages chunk from namespace [${namespace}]`)
 
@@ -281,20 +360,28 @@ export async function checkApiAvailability(url: string, allowedMimeTypes = null)
   }
 }
 
-export async function getPages(mainPage?: PageTitle, pages: PageTitle[] = [], pagesToIgnore: PageTitle[] = [], allowedContentModels: string[] = ['wikitext']) {
+export async function getPages(
+  mainPage?: PageTitle,
+  pages: PageTitle[] = [],
+  pagesToIgnore: PageTitle[] = [],
+  allowedContentModels: string[] = ['wikitext'],
+  keepPageLanguages: string[] = [],
+) {
   const categorySet = new Set<PageTitle>()
 
+  // The main page is never language-filtered: it is the entry point of the ZIM
+  // and dropping it would leave an archive with no way in.
   if (mainPage) {
     await getPagesByTitle([mainPage], 'mainPage', pagesToIgnore, allowedContentModels, categorySet)
   }
 
   if (pages.length) {
-    await getPagesByTitle(pages, 'pages', pagesToIgnore, allowedContentModels, categorySet)
+    await getPagesByTitle(pages, 'pages', pagesToIgnore, allowedContentModels, categorySet, keepPageLanguages)
   } else {
     await pmap(
       MediaWiki.namespacesToMirror,
       (namespace: string) => {
-        return getPagesByNamespace(MediaWiki.namespaces[namespace].num, pagesToIgnore, allowedContentModels, categorySet)
+        return getPagesByNamespace(MediaWiki.namespaces[namespace].num, pagesToIgnore, allowedContentModels, categorySet, undefined, keepPageLanguages)
       },
       { concurrency: Downloader.workers },
     )
@@ -311,7 +398,7 @@ export async function getPages(mainPage?: PageTitle, pages: PageTitle[] = [], pa
 
       logger.debug(`Fetching category details of ${categoriesToFetch.join(', ')}`)
       const newCategorySet = new Set<PageTitle>()
-      await getPagesByTitle(categoriesToFetch, 'categories', pagesToIgnore, allowedContentModels, newCategorySet)
+      await getPagesByTitle(categoriesToFetch, 'categories', pagesToIgnore, allowedContentModels, newCategorySet, keepPageLanguages)
 
       categoriesToFetch = [...newCategorySet].filter((title: PageTitle) => !processedCategories.has(title) && !pagesToIgnore.includes(title))
     }

--- a/test/unit/filterPages.test.ts
+++ b/test/unit/filterPages.test.ts
@@ -1,0 +1,47 @@
+import { filterPages } from '../../src/util/mw-api.js'
+
+// A page as prop=info returns it. Only the fields filterPages reads matter.
+const page = (title: string, pagelanguagehtmlcode?: string) =>
+  ({
+    title,
+    revisions: [{ revid: 1 }],
+    contentmodel: 'wikitext',
+    ...(pagelanguagehtmlcode ? { pagelanguagehtmlcode } : {}),
+  }) as any
+
+const titles = (pages: any[]) => pages.map((p) => p.title)
+
+describe('filterPages', () => {
+  const pages = [page('Rsync', 'en'), page('Rsync (Français)', 'fr'), page('Rsync (Русский)', 'ru'), page('Untagged page')]
+
+  it('keeps every language when keepPageLanguages is empty', () => {
+    expect(titles(filterPages(pages, [], ['wikitext']))).toEqual(['Rsync', 'Rsync (Français)', 'Rsync (Русский)', 'Untagged page'])
+  })
+
+  it('keeps only the requested language', () => {
+    expect(titles(filterPages(pages, [], ['wikitext'], ['en']))).toEqual(['Rsync', 'Untagged page'])
+  })
+
+  it('accepts several languages', () => {
+    expect(titles(filterPages(pages, [], ['wikitext'], ['en', 'fr']))).toEqual(['Rsync', 'Rsync (Français)', 'Untagged page'])
+  })
+
+  // A page reporting no language is KEPT. The field is absent rather than empty
+  // on wikis that do not set it, so dropping those would silently empty the
+  // scrape instead of failing visibly.
+  it('keeps pages that declare no language', () => {
+    expect(titles(filterPages([page('Untagged page')], [], ['wikitext'], ['en']))).toEqual(['Untagged page'])
+  })
+
+  // The language filter must compose with the existing ones rather than
+  // replacing them.
+  it('still applies the ignore list and the content-model filter', () => {
+    const mixed = [page('Rsync', 'en'), page('Ignored', 'en'), { ...page('Module:Foo', 'en'), contentmodel: 'Scribunto' }, page('Rsync (Français)', 'fr')]
+    expect(titles(filterPages(mixed, ['Ignored'] as any, ['wikitext'], ['en']))).toEqual(['Rsync'])
+  })
+
+  it('drops pages without revisions regardless of language', () => {
+    const noRev = [{ title: 'Stub', contentmodel: 'wikitext', pagelanguagehtmlcode: 'en' } as any]
+    expect(titles(filterPages(noRev, [], ['wikitext'], ['en']))).toEqual([])
+  })
+})

--- a/test/unit/filterRedirectsByLanguage.test.ts
+++ b/test/unit/filterRedirectsByLanguage.test.ts
@@ -1,0 +1,84 @@
+import { filterRedirectsByLanguage } from '../../src/util/mw-api.js'
+import Downloader from '../../src/Downloader.js'
+import { jest } from '@jest/globals'
+
+// A redirect as processPagesAndSaveToRedis builds it. Only `from` is looked up.
+const redirect = (from: string, to = 'Rsync') => ({ from, to }) as any
+
+// Stand in for the API answering prop=info about the redirect titles.
+const mockInfo = (languages: Record<string, string | undefined>) =>
+  jest.spyOn(Downloader, 'getPagesByTitle').mockImplementation(
+    async (titles: any) =>
+      (titles as string[]).map((title) => ({
+        title,
+        ...(languages[title] ? { pagelanguagehtmlcode: languages[title] } : {}),
+      })) as any,
+  ) as any
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('filterRedirectsByLanguage', () => {
+  it('makes no request and changes nothing when no language is requested', async () => {
+    const spy = mockInfo({})
+    const redirects = [redirect('Rsync (Italiano)')]
+    expect(await filterRedirectsByLanguage(redirects, [])).toEqual(redirects)
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('makes no request for an empty redirect list', async () => {
+    const spy = mockInfo({})
+    expect(await filterRedirectsByLanguage([], ['en'])).toEqual([])
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('drops redirects whose page language is not wanted', async () => {
+    mockInfo({ 'Rsync backup': 'en', 'Rsync (Italiano)': 'it', 'OpenSSH (Magyar)': 'hu' })
+    const kept = await filterRedirectsByLanguage([redirect('Rsync backup'), redirect('Rsync (Italiano)'), redirect('OpenSSH (Magyar)')], ['en'])
+    expect(kept.map((r) => r.from)).toEqual(['Rsync backup'])
+  })
+
+  it('accepts several languages', async () => {
+    mockInfo({ A: 'en', B: 'it', C: 'hu' })
+    const kept = await filterRedirectsByLanguage([redirect('A'), redirect('B'), redirect('C')], ['en', 'it'])
+    expect(kept.map((r) => r.from)).toEqual(['A', 'B'])
+  })
+
+  // Same rule as for pages: this must narrow a scrape, never empty one. A wiki
+  // that does not report the field would otherwise lose all its redirects.
+  it('keeps a redirect whose language the API does not report', async () => {
+    mockInfo({ Known: 'it' })
+    const kept = await filterRedirectsByLanguage([redirect('Known'), redirect('Unreported')], ['en'])
+    expect(kept.map((r) => r.from)).toEqual(['Unreported'])
+  })
+
+  // followRedirects must be false, or the API describes each redirect's TARGET
+  // and every redirect would inherit the target's language, which is exactly
+  // the language being kept, so nothing would ever be filtered.
+  it('asks about the redirects themselves, not their targets', async () => {
+    const spy = mockInfo({ 'Rsync (Italiano)': 'it' })
+    await filterRedirectsByLanguage([redirect('Rsync (Italiano)')], ['en'])
+    expect(spy).toHaveBeenCalledWith(['Rsync (Italiano)'], false, false)
+  })
+
+  it('asks about each title once', async () => {
+    const spy = mockInfo({ Dup: 'en' })
+    await filterRedirectsByLanguage([redirect('Dup', 'A'), redirect('Dup', 'B')], ['en'])
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect((spy.mock.calls[0] as any)[0]).toEqual(['Dup'])
+  })
+
+  // MediaWiki caps a titles= query at 50 for an ordinary client and silently
+  // truncates beyond it, so an unbatched lookup would report no language for
+  // everything past the cap, and those would all be kept.
+  it('batches lookups at the API limit', async () => {
+    const spy = mockInfo({})
+    const redirects = Array.from({ length: 120 }, (_, i) => redirect(`R${i}`))
+    await filterRedirectsByLanguage(redirects, ['en'])
+    expect(spy).toHaveBeenCalledTimes(3)
+    for (const call of spy.mock.calls) {
+      expect((call as any)[0].length).toBeLessThanOrEqual(50)
+    }
+  })
+})


### PR DESCRIPTION
Partially addresses #2798.

Adds `--keepPageLanguages`, filtering on MediaWiki's `pagelanguage`, which `prop=info` already returns in the query made here, so no heuristic is involved. Pages declaring no language are kept.

Redirects need their own lookup, since `prop=redirects` returns no language. Those pointing at a section are skipped while the filter is on: libzim cannot express them, and the HTML entry written instead has the redirect's own title as its only text.

Verified by scraping wiki.archlinux.org twice with the same `--pageList` and comparing the ZIMs entry by entry. The French and Russian articles are gone, as are all entries with non-ASCII titles, while the English and undeclared ones are untouched.

`test:unit` (393 passed, 4 skipped) and `test:e2e` (191 passed, 1 skipped) both pass, with counts identical to the parent commit. 14 new unit tests cover both filters.

The skipped ones are the S3-gated suites, which `describe.skip` when `S3_URL` is unset. That is two tests in `test/unit/s3.test.ts`, two in the gated block of `test/unit/downloader.test.ts`, and the one in `test/e2e/downloadImage.e2e.test.ts`. I have no credentials for the bucket, so they did not run on my machine. Nothing in this change touches them, and CI covers them where the secret is available.

One question: would you like an e2e test for this? I left it out because it needs a wiki that keeps translations in the main namespace, which Wikipedia does not, and that would add a third-party dependency to CI.
