### PR TITLE
Correctly handle low-level network errors in S3 operations

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -62,6 +62,7 @@ Unreleased:
 * CHANGED: Better error message when site logo fails to be fetched (@benoit74 #2834)
 * FIX: Workaround bug when filtering categories at API-level on MediaWiki >=1.46 (@benoit74 #2819)
 * FIX: Ignore S3-cached objects which are empty (@benoit74 #2859)
+* FIX: Correctly handle low-level network errors in S3 operations (@benoit74 #2872)
 
 1.17.5:
 * FIX: Ignore articles returning permissiondenied error code (@kunalsiyag #2604)

--- a/src/Downloader.ts
+++ b/src/Downloader.ts
@@ -852,76 +852,99 @@ class Downloader {
 
         // Handle the cache response and act accordingly
         .then(async (s3Resp) => {
-          // 'Versioning' of image is made via HTTP ETag. We should
-          // check if we have the proper version by requesting proper
-          // ETag from upstream MediaWiki.
-          // Headers are cloned per-request: concurrent downloads share this.arrayBufferRequestOptions,
-          // so mutating its headers in place would leak one image's If-None-Match onto another's request.
-          const requestOptions = {
-            ...this.arrayBufferRequestOptions,
-            headers: { ...this.arrayBufferRequestOptions.headers },
-          }
-          // Display message when ignoring empty S3 objects
-          if (s3Resp && !s3Resp.ContentLength) {
-            logger.warn(`Ignoring empty S3 object for ${url}`)
-          }
-          // If S3 object has content and etag, check if upstream did changed
-          if (s3Resp?.ContentLength && s3Resp?.Metadata?.etag) {
-            requestOptions.headers['If-None-Match'] = this.removeEtagWeakPrefix(s3Resp.Metadata.etag)
-          }
-          // Use the base domain of the wiki being scraped as the Referer header, so that we can
-          // successfully scrape WMF map tiles.
-          const mwResp = await this.request({ url, method: 'GET', ...requestOptions })
+          // While we might still need s3Resp.Body (below, or in the 304 branch), forward any
+          // stream error (e.g. ECONNRESET) into this handler's rejection path so it is retried
+          // like any other transient download error, instead of hanging (an errored AWS SDK
+          // stream never emits the 'data'/'end' that a later reader would wait for) or crashing
+          // the process (an AWS SDK stream left without an 'error' listener throws on a late
+          // socket-close error).
+          let onBodyError: (err: unknown) => void
+          const bodyError = s3Resp?.Body
+            ? new Promise<never>((_resolve, reject) => {
+                onBodyError = reject
+                s3Resp.Body.on('error', onBodyError)
+              })
+            : new Promise<never>(() => {})
 
-          // Most of the images, after having been uploaded once to the
-          // cache, will always have 304 status, until modified. If cache
-          // is up to date, return cached image. We always have an s3
-          // response when mwResp is 304, since this can only happen
-          // when we have an eTag coming from s3.
-          if (mwResp.status === 304) {
-            // Proceed with image
-            const data = (await this.streamToBuffer(s3Resp.Body as Readable)) as any
-            const contentType = await this.getImageMimeType(data)
-            logger.debug(`Using S3-cached image for ${url} (contentType: ${contentType})`)
-            handler(null, {
-              contentType,
-              content: data,
-            })
-            return
-          }
+          return Promise.race([
+            bodyError,
+            (async () => {
+              // 'Versioning' of image is made via HTTP ETag. We should
+              // check if we have the proper version by requesting proper
+              // ETag from upstream MediaWiki.
+              // Headers are cloned per-request: concurrent downloads share this.arrayBufferRequestOptions,
+              // so mutating its headers in place would leak one image's If-None-Match onto another's request.
+              const requestOptions = {
+                ...this.arrayBufferRequestOptions,
+                headers: { ...this.arrayBufferRequestOptions.headers },
+              }
+              // Display message when ignoring empty S3 objects
+              if (s3Resp && !s3Resp.ContentLength) {
+                logger.warn(`Ignoring empty S3 object for ${url}`)
+              }
+              // If S3 object has content and etag, check if upstream did changed
+              if (s3Resp?.ContentLength && s3Resp?.Metadata?.etag) {
+                requestOptions.headers['If-None-Match'] = this.removeEtagWeakPrefix(s3Resp.Metadata.etag)
+              }
+              // Use the base domain of the wiki being scraped as the Referer header, so that we can
+              // successfully scrape WMF map tiles.
+              const mwResp = await this.request({ url, method: 'GET', ...requestOptions })
 
-          // Destroy the Readable so that socket is freed and returned to the pool
-          if (s3Resp?.Body) {
-            s3Resp.Body.destroy()
-          }
+              // Most of the images, after having been uploaded once to the
+              // cache, will always have 304 status, until modified. If cache
+              // is up to date, return cached image. We always have an s3
+              // response when mwResp is 304, since this can only happen
+              // when we have an eTag coming from s3.
+              if (mwResp.status === 304) {
+                // Proceed with image
+                const data = (await this.streamToBuffer(s3Resp.Body as Readable)) as any
+                const contentType = await this.getImageMimeType(data)
+                logger.debug(`Using S3-cached image for ${url} (contentType: ${contentType})`)
+                handler(null, {
+                  contentType,
+                  content: data,
+                })
+                return
+              }
 
-          // Compress content because image blob comes from upstream MediaWiki
-          const compressedData = await this.getCompressedBody({ data: mwResp.data, context: url }, requestedWidth)
+              // From here we no longer need s3Resp.Body: stop treating its errors as fatal (we
+              // already have what we need from upstream MediaWiki), then destroy the Readable so
+              // the socket is freed and returned to the pool.
+              if (s3Resp?.Body) {
+                s3Resp.Body.off('error', onBodyError)
+                s3Resp.Body.on('error', () => {})
+                s3Resp.Body.destroy()
+              }
 
-          // Check content really exists
-          if (!compressedData?.length) {
-            throw new Error(`Content for ${url} is missing or empty (${typeof compressedData})`)
-          }
+              // Compress content because image blob comes from upstream MediaWiki
+              const compressedData = await this.getCompressedBody({ data: mwResp.data, context: url }, requestedWidth)
 
-          // Check for the ETag and upload to cache
-          const etag = this.removeEtagWeakPrefix(mwResp.headers.etag)
-          if (etag) {
-            await this.s3.uploadBlob(stripHttpFromUrl(url), compressedData, etag, cacheVersion)
-          }
+              // Check content really exists
+              if (!compressedData?.length) {
+                throw new Error(`Content for ${url} is missing or empty (${typeof compressedData})`)
+              }
 
-          // get contentType from image, with fallback to response headers should the image be unsupported at all (e.g. SVG)
-          const contentType = (await this.getImageMimeType(compressedData)) || mwResp.headers['content-type']
-          if (s3Resp) {
-            logger.debug(`Using image downloaded from upstream for ${url} (S3-cached image is outdated, contentType: ${contentType})`)
-          } else {
-            logger.debug(`Using image downloaded from upstream for ${url} (no S3-cached image found, contentType: ${contentType})`)
-          }
+              // Check for the ETag and upload to cache
+              const etag = this.removeEtagWeakPrefix(mwResp.headers.etag)
+              if (etag) {
+                await this.s3.uploadBlob(stripHttpFromUrl(url), compressedData, etag, cacheVersion)
+              }
 
-          // Proceed with image
-          handler(null, {
-            contentType,
-            content: compressedData,
-          })
+              // get contentType from image, with fallback to response headers should the image be unsupported at all (e.g. SVG)
+              const contentType = (await this.getImageMimeType(compressedData)) || mwResp.headers['content-type']
+              if (s3Resp) {
+                logger.debug(`Using image downloaded from upstream for ${url} (S3-cached image is outdated, contentType: ${contentType})`)
+              } else {
+                logger.debug(`Using image downloaded from upstream for ${url} (no S3-cached image found, contentType: ${contentType})`)
+              }
+
+              // Proceed with image
+              handler(null, {
+                contentType,
+                content: compressedData,
+              })
+            })(),
+          ])
         })
         .catch((err) => {
           this.errHandler(err, url, handler)


### PR DESCRIPTION
Fix #2872 

## Issue

Scrapes were crashing outright (Error: aborted / ECONNRESET, Unhandled 'error' event ... on ChecksumStream instance) with no retry or logging. In Downloader.downloadImage, the S3-cached GetObject response body is sometimes discarded early (.destroy()) once we know upstream has a fresher copy, or left briefly unread while we await the upstream request. If the underlying S3 connection reset during that window, the AWS SDK stream (ChecksumStream) emitted an 'error' with no listener attached, which Node treats as fatal and kills the whole process — losing an entire in-progress dump.

## Change

Attach an error listener to s3Resp.Body for the whole time we might still need it (waiting on upstream, or reading it in the 304/cache-hit path), and race it against the normal flow so a stream error now rejects and gets retried like any other transient download error instead of crashing the process. Once we've decided we no longer need the S3 body (upstream returned a fresher image), we detach that listener and swallow further errors instead — a benign teardown error there shouldn't fail a download that already succeeded via the upstream fetch.