### PR TITLE
Move tests around empty sections to another page not yet complete

### DIFF
--- a/test/e2e/en.e2e.test.ts
+++ b/test/e2e/en.e2e.test.ts
@@ -87,7 +87,6 @@ await testAllRenders('en-wikipedia', parameters, async (outFiles) => {
           'vector-feature-limited-width-clientpref-1',
           'vector-feature-limited-width-content-enabled',
           'vector-feature-main-menu-pinned-disabled',
-          'vector-feature-navigation-update-disabled',
           'vector-feature-page-tools-pinned-disabled',
           'vector-feature-toc-pinned-clientpref-0',
           'vector-sticky-header-enabled',

--- a/test/unit/saveArticles.test.ts
+++ b/test/unit/saveArticles.test.ts
@@ -182,7 +182,7 @@ describe('savePages', () => {
     test(`Remove empty sections for ${renderer} renderer`, async () => {
       const { dump } = await setupScrapeClasses({ mwUrl: 'https://en.wikivoyage.org', format: 'nopic' })
       await RenderingContext.createRenderers(renderer as renderName)
-      const pageTitle = 'Western_Greenland' as PageTitle
+      const pageTitle = 'Qassiarsuk' as PageTitle
       const pageUrl = Downloader.getPageUrl(pageTitle)
       const _pageDetailsRet = await Downloader.getPagesByTitle([pageTitle])
       const pagesDetail = mwRetToPageDetail(_pageDetailsRet)
@@ -191,17 +191,17 @@ describe('savePages', () => {
       pageDetailStore.setMany(pagesDetail)
       const result = await Downloader.getPage(pageTitle, RenderingContext.pagesRenderer, pageUrl, dump, pageDetail)
       const pageDoc = domino.createDocument(result.items[0].htmlContent)
-      expect(pageDoc.querySelector('#Get_around')).toBeTruthy()
+      expect(pageDoc.querySelector('#Get_in')).toBeTruthy()
+      expect(pageDoc.querySelector('#Get_around')).toBeFalsy()
+      expect(pageDoc.querySelector('#See')).toBeTruthy()
       expect(pageDoc.querySelector('#Do')).toBeFalsy()
-      expect(pageDoc.querySelector('#Eat')).toBeTruthy()
-      expect(pageDoc.querySelector('#Drink')).toBeFalsy()
     })
 
     test(`Keep empty sections for ${renderer} renderer`, async () => {
       const { dump } = await setupScrapeClasses({ mwUrl: 'https://en.wikivoyage.org', format: 'nopic' })
       dump.opts.keepEmptySections = true
       await RenderingContext.createRenderers(renderer as renderName)
-      const pageTitle = 'Western_Greenland' as PageTitle
+      const pageTitle = 'Qassiarsuk' as PageTitle
       const pageUrl = Downloader.getPageUrl(pageTitle)
       const _pageDetailsRet = await Downloader.getPagesByTitle([pageTitle])
       const pagesDetail = mwRetToPageDetail(_pageDetailsRet)
@@ -210,10 +210,10 @@ describe('savePages', () => {
       pageDetailStore.setMany(pagesDetail)
       const result = await Downloader.getPage(pageTitle, RenderingContext.pagesRenderer, pageUrl, dump, pageDetail)
       const pageDoc = domino.createDocument(result.items[0].htmlContent)
+      expect(pageDoc.querySelector('#Get_in')).toBeTruthy()
       expect(pageDoc.querySelector('#Get_around')).toBeTruthy()
+      expect(pageDoc.querySelector('#See')).toBeTruthy()
       expect(pageDoc.querySelector('#Do')).toBeTruthy()
-      expect(pageDoc.querySelector('#Eat')).toBeTruthy()
-      expect(pageDoc.querySelector('#Drink')).toBeTruthy()
     })
   }
 


### PR DESCRIPTION
Tests around empty sections where based on Western_Greenland page of en.wikivoyage.org which now has text in all sections.

I hence transition the two tests to Qassiarsuk which is sufficiently niche to have some empty sections left ... let's hope it will be so for few years to come.

Also fixed a test failing due to another upstream change.

Fix #2884 