### PR TITLE
Make --pageListToIgnore support case-insensitive first letter

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,5 @@
 Unreleased
+* FIX: Make pageListToIgnore support case-insensitive first letter and space/underscore variations (@sundeep8967 #2784 #2888)
 
 2.0.0
 * NEW: Scrape only wikitext contentmodel articles by default (@triemerge #2445)

--- a/src/MediaWiki.ts
+++ b/src/MediaWiki.ts
@@ -82,6 +82,7 @@ export interface SiteInfoGeneral {
     code: string
   }[]
   categorycollation: string
+  case?: string
 }
 
 export interface SiteInfoSkin {
@@ -111,6 +112,7 @@ class MediaWiki {
   public queryOpts: QueryOpts
   public urlDirector: BaseURLDirector
   public skin = 'vector' // Default fallback
+  public case = 'first-letter'
 
   #wikiPath: string
   #indexPhpPath: string
@@ -199,6 +201,7 @@ class MediaWiki {
     this.#username = ''
     this.#password = ''
     this.getCategories = false
+    this.case = 'first-letter'
 
     this.#actionApiPath = '/w/api.php'
     this.#wikiPath = '/wiki/'
@@ -475,6 +478,7 @@ class MediaWiki {
 
     this.setNamespaces(body.query, addNamespaces || [], onlyNamespaces || [])
     Gadgets.setGadgets(body.query.gadgets)
+    this.case = generalEntries.case
 
     const { url: licenseUrl, text: licenseName } = body.query.rightsinfo
     const subTitle = body.query.allmessages[0].content || ''

--- a/src/util/mw-api.ts
+++ b/src/util/mw-api.ts
@@ -4,7 +4,7 @@ import Downloader from '../Downloader.js'
 import Timer from './Timer.js'
 import RedisStore from '../RedisStore.js'
 import MediaWiki from '../MediaWiki.js'
-import { cleanupAxiosError } from './misc.js'
+import { cleanupAxiosError, lcFirst, ucFirst } from './misc.js'
 
 const MAX_TITLES_PARAM_SIZE = 7400
 const MAX_BATCH_SIZE = 50
@@ -57,6 +57,24 @@ export async function getPagesByTitle(
   )
 }
 
+export function isPageIgnored(title: string, pagesToIgnore: PageTitle[]): boolean {
+  if (!pagesToIgnore || pagesToIgnore.length === 0 || !title) {
+    return false
+  }
+  const normTitle = title.replace(/_/g, ' ')
+  if (MediaWiki.case === 'case-sensitive') {
+    return pagesToIgnore.some((ignored) => (ignored as string).replace(/_/g, ' ') === normTitle)
+  }
+
+  const normTitleUc = ucFirst(normTitle)
+  const normTitleLc = lcFirst(normTitle)
+
+  return pagesToIgnore.some((ignored) => {
+    const normIgnored = (ignored as string).replace(/_/g, ' ')
+    return normIgnored === normTitle || normIgnored === normTitleUc || normIgnored === normTitleLc
+  })
+}
+
 export function filterPages(pages: QueryMwRet, pagesToIgnore: PageTitle[], allowedContentModels: string[]) {
   function revisionFilter(page: PageInfo & QueryRet): boolean {
     return !page.revisions
@@ -67,7 +85,7 @@ export function filterPages(pages: QueryMwRet, pagesToIgnore: PageTitle[], allow
   }
 
   function ignoredPagesFilter(page: PageInfo & QueryRet): boolean {
-    return pagesToIgnore.includes(page.title) || pagesToIgnore.includes((page.title as string).replace(/ /g, '_') as PageTitle)
+    return isPageIgnored(page.title as string, pagesToIgnore)
   }
 
   // Filter pages without revisions (#2091)
@@ -304,7 +322,7 @@ export async function getPages(mainPage?: PageTitle, pages: PageTitle[] = [], pa
     // Categories can themselves belong to parent categories (subcategories), so we need to walk up the
     // category tree until no new (unprocessed) category is discovered, to also capture root categories
     const processedCategories = new Set<PageTitle>()
-    let categoriesToFetch = pagesToIgnore ? [...categorySet].filter((title: PageTitle) => !pagesToIgnore.includes(title)) : [...categorySet]
+    let categoriesToFetch = pagesToIgnore ? [...categorySet].filter((title: PageTitle) => !isPageIgnored(title as string, pagesToIgnore)) : [...categorySet]
 
     while (categoriesToFetch.length) {
       categoriesToFetch.forEach((title) => processedCategories.add(title))
@@ -313,7 +331,7 @@ export async function getPages(mainPage?: PageTitle, pages: PageTitle[] = [], pa
       const newCategorySet = new Set<PageTitle>()
       await getPagesByTitle(categoriesToFetch, 'categories', pagesToIgnore, allowedContentModels, newCategorySet)
 
-      categoriesToFetch = [...newCategorySet].filter((title: PageTitle) => !processedCategories.has(title) && !pagesToIgnore.includes(title))
+      categoriesToFetch = [...newCategorySet].filter((title: PageTitle) => !processedCategories.has(title) && !isPageIgnored(title as string, pagesToIgnore))
     }
   }
 }

--- a/test/unit/util/filterPages.test.ts
+++ b/test/unit/util/filterPages.test.ts
@@ -1,0 +1,61 @@
+import { isPageIgnored, filterPages } from '../../../src/util/mw-api.js'
+import MediaWiki from '../../../src/MediaWiki.js'
+
+describe('isPageIgnored and filterPages', () => {
+  afterEach(() => {
+    MediaWiki.case = 'first-letter'
+  })
+
+  test('isPageIgnored matches case-insensitive first letter and space/underscore variations', () => {
+    const pagesToIgnore = ['Earth', 'main_page', 'Solar System'] as PageTitle[]
+
+    // Exact matches
+    expect(isPageIgnored('Earth', pagesToIgnore)).toBe(true)
+    expect(isPageIgnored('main_page', pagesToIgnore)).toBe(true)
+    expect(isPageIgnored('Solar System', pagesToIgnore)).toBe(true)
+
+    // Case-insensitive first letter
+    expect(isPageIgnored('earth', pagesToIgnore)).toBe(true)
+    expect(isPageIgnored('Main_page', pagesToIgnore)).toBe(true)
+    expect(isPageIgnored('solar System', pagesToIgnore)).toBe(true)
+
+    // Space vs underscore normalization
+    expect(isPageIgnored('Main page', pagesToIgnore)).toBe(true)
+    expect(isPageIgnored('main page', pagesToIgnore)).toBe(true)
+    expect(isPageIgnored('Solar_System', pagesToIgnore)).toBe(true)
+    expect(isPageIgnored('solar_System', pagesToIgnore)).toBe(true)
+
+    // Non-matching page
+    expect(isPageIgnored('Mars', pagesToIgnore)).toBe(false)
+    expect(isPageIgnored('EARTH', pagesToIgnore)).toBe(false)
+  })
+
+  test('isPageIgnored does not fold first letter on case-sensitive wikis', () => {
+    MediaWiki.case = 'case-sensitive'
+    const pagesToIgnore = ['Earth', 'main_page'] as PageTitle[]
+
+    // Exact match matches
+    expect(isPageIgnored('Earth', pagesToIgnore)).toBe(true)
+    expect(isPageIgnored('main_page', pagesToIgnore)).toBe(true)
+
+    // Space vs underscore normalization still works
+    expect(isPageIgnored('main page', pagesToIgnore)).toBe(true)
+
+    // First letter case difference does NOT match
+    expect(isPageIgnored('earth', pagesToIgnore)).toBe(false)
+    expect(isPageIgnored('Main_page', pagesToIgnore)).toBe(false)
+  })
+
+  test('filterPages correctly removes ignored pages with case-insensitive first letter', () => {
+    const pagesToIgnore = ['earth', 'Solar_System'] as PageTitle[]
+    const mockPages: any = [
+      { title: 'Earth', contentmodel: 'wikitext', revisions: [{ revid: 1 }] },
+      { title: 'Mars', contentmodel: 'wikitext', revisions: [{ revid: 2 }] },
+      { title: 'Solar System', contentmodel: 'wikitext', revisions: [{ revid: 3 }] },
+    ]
+
+    const result = filterPages(mockPages, pagesToIgnore, ['wikitext'])
+    expect(result).toHaveLength(1)
+    expect(result[0].title).toBe('Mars')
+  })
+})


### PR DESCRIPTION
## Description
MediaWiki page titles are case-insensitive on their initial letter and normalize spaces and underscores. When users specify `--pageListToIgnore`, entries previously failed to match if the first letter's case or space/underscore formatting differed between the command line and MediaWiki API responses.

This PR introduces `isPageIgnored` to normalize:
1. First-letter case variations (`Earth` / `earth`).
2. Space vs underscore formatting (`Solar System` / `Solar_System`).

Applied across `filterPages` and category traversal in `src/util/mw-api.ts`. Added unit tests in `test/unit/util/filterPages.test.ts`.

Fixes #2784
Signed-off-by: Sundeep <sundeep8967@gmail.com>