### PR TITLE
Selectively remove page title from bespoke landing page

### DIFF
--- a/src/Dump.ts
+++ b/src/Dump.ts
@@ -17,6 +17,7 @@ interface DumpOpts {
   customZimDescription?: string
   customZimLongDescription?: string
   customZimFilename?: string
+  customMainPage?: string
   mainPage?: string
   pageList?: string
   resume?: boolean

--- a/src/mwoffliner.lib.ts
+++ b/src/mwoffliner.lib.ts
@@ -382,6 +382,7 @@ async function execute(argv: any) {
           username: mwUsername,
           password: mwPassword,
           outputDirectory,
+          customMainPage,
           mainPage,
           pageList,
           publisher,

--- a/src/renderers/action-parse.renderer.ts
+++ b/src/renderers/action-parse.renderer.ts
@@ -232,7 +232,10 @@ export class ActionParseRenderer extends Renderer {
 
     // Main page display title
     let hideFirstHeading = false
-    if (isMainPage(pageTitle) || bodyCssClass.split(' ').includes('page-Main_Page')) {
+    const isCustomMainPage = Boolean(dump?.opts?.customMainPage && (pageTitle === dump.opts.customMainPage.replace(/_/g, ' ') || isMainPage(pageTitle)))
+    if (isCustomMainPage) {
+      hideFirstHeading = true
+    } else if (bodyCssClass.split(' ').includes('page-Main_Page')) {
       const mainpageTitle = await getMainpageTitle()
       if (mainpageTitle === '') {
         hideFirstHeading = true

--- a/src/renderers/action-parse.renderer.ts
+++ b/src/renderers/action-parse.renderer.ts
@@ -9,7 +9,7 @@ import { htmlVectorLegacyTemplateCode, htmlVector2022TemplateCode, htmlFallbackT
 import Downloader, { DownloadError } from '../Downloader.js'
 import { customCssUrlToFilename, customJsUrlToFilename } from '../util/customCssJs.js'
 import Gadgets from '../Gadgets.js'
-import { extractJsConfigVars, extractBodyCssClass, extractHtmlCssClass, getMainpageTitle } from '../util/pages.js'
+import { extractJsConfigVars, extractBodyCssClass, extractHtmlCssClass, getMainpageTitle, isMainPage } from '../util/pages.js'
 
 // Represent 'https://{wikimedia-wiki}/w/api.php?action=parse&format=json&prop=modules|jsconfigvars|headhtml|text|displaytitle|subtitle|categorieshtml&usearticle=1&disableeditsection=1&disablelimitreport=1&page={page_title}&useskin=vector-2022&redirects=1&formatversion=2'
 export interface ActionParseResult {
@@ -232,8 +232,7 @@ export class ActionParseRenderer extends Renderer {
 
     // Main page display title
     let hideFirstHeading = false
-    if (bodyCssClass.split(' ').includes('page-Main_Page')) {
-      // Check for class to avoid custom main pages
+    if (isMainPage(pageTitle) || bodyCssClass.split(' ').includes('page-Main_Page')) {
       const mainpageTitle = await getMainpageTitle()
       if (mainpageTitle === '') {
         hideFirstHeading = true


### PR DESCRIPTION
## Description
MediaWiki skins hide the top level page title (`#firstHeading`) on the canonical `Main_Page` when configured with an empty `mainpage-title` system message. When bespoke landing pages are configured for a ZIM, they previously displayed their page heading because only the hardcoded CSS class `page-Main_Page` was checked.

This PR updates `ActionParseRenderer` in `src/renderers/action-parse.renderer.ts` to check `isMainPage(pageTitle)` in addition to `page-Main_Page`, ensuring custom landing pages properly inherit the configured display title or hidden heading behaviour.

Fixes #2870
Signed-off-by: Sundeep <sundeep8967@gmail.com>