### PR TITLE
Fix image thumb layout when removing links

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,6 @@
 Unreleased:
 * CHANGED: Create multiple files for language variants, similar to different formats (@Markus-Rost #2691)
+* FIX: Fix image thumb layout when removing links (@Markus-Rost #2893)
 * CHANGED: Redesign speed to handle both worker count and request pacing (@triemerge #2393)
 * FIX: Fix URL size estimation to prevent 414 Request-URI Too Long on non-Latin wikis (@paratha14 #2705)
 * FIX: Fix file name detection for Wikimedia image urls (@Markus-Rost #2701)

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -151,19 +151,6 @@ export function contains(arr: any[], value: any) {
   return arr.some((v) => v === value)
 }
 
-/*
- * Move 'from'.childNodes to 'to' adding them before 'beforeNode'
- * If 'beforeNode' is null, the nodes are appended at the end.
- */
-export function migrateChildren(from: any, to: any, beforeNode: any) {
-  if (beforeNode === undefined) {
-    beforeNode = null
-  }
-  while (from.firstChild) {
-    to.insertBefore(from.firstChild, beforeNode)
-  }
-}
-
 export async function saveStaticFiles(staticFiles: Set<string>, zimCreator: Creator) {
   try {
     await Promise.all(

--- a/src/util/rewriteUrls.ts
+++ b/src/util/rewriteUrls.ts
@@ -1,4 +1,4 @@
-import { migrateChildren, getMediaBase, getFullUrl, getRelativeFilePath, encodePageTitleForZimHtmlUrl } from './misc.js'
+import { getMediaBase, getFullUrl, getRelativeFilePath, encodePageTitleForZimHtmlUrl } from './misc.js'
 import { Dump } from '../Dump.js'
 import MediaWiki from '../MediaWiki.js'
 import RedisStore from '../RedisStore.js'
@@ -22,8 +22,7 @@ function rewriteUrlNoContentCheck(pagePath: ZimPath, dump: Dump, linkNode: Domin
   }
   // Always remove redlinks
   if (classList.includes('new')) {
-    migrateChildren(linkNode, linkNode.parentNode, linkNode)
-    linkNode.parentNode.removeChild(linkNode)
+    linkNode.outerHTML = linkNode.innerHTML
     return null
   }
 
@@ -148,8 +147,7 @@ function rewriteUrlNoContentCheck(pagePath: ZimPath, dump: Dump, linkNode: Domin
       if (href.substring(0, 1) === '/') {
         linkNode.setAttribute('href', getFullUrl(href, MediaWiki.baseUrl))
       } else if (href.substring(0, 2) === './') {
-        migrateChildren(linkNode, linkNode.parentNode, linkNode)
-        linkNode.parentNode.removeChild(linkNode)
+        linkNode.outerHTML = linkNode.innerHTML
       }
       return null
     }
@@ -218,8 +216,12 @@ export async function rewriteUrls(pagePath: ZimPath, dump: Dump, linkNodes: Domi
       const redirect = pagesRedirected[pageTitle]
       if (!redirect) {
         wikilinkMappings[pageTitle].forEach((linkNode: DominoElement) => {
-          migrateChildren(linkNode, linkNode.parentNode, linkNode)
-          linkNode.parentNode.removeChild(linkNode)
+          const classList: string[] = (linkNode.getAttribute('class') || '').split(' ').filter((cssClass) => cssClass)
+          if (classList.includes('mw-file-description')) {
+            linkNode.outerHTML = `<span>${linkNode.innerHTML}</span>`
+          } else {
+            linkNode.outerHTML = linkNode.innerHTML
+          }
         })
         delete wikilinkMappings[pageTitle]
       }


### PR DESCRIPTION
Fix #2893 

Also replaced `migrateChildren` helper function with the more direct `outerHTML = innerHTML`